### PR TITLE
feat(settings): add interface privacy mode to mask UID

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -286,6 +286,18 @@
   "settingsLocaleSystem": "Follow system",
   "settingsDataManagement": "Data management",
   "settingsAccountManagement": "Account management",
+  "settingsPrivacySectionTitle": "Privacy",
+  "@settingsPrivacySectionTitle": {
+    "description": "Settings page section title for privacy-related toggles."
+  },
+  "settingsMaskUidInUi": "Mask UID in interface",
+  "@settingsMaskUidInUi": {
+    "description": "Settings toggle label: when on, UIDs are masked in the app UI."
+  },
+  "settingsMaskUidInUiHint": "When on, UIDs in the interface and account list show the first 3 digits with the rest masked (e.g. 123xxxxx). Useful for streaming or screen sharing. Share images, exported files, and the delete confirmation dialog are not affected.",
+  "@settingsMaskUidInUiHint": {
+    "description": "Settings toggle subtitle: explains scope of the maskUidInUi setting."
+  },
   "settingsAbout": "About",
   "settingsAboutVersion": "Version {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "Seguir el sistema",
   "settingsDataManagement": "Gestión de datos",
   "settingsAccountManagement": "Gestión de cuentas",
+  "settingsPrivacySectionTitle": "Privacidad",
+  "settingsMaskUidInUi": "Ocultar UID en la interfaz",
+  "settingsMaskUidInUiHint": "Cuando está activado, los UID en la interfaz y la lista de cuentas muestran los primeros 3 dígitos y el resto enmascarado (por ejemplo, 123xxxxx). Útil para transmisiones en vivo o al compartir pantalla. Las imágenes para compartir, los archivos exportados y el diálogo de confirmación de eliminación no se ven afectados.",
   "settingsAbout": "Sobre",
   "settingsAboutVersion": "Versión {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "Suivre le système",
   "settingsDataManagement": "Gestion des données",
   "settingsAccountManagement": "Gestion des comptes",
+  "settingsPrivacySectionTitle": "Confidentialité",
+  "settingsMaskUidInUi": "Masquer l'UID dans l'interface",
+  "settingsMaskUidInUiHint": "Lorsqu'activé, les UID dans l'interface et la liste des comptes affichent les 3 premiers chiffres et le reste est masqué (par exemple 123xxxxx). Utile pour le streaming ou le partage d'écran. Les images de partage, les fichiers exportés et la boîte de dialogue de confirmation de suppression ne sont pas affectés.",
   "settingsAbout": "Sur",
   "settingsAboutVersion": "Version {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "システムに合わせる",
   "settingsDataManagement": "データ管理",
   "settingsAccountManagement": "アカウント管理",
+  "settingsPrivacySectionTitle": "プライバシー",
+  "settingsMaskUidInUi": "画面上の UID をマスク",
+  "settingsMaskUidInUiHint": "オンにすると、画面とアカウント一覧の UID が先頭 3 桁と残りを x でマスクして表示されます（例：123xxxxx）。配信や画面共有時に便利です。共有画像、エクスポートファイル、削除確認ダイアログは影響を受けません。",
   "settingsAbout": "このツールについて",
   "settingsAboutVersion": "バージョン {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "Seguir sistema",
   "settingsDataManagement": "Gerenciamento de dados",
   "settingsAccountManagement": "Gerenciamento de contas",
+  "settingsPrivacySectionTitle": "Privacidade",
+  "settingsMaskUidInUi": "Mascarar UID na interface",
+  "settingsMaskUidInUiHint": "Quando ativado, os UIDs na interface e na lista de contas mostram os 3 primeiros dígitos com o restante mascarado (por exemplo, 123xxxxx). Útil para transmissões ou compartilhamento de tela. Imagens compartilháveis, arquivos exportados e a caixa de diálogo de confirmação de exclusão não são afetados.",
   "settingsAbout": "Cerca de",
   "settingsAboutVersion": "Versão {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "ตามระบบ",
   "settingsDataManagement": "จัดการข้อมูล",
   "settingsAccountManagement": "จัดการบัญชี",
+  "settingsPrivacySectionTitle": "ความเป็นส่วนตัว",
+  "settingsMaskUidInUi": "ปิดบัง UID ในอินเทอร์เฟซ",
+  "settingsMaskUidInUiHint": "เมื่อเปิดใช้งาน UID ในอินเทอร์เฟซและรายการบัญชีจะแสดง 3 หลักแรกและส่วนที่เหลือจะถูกปิดบัง (เช่น 123xxxxx) เหมาะสำหรับการสตรีมหรือการแชร์หน้าจอ ภาพแชร์ ไฟล์ส่งออก และกล่องโต้ตอบยืนยันการลบจะไม่ได้รับผลกระทบ",
   "settingsAbout": "เกี่ยวกับ",
   "settingsAboutVersion": "เวอร์ชัน {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -286,6 +286,9 @@
   "settingsLocaleSystem": "Theo hệ thống",
   "settingsDataManagement": "Quản Lý Dữ Liệu",
   "settingsAccountManagement": "Quản Lý Tài Khoản",
+  "settingsPrivacySectionTitle": "Quyền riêng tư",
+  "settingsMaskUidInUi": "Che giấu UID trong giao diện",
+  "settingsMaskUidInUiHint": "Khi bật, UID trong giao diện và danh sách tài khoản sẽ hiển thị 3 chữ số đầu tiên và phần còn lại được che giấu (ví dụ: 123xxxxx). Hữu ích khi phát trực tiếp hoặc chia sẻ màn hình. Hình ảnh chia sẻ, tệp xuất và hộp thoại xác nhận xóa không bị ảnh hưởng.",
   "settingsAbout": "Giới Thiệu",
   "settingsAboutVersion": "Phiên bản {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -216,6 +216,9 @@
   "settingsLocaleSystem": "跟隨系統",
   "settingsDataManagement": "資料管理",
   "settingsAccountManagement": "帳號管理",
+  "settingsPrivacySectionTitle": "隱私",
+  "settingsMaskUidInUi": "遮蔽介面中的 UID",
+  "settingsMaskUidInUiHint": "開啟後，畫面與帳號清單中的 UID 會以前 3 碼搭配 x 顯示（例如 123xxxxx），適合實況或螢幕分享時使用。分享圖、匯出檔案、刪除確認框不受影響。",
   "settingsAbout": "關於",
   "settingsAboutVersion": "版本 {version}",
   "@settingsAboutVersion": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -282,6 +282,9 @@
   "settingsLocaleSystem": "跟随系统",
   "settingsDataManagement": "数据管理",
   "settingsAccountManagement": "账号管理",
+  "settingsPrivacySectionTitle": "隐私",
+  "settingsMaskUidInUi": "遮蔽界面中的 UID",
+  "settingsMaskUidInUiHint": "开启后，画面与账号清单中的 UID 会以前 3 码搭配 x 显示（例如 123xxxxx），适合直播或屏幕分享时使用。分享图、导出文件、删除确认框不受影响。",
   "settingsAbout": "关于",
   "settingsAboutVersion": "版本 {version}",
   "@settingsAboutVersion": {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -87,6 +87,12 @@ class SettingsPage extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(
+                title: l.settingsAccountManagement,
+                icon: Icons.manage_accounts_outlined,
+                child: const AccountManagement(),
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              SectionCard(
                 title: l.settingsDataManagement,
                 icon: Icons.folder_outlined,
                 child: const _DataManagement(),
@@ -96,12 +102,6 @@ class SettingsPage extends ConsumerWidget {
                 title: l.settingsImageCache,
                 icon: Icons.image_outlined,
                 child: const _ImageCacheSection(),
-              ),
-              const SizedBox(height: AppSpacing.xl),
-              SectionCard(
-                title: l.settingsAccountManagement,
-                icon: Icons.manage_accounts_outlined,
-                child: const AccountManagement(),
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -71,6 +71,12 @@ class SettingsPage extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(
+                title: l.settingsPrivacySectionTitle,
+                icon: Icons.shield_outlined,
+                child: const _PrivacySection(),
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              SectionCard(
                 title: l.settingsLanguage,
                 icon: Icons.language,
                 child: _LocaleDropdown(
@@ -891,6 +897,38 @@ class _UsageRows extends StatelessWidget {
         row(l.settingsImageCacheIcons, icons, secondaryStyle),
         row(l.settingsImageCacheGallery, gallery, secondaryStyle),
       ],
+    );
+  }
+}
+
+/// 隱私設定區塊：目前僅含「遮蔽介面 UID」開關。
+class _PrivacySection extends ConsumerWidget {
+  /// 建立 [_PrivacySection]。
+  const _PrivacySection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final maskUid = ref.watch(settingsProvider.select((s) => s.maskUidInUi));
+    final notifier = ref.read(settingsProvider.notifier);
+
+    return SwitchListTile(
+      key: const ValueKey('settings.maskUidInUiSwitch'),
+      value: maskUid,
+      title: Text(l.settingsMaskUidInUi),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: AppSpacing.xs),
+        child: Text(
+          l.settingsMaskUidInUiHint,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: tokens.textSecondary,
+          ),
+        ),
+      ),
+      contentPadding: EdgeInsets.zero,
+      onChanged: notifier.setMaskUidInUi,
     );
   }
 }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -71,12 +71,6 @@ class SettingsPage extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(
-                title: l.settingsPrivacySectionTitle,
-                icon: Icons.shield_outlined,
-                child: const _PrivacySection(),
-              ),
-              const SizedBox(height: AppSpacing.xl),
-              SectionCard(
                 title: l.settingsLanguage,
                 icon: Icons.language,
                 child: _LocaleDropdown(
@@ -84,6 +78,12 @@ class SettingsPage extends ConsumerWidget {
                   onChanged: notifier.setLocale,
                   l: l,
                 ),
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              SectionCard(
+                title: l.settingsPrivacySectionTitle,
+                icon: Icons.shield_outlined,
+                child: const _PrivacySection(),
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(

--- a/lib/services/settings_storage.dart
+++ b/lib/services/settings_storage.dart
@@ -80,6 +80,7 @@ class AppSettings {
     this.uidAliases = const {},
     this.uidOrder = const [],
     this.skippedReleaseTag,
+    this.maskUidInUi = false,
   });
 
   /// 外觀主題。
@@ -100,6 +101,9 @@ class AppSettings {
   /// 使用者選擇跳過的 release tag（已讀過不再提示）。
   final String? skippedReleaseTag;
 
+  /// 是否在介面中遮蔽 UID（前 3 碼搭配 `x`）；資料檔與刪除確認框不受影響。
+  final bool maskUidInUi;
+
   /// 預設設定值（跟隨系統主題與語言）。
   static const defaults = AppSettings(
     themeMode: AppThemeMode.system,
@@ -117,6 +121,7 @@ class AppSettings {
     List<String>? uidOrder,
     String? skippedReleaseTag,
     bool clearSkippedReleaseTag = false,
+    bool? maskUidInUi,
   }) => AppSettings(
     themeMode: themeMode ?? this.themeMode,
     locale: locale ?? this.locale,
@@ -128,6 +133,7 @@ class AppSettings {
     skippedReleaseTag: clearSkippedReleaseTag
         ? null
         : (skippedReleaseTag ?? this.skippedReleaseTag),
+    maskUidInUi: maskUidInUi ?? this.maskUidInUi,
   );
 }
 
@@ -154,6 +160,9 @@ abstract final class SettingsStorage {
   /// SharedPreferences key：使用者跳過的 release tag。
   static const _kSkippedReleaseTag = 'pref.skippedReleaseTag';
 
+  /// SharedPreferences key：是否在介面中遮蔽 UID。
+  static const _kMaskUidInUi = 'pref.maskUidInUi';
+
   /// 從 SharedPreferences 讀取設定，欄位缺漏時回退到預設值。
   static Future<AppSettings> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -164,6 +173,7 @@ abstract final class SettingsStorage {
       uidAliases: _parseAliases(prefs.getString(_kUidAliases)),
       uidOrder: _parseOrder(prefs.getString(_kUidOrder)),
       skippedReleaseTag: prefs.getString(_kSkippedReleaseTag),
+      maskUidInUi: prefs.getBool(_kMaskUidInUi) ?? false,
     );
   }
 
@@ -184,6 +194,7 @@ abstract final class SettingsStorage {
     } else {
       await prefs.setString(_kSkippedReleaseTag, s.skippedReleaseTag!);
     }
+    await prefs.setBool(_kMaskUidInUi, s.maskUidInUi);
   }
 
   /// 解析主題設定字串，未知值回退到 [AppThemeMode.system]。

--- a/lib/state/settings.dart
+++ b/lib/state/settings.dart
@@ -77,7 +77,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setMaskUidInUi(bool value) async {
     state = state.copyWith(maskUidInUi: value);
     await SettingsStorage.save(state);
-    Logger('app.settings').info('maskUidInUi toggled', value);
+    Logger('app.settings').info('maskUidInUi toggled=$value');
   }
 
   /// 從 aliases 與 uidOrder 中移除指定 UID 並持久化。

--- a/lib/state/settings.dart
+++ b/lib/state/settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/services/settings_storage.dart';
 
@@ -70,6 +71,13 @@ class SettingsNotifier extends Notifier<AppSettings> {
       clearSkippedReleaseTag: tag == null,
     );
     await SettingsStorage.save(state);
+  }
+
+  /// 切換「遮蔽介面 UID」設定並持久化；變更值同步寫入 log。
+  Future<void> setMaskUidInUi(bool value) async {
+    state = state.copyWith(maskUidInUi: value);
+    await SettingsStorage.save(state);
+    Logger('app.settings').info('maskUidInUi toggled', value);
   }
 
   /// 從 aliases 與 uidOrder 中移除指定 UID 並持久化。

--- a/lib/utils/uid_display.dart
+++ b/lib/utils/uid_display.dart
@@ -1,0 +1,11 @@
+import 'package:genshin_impact_wish_gacha_analyzer/services/share_uid_mask.dart';
+
+/// UID 介面顯示工具：依介面隱私設定回傳遮蔽後或原樣 UID。
+///
+/// [mask] 來自 `AppSettings.maskUidInUi`。`true` 時呼叫 [maskUidForShare]
+/// （前 3 碼搭配 `x` 遮蔽其餘），與分享圖政策一致；`false` 時原樣回傳。
+///
+/// 與 log 用的 `sanitizeUid` 刻意分開：log 場景需要末碼幫助稽核交叉比對，
+/// UI 場景則是公開曝光情境，不應洩漏末碼。
+String displayUid(String uid, {required bool mask}) =>
+    mask ? maskUidForShare(uid) : uid;

--- a/lib/widgets/cards/account_management.dart
+++ b/lib/widgets/cards/account_management.dart
@@ -8,6 +8,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/uid_ordering.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/settings.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_repository.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/uid_display.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/confirm_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/relative_time_text.dart';
 
@@ -26,6 +27,7 @@ class AccountManagement extends ConsumerWidget {
     );
     final uidAliases = ref.watch(settingsProvider.select((s) => s.uidAliases));
     final uidOrder = ref.watch(settingsProvider.select((s) => s.uidOrder));
+    final maskUid = ref.watch(settingsProvider.select((s) => s.maskUidInUi));
     final notifier = ref.read(gachaRepositoryProvider.notifier);
     final settingsNotifier = ref.read(settingsProvider.notifier);
 
@@ -70,6 +72,7 @@ class AccountManagement extends ConsumerWidget {
                 lastUpdated: byUid[uid]!.lastUpdated,
                 isActive: uid == activeUid,
                 alias: uidAliases[uid] ?? '',
+                maskUid: maskUid,
                 onSetActive: () => notifier.setActiveUid(uid),
                 onRemove: () => _remove(context, ref, uid),
                 onAliasSubmit: (value) =>
@@ -117,6 +120,7 @@ class _Row extends StatefulWidget {
     required this.lastUpdated,
     required this.isActive,
     required this.alias,
+    required this.maskUid,
     required this.onSetActive,
     required this.onRemove,
     required this.onAliasSubmit,
@@ -136,6 +140,9 @@ class _Row extends StatefulWidget {
 
   /// 使用者自訂別名；空字串表示未設定。
   final String alias;
+
+  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  final bool maskUid;
 
   /// 點擊「切換」後呼叫。
   final VoidCallback onSetActive;
@@ -221,7 +228,7 @@ class _RowState extends State<_Row> {
                 Row(
                   children: [
                     Text(
-                      widget.uid,
+                      displayUid(widget.uid, mask: widget.maskUid),
                       style: TextStyle(
                         color: tokens.textPrimary,
                         fontWeight: FontWeight.w600,

--- a/lib/widgets/uid_indicator.dart
+++ b/lib/widgets/uid_indicator.dart
@@ -8,6 +8,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/uid_ordering.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/settings.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_repository.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/uid_display.dart';
 
 /// AppBar 上的 UID 切換按鈕，點擊後展開帳號選單。
 class UidIndicator extends ConsumerWidget {
@@ -20,6 +21,7 @@ class UidIndicator extends ConsumerWidget {
     final settings = ref.watch(settingsProvider);
     final notifier = ref.read(gachaRepositoryProvider.notifier);
     final activeUid = state.activeUid;
+    final maskUid = settings.maskUidInUi;
     final l = AppLocalizations.of(context)!;
 
     final orderedUids = state.byUid.isEmpty
@@ -50,6 +52,7 @@ class UidIndicator extends ConsumerWidget {
                   uid: uid,
                   alias: settings.uidAliases[uid],
                   isActive: uid == activeUid,
+                  maskUid: maskUid,
                 ),
               ),
             ],
@@ -110,6 +113,7 @@ class UidIndicator extends ConsumerWidget {
       child: AccountTriggerLabel(
         activeUid: activeUid,
         alias: activeUid == null ? null : settings.uidAliases[activeUid],
+        maskUid: maskUid,
       ),
     );
   }
@@ -119,13 +123,21 @@ class UidIndicator extends ConsumerWidget {
 /// 無 alias 顯示 UID;activeUid==null 顯示「未同步」。
 class AccountTriggerLabel extends StatelessWidget {
   /// 建立 [AccountTriggerLabel]。
-  const AccountTriggerLabel({super.key, this.activeUid, this.alias});
+  const AccountTriggerLabel({
+    super.key,
+    this.activeUid,
+    this.alias,
+    this.maskUid = false,
+  });
 
   /// 當前登入的 UID，`null` 表示尚未同步。
   final String? activeUid;
 
   /// 使用者自訂的帳號別名。
   final String? alias;
+
+  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  final bool maskUid;
 
   @override
   Widget build(BuildContext context) {
@@ -140,6 +152,7 @@ class AccountTriggerLabel extends StatelessWidget {
       ]);
     }
     final hasAlias = alias != null && alias!.isNotEmpty;
+    final shown = displayUid(uid, mask: maskUid);
     return _row([
       const Icon(Icons.person_outline, size: 18),
       const SizedBox(width: AppSpacing.xs),
@@ -148,9 +161,9 @@ class AccountTriggerLabel extends StatelessWidget {
           constraints: const BoxConstraints(maxWidth: 160),
           child: Text(alias!, maxLines: 1, overflow: TextOverflow.ellipsis),
         ),
-        Text(' ($uid)'),
+        Text(' ($shown)'),
       ] else
-        Text(uid),
+        Text(shown),
       const Icon(Icons.arrow_drop_down, size: 18),
     ]);
   }
@@ -209,6 +222,7 @@ class AccountMenuLabel extends StatelessWidget {
     required this.uid,
     required this.isActive,
     this.alias,
+    this.maskUid = false,
   });
 
   /// 帳號 UID。
@@ -220,12 +234,16 @@ class AccountMenuLabel extends StatelessWidget {
   /// 是否為當前使用中的帳號。
   final bool isActive;
 
+  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  final bool maskUid;
+
   @override
   Widget build(BuildContext context) {
     final tokens = Theme.of(context).gacha;
     final l = AppLocalizations.of(context)!;
     final hasAlias = alias != null && alias!.isNotEmpty;
-    final primary = hasAlias ? alias! : uid;
+    final shownUid = displayUid(uid, mask: maskUid);
+    final primary = hasAlias ? alias! : shownUid;
 
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 280),
@@ -250,7 +268,10 @@ class AccountMenuLabel extends StatelessWidget {
             ],
           ),
           if (hasAlias)
-            Text(uid, style: TextStyle(fontSize: 12, color: tokens.textMuted)),
+            Text(
+              shownUid,
+              style: TextStyle(fontSize: 12, color: tokens.textMuted),
+            ),
         ],
       ),
     );

--- a/test/pages/settings_privacy_section_test.dart
+++ b/test/pages/settings_privacy_section_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/app_info.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/pages/settings_page.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/cancellable_http_client.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_storage.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_capture.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_repository.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/settings.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+
+/// 空 [GachaCapture] 替身，避免測試啟動真實 MITM session。
+class _NullCapture implements GachaCapture {
+  @override
+  CaptureSession start() =>
+      CaptureSession(result: Future.value(null), cancel: () async {});
+}
+
+/// 啟動測試用 [ProviderContainer]，覆寫 SettingsPage 所需依賴並完成 bootstrap。
+Future<ProviderContainer> _setupContainer({
+  required GachaStorage storage,
+  required Directory tempDir,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      gachaStorageProvider.overrideWithValue(storage),
+      gachaCaptureProvider.overrideWithValue(_NullCapture()),
+      cancellableHttpClientFactoryProvider.overrideWithValue(
+        () => CancellableHttpClient(
+          client: MockClient((_) async => http.Response('{}', 200)),
+          cancel: () {},
+        ),
+      ),
+      hoyowikiIndexStorageProvider.overrideWithValue(
+        HoYoWikiIndexStorage(tempDir),
+      ),
+      hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+      appVersionProvider.overrideWithValue('0.0.0-test'),
+    ],
+  );
+  await container.read(settingsProvider.notifier).waitForLoad();
+  container.read(gachaRepositoryProvider);
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+  return container;
+}
+
+/// 將 [SettingsPage] 包進 [MaterialApp] 與 [UncontrolledProviderScope]，
+/// 套用測試所需的 i18n delegates 與英文語系。
+Widget _wrap(ProviderContainer container) => UncontrolledProviderScope(
+  container: container,
+  child: MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    locale: const Locale('en'),
+    theme: buildDarkTheme(),
+    home: const Scaffold(body: SettingsPage()),
+  ),
+);
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    tempDir = await Directory.systemTemp.createTemp('settings_privacy_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  /// 啟動 container 與 SettingsPage，回傳 container 供測試讀取 settingsProvider。
+  Future<ProviderContainer> pumpSettingsPage(WidgetTester tester) async {
+    late ProviderContainer container;
+    await tester.runAsync(() async {
+      container = await _setupContainer(
+        storage: GachaStorage(tempDir),
+        tempDir: tempDir,
+      );
+    });
+    addTearDown(container.dispose);
+    await tester.pumpWidget(_wrap(container));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return container;
+  }
+
+  testWidgets('Privacy section title renders', (tester) async {
+    await pumpSettingsPage(tester);
+    expect(find.text('Privacy'), findsOneWidget);
+  });
+
+  testWidgets('Privacy switch reflects default false', (tester) async {
+    await pumpSettingsPage(tester);
+    final sw = tester.widget<SwitchListTile>(
+      find.byKey(const ValueKey('settings.maskUidInUiSwitch')),
+    );
+    expect(sw.value, false);
+  });
+
+  testWidgets('Toggling switch calls setMaskUidInUi(true)', (tester) async {
+    final container = await pumpSettingsPage(tester);
+    expect(container.read(settingsProvider).maskUidInUi, false);
+
+    await tester.tap(find.byKey(const ValueKey('settings.maskUidInUiSwitch')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(container.read(settingsProvider).maskUidInUi, true);
+  });
+
+  testWidgets('Section sits between Appearance and Language', (tester) async {
+    await pumpSettingsPage(tester);
+    final appearanceY = tester.getTopLeft(find.text('Appearance')).dy;
+    final privacyY = tester.getTopLeft(find.text('Privacy')).dy;
+    final languageY = tester.getTopLeft(find.text('Language')).dy;
+    expect(appearanceY, lessThan(privacyY));
+    expect(privacyY, lessThan(languageY));
+  });
+}

--- a/test/pages/settings_privacy_section_test.dart
+++ b/test/pages/settings_privacy_section_test.dart
@@ -112,19 +112,26 @@ void main() {
     final container = await pumpSettingsPage(tester);
     expect(container.read(settingsProvider).maskUidInUi, false);
 
-    await tester.tap(find.byKey(const ValueKey('settings.maskUidInUiSwitch')));
+    final switchFinder = find.byKey(
+      const ValueKey('settings.maskUidInUiSwitch'),
+    );
+    await tester.ensureVisible(switchFinder);
+    await tester.pump();
+    await tester.tap(switchFinder);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(container.read(settingsProvider).maskUidInUi, true);
   });
 
-  testWidgets('Section sits between Appearance and Language', (tester) async {
+  testWidgets('Section sits between Language and Data Management', (
+    tester,
+  ) async {
     await pumpSettingsPage(tester);
-    final appearanceY = tester.getTopLeft(find.text('Appearance')).dy;
-    final privacyY = tester.getTopLeft(find.text('Privacy')).dy;
     final languageY = tester.getTopLeft(find.text('Language')).dy;
-    expect(appearanceY, lessThan(privacyY));
-    expect(privacyY, lessThan(languageY));
+    final privacyY = tester.getTopLeft(find.text('Privacy')).dy;
+    final dataManagementY = tester.getTopLeft(find.text('Data management')).dy;
+    expect(languageY, lessThan(privacyY));
+    expect(privacyY, lessThan(dataManagementY));
   });
 }

--- a/test/services/settings_storage_test.dart
+++ b/test/services/settings_storage_test.dart
@@ -193,4 +193,31 @@ void main() {
       expect(s.skippedReleaseTag, isNull);
     });
   });
+
+  group('maskUidInUi', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('defaults to false when key absent', () async {
+      final s = await SettingsStorage.load();
+      expect(s.maskUidInUi, false);
+    });
+
+    test('roundtrips true', () async {
+      await SettingsStorage.save(
+        AppSettings.defaults.copyWith(maskUidInUi: true),
+      );
+      final s = await SettingsStorage.load();
+      expect(s.maskUidInUi, true);
+    });
+
+    test('roundtrips false explicitly', () async {
+      await SettingsStorage.save(
+        AppSettings.defaults.copyWith(maskUidInUi: false),
+      );
+      final s = await SettingsStorage.load();
+      expect(s.maskUidInUi, false);
+    });
+  });
 }

--- a/test/services/settings_storage_test.dart
+++ b/test/services/settings_storage_test.dart
@@ -195,10 +195,6 @@ void main() {
   });
 
   group('maskUidInUi', () {
-    setUp(() async {
-      SharedPreferences.setMockInitialValues(<String, Object>{});
-    });
-
     test('defaults to false when key absent', () async {
       final s = await SettingsStorage.load();
       expect(s.maskUidInUi, false);

--- a/test/state/settings_test.dart
+++ b/test/state/settings_test.dart
@@ -218,4 +218,42 @@ void main() {
     final reloaded = await SettingsStorage.load();
     expect(reloaded.skippedReleaseTag, isNull);
   });
+
+  group('setMaskUidInUi', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('default state is false', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(settingsProvider.notifier).waitForLoad();
+      expect(container.read(settingsProvider).maskUidInUi, false);
+    });
+
+    test('toggles state and persists', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(settingsProvider.notifier).waitForLoad();
+
+      await container.read(settingsProvider.notifier).setMaskUidInUi(true);
+      expect(container.read(settingsProvider).maskUidInUi, true);
+
+      final reloaded = await SettingsStorage.load();
+      expect(reloaded.maskUidInUi, true);
+    });
+
+    test('toggles back to false and persists', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(settingsProvider.notifier).waitForLoad();
+      await container.read(settingsProvider.notifier).setMaskUidInUi(true);
+
+      await container.read(settingsProvider.notifier).setMaskUidInUi(false);
+      expect(container.read(settingsProvider).maskUidInUi, false);
+
+      final reloaded = await SettingsStorage.load();
+      expect(reloaded.maskUidInUi, false);
+    });
+  });
 }

--- a/test/utils/uid_display_test.dart
+++ b/test/utils/uid_display_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/share_uid_mask.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/uid_display.dart';
+
+void main() {
+  group('displayUid', () {
+    test('returns original uid when mask=false', () {
+      expect(displayUid('123456789', mask: false), '123456789');
+    });
+
+    test('returns masked uid when mask=true', () {
+      expect(displayUid('123456789', mask: true), '123xxxxxx');
+    });
+
+    test('mask=true delegates to maskUidForShare', () {
+      const uid = '987654321';
+      expect(displayUid(uid, mask: true), maskUidForShare(uid));
+    });
+
+    test('handles empty string', () {
+      expect(displayUid('', mask: true), 'xxx');
+      expect(displayUid('', mask: false), '');
+    });
+
+    test('handles short uid (< 3 chars)', () {
+      expect(displayUid('12', mask: true), 'xxx');
+      expect(displayUid('12', mask: false), '12');
+    });
+
+    test('handles uid of exactly 3 chars', () {
+      expect(displayUid('123', mask: true), '123');
+      expect(displayUid('123', mask: false), '123');
+    });
+  });
+}

--- a/test/widgets/cards/account_management_test.dart
+++ b/test/widgets/cards/account_management_test.dart
@@ -256,4 +256,63 @@ void main() {
     final reloaded = await tester.runAsync(() => SettingsStorage.load());
     expect(reloaded!.uidAliases, isEmpty);
   });
+
+  group('AccountManagement: maskUidInUi', () {
+    /// 建立含單一 UID 的 storage 並 pump AccountManagement，回傳預熱完成的 container。
+    Future<ProviderContainer> pumpWithUid(
+      WidgetTester tester, {
+      required String uid,
+      required bool maskUidInUi,
+    }) async {
+      final storage = GachaStorage(tempDir);
+      await tester.runAsync(() async {
+        await storage.save(
+          BannerStorage(
+            uid: uid,
+            lastUpdated: DateTime.utc(2026, 5, 9),
+            banners: const {
+              '301': [],
+              '302': [],
+              '500': [],
+              '200': [],
+              '100': [],
+            },
+          ),
+        );
+      });
+      late ProviderContainer container;
+      await tester.runAsync(() async {
+        container = await _setupContainer(
+          storage: storage,
+          prefs: {'pref.maskUidInUi': maskUidInUi},
+        );
+      });
+      addTearDown(container.dispose);
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      return container;
+    }
+
+    testWidgets('maskUidInUi=false 顯示完整 UID', (tester) async {
+      await pumpWithUid(tester, uid: '123456789', maskUidInUi: false);
+      expect(find.text('123456789'), findsOneWidget);
+      expect(find.text('123xxxxxx'), findsNothing);
+    });
+
+    testWidgets('maskUidInUi=true 顯示遮蔽 UID', (tester) async {
+      await pumpWithUid(tester, uid: '123456789', maskUidInUi: true);
+      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123456789'), findsNothing);
+    });
+
+    testWidgets('刪除確認 dialog 仍顯示完整 UID（隱私模式下）', (tester) async {
+      await pumpWithUid(tester, uid: '123456789', maskUidInUi: true);
+      await tester.tap(find.byIcon(Icons.delete_outline).first);
+      await tester.pumpAndSettle();
+      // confirm dialog 透過 i18n confirmClearActiveBody({uid}) 把完整 UID 嵌入訊息，
+      // 即使介面隱私模式啟用也要顯示完整碼，避免使用者誤刪錯帳號。
+      expect(find.textContaining('123456789'), findsWidgets);
+    });
+  });
 }

--- a/test/widgets/uid_indicator_test.dart
+++ b/test/widgets/uid_indicator_test.dart
@@ -168,4 +168,84 @@ void main() {
       expect(aliasText.maxLines, 1);
     });
   });
+
+  group('AccountTriggerLabel: maskUid', () {
+    testWidgets('displays full uid when maskUid=false', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const AccountTriggerLabel(activeUid: '123456789', maskUid: false),
+        ),
+      );
+      expect(find.text('123456789'), findsOneWidget);
+    });
+
+    testWidgets('displays masked uid when maskUid=true', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const AccountTriggerLabel(activeUid: '123456789', maskUid: true)),
+      );
+      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123456789'), findsNothing);
+    });
+
+    testWidgets('with alias: still masks the (uid) suffix', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const AccountTriggerLabel(
+            activeUid: '123456789',
+            alias: '主帳',
+            maskUid: true,
+          ),
+        ),
+      );
+      expect(find.text('主帳'), findsOneWidget);
+      expect(find.text(' (123xxxxxx)'), findsOneWidget);
+      expect(find.text(' (123456789)'), findsNothing);
+    });
+
+    testWidgets('with alias: maskUid=false shows full', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const AccountTriggerLabel(
+            activeUid: '123456789',
+            alias: '主帳',
+            maskUid: false,
+          ),
+        ),
+      );
+      expect(find.text(' (123456789)'), findsOneWidget);
+    });
+  });
+
+  group('AccountMenuLabel: maskUid', () {
+    testWidgets('without alias shows masked uid as primary', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const AccountMenuLabel(
+            uid: '123456789',
+            isActive: false,
+            maskUid: true,
+          ),
+        ),
+      );
+      expect(find.text('123xxxxxx'), findsOneWidget);
+    });
+
+    testWidgets('with alias: alias primary, masked uid as subtitle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const AccountMenuLabel(
+            uid: '123456789',
+            alias: '主帳',
+            isActive: false,
+            maskUid: true,
+          ),
+        ),
+      );
+      expect(find.text('主帳'), findsOneWidget);
+      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123456789'), findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- 設定頁新增「隱私」區塊，提供「遮蔽介面中的 UID」開關。開啟後 AppBar 帳號鈕、帳號菜單、帳號管理清單三處的 UID 以前 3 碼搭配 `x` 顯示（例如 `123xxxxx`），方便實況或螢幕分享情境。
- 沿用既有 `maskUidForShare` helper；資料檔、匯出 JSON、log、刪除確認框、分享圖維持顯示完整 UID（分享圖仍由獨立的 `showFullUid` 設定控制）。
- 同步調整 settings 區塊順序：Privacy 放在 Language 下方、Account Management 上移到 Data Management 之前。

🤖 Generated with [Claude Code](https://claude.com/claude-code)