### PR TITLE
feat(installer): ask whether to remove user data on uninstall

### DIFF
--- a/scripts/build_installer/installer.iss
+++ b/scripts/build_installer/installer.iss
@@ -92,12 +92,23 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: 
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; \
     Flags: nowait postinstall skipifsilent
 
+[CustomMessages]
+UninstallRemoveDataBody=Also remove user data?%n%nThis will permanently delete the contents of:%n%1%n%nincluding banner records, settings, caches and logs. This cannot be undone.
+tradchinese.UninstallRemoveDataBody=是否要同時移除使用者資料？%n%n將永久刪除位於以下目錄的所有內容：%n%1%n%n包含卡池記錄、設定、快取與 log。此操作無法復原。
+simpchinese.UninstallRemoveDataBody=是否要同时移除用户数据？%n%n将永久删除位于以下目录的所有内容：%n%1%n%n包含卡池记录、设定、缓存与 log。此操作无法复原。
+
 [Code]
 const
   UninstallPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall';
   DisplayNameNeedle = 'Genshin Impact Wish Gacha Analyzer';
   // 新版自己的 Inno Setup 卸載 key 名稱（用於排除），格式固定為 "{AppId}_is1"
   SelfUninstKey = '{#MyAppId}_is1';
+
+var
+  // 解除安裝期間記錄使用者是否選擇連同移除 %APPDATA% 內的使用者資料。
+  // usUninstall 階段由 MsgBox 設定，usPostUninstall 階段讀取以決定是否 DelTree。
+  // Inno Setup 啟動 uninstaller process 時 Pascal Boolean 預設為 False，符合「預設不刪」語意。
+  ShouldRemoveUserData: Boolean;
 
 // 收集所有判定為「舊版」的 UninstallString
 procedure CollectOldUninstallers(RootKey: Integer; const SubPath: String; List: TStringList);
@@ -209,5 +220,35 @@ begin
     // 若 uninstaller 不存在（殘留註冊表項）→ ShellExec 失敗，但舊版已壞，讓新版蓋過去
   finally
     Olds.Free;
+  end;
+end;
+
+// 解除安裝流程：usUninstall 階段詢問使用者是否同時移除使用者資料，
+// usPostUninstall 階段依旗標執行 DelTree（主程式檔已被卸載，避免 file lock）。
+// silent 模式（/VERYSILENT、/SILENT）下 MsgBox 自動回傳預設按鈕值 = IDNO，
+// 結果與「預設不勾」一致。
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  UserDataDir: String;
+begin
+  UserDataDir := ExpandConstant('{userappdata}\tw.reh\genshin_impact_wish_gacha_analyzer');
+  case CurUninstallStep of
+    usUninstall:
+      begin
+        ShouldRemoveUserData :=
+          MsgBox(
+            FmtMessage(CustomMessage('UninstallRemoveDataBody'), [UserDataDir]),
+            mbConfirmation,
+            MB_YESNO or MB_DEFBUTTON2
+          ) = IDYES;
+      end;
+    usPostUninstall:
+      begin
+        if ShouldRemoveUserData then
+        begin
+          if not DelTree(UserDataDir, True, True, True) then
+            Log('uninstall: DelTree failed for ' + UserDataDir);
+        end;
+      end;
   end;
 end;


### PR DESCRIPTION
## 摘要

- 在 Inno Setup 解除安裝流程中新增「Also remove user data?」MsgBox（預設 No，`MB_DEFBUTTON2`）。
- 勾 Yes 時於 `usPostUninstall` 階段 `DelTree` 整個 `%APPDATA%\tw.reh\genshin_impact_wish_gacha_analyzer\`（含卡池記錄、設定、HoYoWiki 快取、log）—— 此時主程式檔案已被卸載，避免 file lock 衝突。
- 完整翻譯：繁體中文、簡體中文、英文（其他語系 fallback）。

## 設計重點

- **兩階段流程：** `usUninstall` 顯示 MsgBox 並把使用者選擇存到模組變數；`usPostUninstall` 依旗標決定是否 `DelTree`。
- **預設安全：** `MB_DEFBUTTON2` 把 No 設為預設按鈕，所以在 MsgBox 上直接按 Enter、或執行 `/VERYSILENT` silent 解除安裝，使用者資料都會被保留。
- **i18n 放置位置：** 所有翻譯寫在 `installer.iss` 的 `[CustomMessages]` 段內、用 `langname.Key=` 語法 —— **不放在** 各語系 `.isl` 檔內。Inno Setup 不會把 `.isl` 內的 `[CustomMessages]` 條目打包到 uninstaller（`unins000.dat`），解除安裝階段呼叫 `CustomMessage()` 只看得到 `installer.iss` 內定義的條目。本檔既有的 `InitializeSetup()` 也是用 `ActiveLanguage()` + hardcoded 字串而非 `CustomMessage()`，原因相同。
- **路徑透明度：** MsgBox 本文透過 `ExpandConstant('{userappdata}\tw.reh\genshin_impact_wish_gacha_analyzer')` + `FmtMessage('%1', [...])` 顯示完整 expanded 絕對路徑，讓使用者在確認前可以核對目標。

## 淨變更

只動 `scripts/build_installer/installer.iss`（+41 行）：一個 `[CustomMessages]` 段（含英文／繁中／簡中三組翻譯）、一個 `ShouldRemoveUserData: Boolean` 模組變數、一個 `CurUninstallStepChanged` procedure。

## 備註

- 本 PR 由 7 個 commit 壓成 1 個 feat commit。原 7 個 commit 內含初始實作 + debug 過程（途中發現「`.isl` 內的 `[CustomMessages]` 不會被打包到 uninstaller」），完整 debug 敘事已併入此 PR 描述。

🤖 Generated with [Claude Code](https://claude.com/claude-code)