### PR TITLE
feat(theme): refresh rarity color tokens and add 1-star token

### DIFF
--- a/lib/theme/tokens.dart
+++ b/lib/theme/tokens.dart
@@ -142,15 +142,15 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     textPrimary: Color(0xFFFFFFFF),
     textSecondary: Color(0xFFDDE3EE),
     textMuted: Color(0xFF8A92A6),
-    fiveStar: Color(0xFFCD8E48),
+    fiveStar: Color(0xFFD6A268),
     fourStar: Color(0xFFB594C5),
     threeStar: Color(0xFF73A8C5),
     twoStar: Color(0xFF6DAD8A),
     oneStar: Color(0xFFA3A2A3),
-    accentPrimary: Color(0xFFCD8E48),
+    accentPrimary: Color(0xFFD6A268),
     stateDanger: Color(0xFFE6736B),
     stateSuccess: Color(0xFF46B07A),
-    stateWarning: Color(0xFFCD8E48),
+    stateWarning: Color(0xFFD6A268),
   );
 
   /// Light = 由 dark 衍生（背景反轉、卡池色稍降亮度）
@@ -163,15 +163,15 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     textPrimary: Color(0xFF0C1220),
     textSecondary: Color(0xFF2C3245),
     textMuted: Color(0xFF6A7080),
-    fiveStar: Color(0xFF8D5A25),
+    fiveStar: Color(0xFFAD6F2E),
     fourStar: Color(0xFF7E589A),
     threeStar: Color(0xFF437897),
     twoStar: Color(0xFF467B62),
     oneStar: Color(0xFF686769),
-    accentPrimary: Color(0xFF8D5A25),
+    accentPrimary: Color(0xFFAD6F2E),
     stateDanger: Color(0xFFC62828),
     stateSuccess: Color(0xFF2E7D32),
-    stateWarning: Color(0xFF8D5A25),
+    stateWarning: Color(0xFFAD6F2E),
   );
 
   @override

--- a/lib/theme/tokens.dart
+++ b/lib/theme/tokens.dart
@@ -74,6 +74,7 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     required this.fourStar,
     required this.threeStar,
     required this.twoStar,
+    required this.oneStar,
     required this.accentPrimary,
     required this.stateDanger,
     required this.stateSuccess,
@@ -116,6 +117,9 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
   /// 二星稀有度色。
   final Color twoStar;
 
+  /// 一星稀有度色。
+  final Color oneStar;
+
   /// 品牌主色（按鈕、強調色）。
   final Color accentPrimary;
 
@@ -138,14 +142,15 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     textPrimary: Color(0xFFFFFFFF),
     textSecondary: Color(0xFFDDE3EE),
     textMuted: Color(0xFF8A92A6),
-    fiveStar: Color(0xFFE6C477),
-    fourStar: Color(0xFFA385E0),
-    threeStar: Color(0xFF5B9BD5),
-    twoStar: Color(0xFF6A7080),
-    accentPrimary: Color(0xFFE6C477),
+    fiveStar: Color(0xFFCD8E48),
+    fourStar: Color(0xFFB594C5),
+    threeStar: Color(0xFF73A8C5),
+    twoStar: Color(0xFF6DAD8A),
+    oneStar: Color(0xFFA3A2A3),
+    accentPrimary: Color(0xFFCD8E48),
     stateDanger: Color(0xFFE6736B),
     stateSuccess: Color(0xFF46B07A),
-    stateWarning: Color(0xFFE6C477),
+    stateWarning: Color(0xFFCD8E48),
   );
 
   /// Light = 由 dark 衍生（背景反轉、卡池色稍降亮度）
@@ -158,14 +163,15 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     textPrimary: Color(0xFF0C1220),
     textSecondary: Color(0xFF2C3245),
     textMuted: Color(0xFF6A7080),
-    fiveStar: Color(0xFFB8860B),
-    fourStar: Color(0xFF7A4FB8),
-    threeStar: Color(0xFF2E7CC2),
-    twoStar: Color(0xFF8A92A6),
-    accentPrimary: Color(0xFFB8860B),
+    fiveStar: Color(0xFF8D5A25),
+    fourStar: Color(0xFF7E589A),
+    threeStar: Color(0xFF437897),
+    twoStar: Color(0xFF467B62),
+    oneStar: Color(0xFF686769),
+    accentPrimary: Color(0xFF8D5A25),
     stateDanger: Color(0xFFC62828),
     stateSuccess: Color(0xFF2E7D32),
-    stateWarning: Color(0xFFB8860B),
+    stateWarning: Color(0xFF8D5A25),
   );
 
   @override
@@ -182,6 +188,7 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     Color? fourStar,
     Color? threeStar,
     Color? twoStar,
+    Color? oneStar,
     Color? accentPrimary,
     Color? stateDanger,
     Color? stateSuccess,
@@ -199,6 +206,7 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
     fourStar: fourStar ?? this.fourStar,
     threeStar: threeStar ?? this.threeStar,
     twoStar: twoStar ?? this.twoStar,
+    oneStar: oneStar ?? this.oneStar,
     accentPrimary: accentPrimary ?? this.accentPrimary,
     stateDanger: stateDanger ?? this.stateDanger,
     stateSuccess: stateSuccess ?? this.stateSuccess,
@@ -225,6 +233,7 @@ class GachaTokens extends ThemeExtension<GachaTokens> {
       fourStar: Color.lerp(fourStar, other.fourStar, t)!,
       threeStar: Color.lerp(threeStar, other.threeStar, t)!,
       twoStar: Color.lerp(twoStar, other.twoStar, t)!,
+      oneStar: Color.lerp(oneStar, other.oneStar, t)!,
       accentPrimary: Color.lerp(accentPrimary, other.accentPrimary, t)!,
       stateDanger: Color.lerp(stateDanger, other.stateDanger, t)!,
       stateSuccess: Color.lerp(stateSuccess, other.stateSuccess, t)!,

--- a/lib/widgets/rank_palette.dart
+++ b/lib/widgets/rank_palette.dart
@@ -8,5 +8,6 @@ Color accentForRank(int rank, GachaTokens t) => switch (rank) {
   4 => t.fourStar,
   3 => t.threeStar,
   2 => t.twoStar,
+  1 => t.oneStar,
   _ => t.textMuted,
 };

--- a/test/widgets/gacha_item_icon_test.dart
+++ b/test/widgets/gacha_item_icon_test.dart
@@ -54,6 +54,13 @@ void main() {
   });
 
   tearDown(() async {
+    // 清 process-wide ImageCache（含 live image listeners），避免「完整 chain」
+    // 那一 case 留下的 Image.file 背景 codec 在 tempDir 被刪後仍嘗試讀檔，
+    // 害下一個 testWidgets 收到 ImageResourceService 拋的「Codec failed to
+    // produce an image」。Linux CI 上 tempDir.delete 必定成功，曾觀察到 flaky。
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+
     // Windows 上 Image.file 可能持有檔案 handle，忽略刪除失敗。
     if (await tempDir.exists()) {
       try {

--- a/test/widgets/rank_palette_test.dart
+++ b/test/widgets/rank_palette_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/rank_palette.dart';
+
+void main() {
+  group('accentForRank', () {
+    const tokens = GachaTokens.dark;
+
+    test('rank 5 maps to fiveStar', () {
+      expect(accentForRank(5, tokens), tokens.fiveStar);
+    });
+
+    test('rank 4 maps to fourStar', () {
+      expect(accentForRank(4, tokens), tokens.fourStar);
+    });
+
+    test('rank 3 maps to threeStar', () {
+      expect(accentForRank(3, tokens), tokens.threeStar);
+    });
+
+    test('rank 2 maps to twoStar', () {
+      expect(accentForRank(2, tokens), tokens.twoStar);
+    });
+
+    test('rank 1 maps to oneStar', () {
+      expect(accentForRank(1, tokens), tokens.oneStar);
+    });
+
+    test('rank 0 falls back to textMuted', () {
+      expect(accentForRank(0, tokens), tokens.textMuted);
+    });
+
+    test('out-of-range rank 99 falls back to textMuted', () {
+      expect(accentForRank(99, tokens), tokens.textMuted);
+    });
+  });
+}


### PR DESCRIPTION
## 概述

重整稀有度（1-5★）色票，對齊原神武器 / 聖遺物配色慣例（5★ 銅金、4★ 紫、3★ 藍、2★ 綠、1★ 灰）。新增 `GachaTokens.oneStar`，`accentForRank` 不再對 rank 1 fallback 到 `textMuted`。視覺驗證後將 5★ 提亮 +8% L 以改善 dark / light 兩主題的可讀性。

附帶修復一個與本 PR 無關但被本 PR CI 暴露的 Linux 上 `gacha_item_icon_test` ImageCache cross-test race。

`4 files changed, +66 / −12`（3 個 commit）

## 主要變更

### 色 token（`lib/theme/tokens.dart`）

- 新增 `GachaTokens.oneStar` field（含 constructor / `copyWith` / `lerp` 同步補齊）
- dark / light 兩個 static const 各換 6 個欄位 hex
- `accentPrimary` 與 `stateWarning` 沿用「跟 5★ 同色」既有慣例，跟著一起換

### 色映射（`lib/widgets/rank_palette.dart`）

- `accentForRank()` switch 加入 `1 => t.oneStar`，default `_ => t.textMuted` 保留處理異常 rank

### 最終色票

| 星級 | Dark | Light |
|---|---|---|
| 5★ | `#D6A268` | `#AD6F2E` |
| 4★ | `#B594C5` | `#7E589A` |
| 3★ | `#73A8C5` | `#437897` |
| 2★ | `#6DAD8A` | `#467B62` |
| 1★ | `#A3A2A3` | `#686769` |

`accentPrimary` / `stateWarning` 兩主題均同 5★（dark `#D6A268` / light `#AD6F2E`）。

### 測試

新增 `test/widgets/rank_palette_test.dart`：7 個 case 覆蓋 rank 1-5 對應 token + rank 0 / rank 99 fallback。

## 附帶修復

`test/widgets/gacha_item_icon_test.dart` tearDown 加上 `imageCache.clear()` + `clearLiveImages()`。

**Root cause**：「完整 chain → 顯示 Image」case 用 `Image.file()` 渲染 tempDir 內的 cache 檔，process-wide `ImageCache` 持有 `FileImage` 的 live reference + 背景 codec decode。tearDown 刪 tempDir 後，背景 decode 試圖讀已不存在的檔，`ImageResourceService` 拋 `Codec failed to produce an image`，被 flutter_test 報為**下一個** case（`PreloadedHoYoWikiImages 命中`）的 unhandled exception。

Windows 上 `Image.file` 持 file handle，`tempDir.delete` 常失敗（被 try/catch swallow），所以舊檔仍在，背景 decode 成功 — 因此 Windows local 永遠綠。Linux CI `delete` 必成功，race 才暴露為 transient flaky（本 PR 首次 CI run 即觸發）。

## 驗證

各 commit 前皆通過 `dart format` / `flutter analyze` / `flutter test`（651 tests）。
手動視覺驗證：dark / light 兩主題下覽覽頁、卡池頁、分享圖、warning dialog 確認 5★ / 4★ / 3★ / 2★ / 1★ 色感 OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)