### PR TITLE
feat(settings): add current-version release notes viewer in About

### DIFF
--- a/docs/superpowers/plans/2026-05-28-current-version-release-notes.md
+++ b/docs/superpowers/plans/2026-05-28-current-version-release-notes.md
@@ -1,0 +1,1871 @@
+# 目前版本更新內容 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在設定頁「關於」section 新增「查看更新內容」按鈕，點擊開啟 dialog 顯示**目前安裝版本**對應的 GitHub release notes（Markdown）。
+
+**Architecture:** 重用既有 `AppReleaseChecker` + `markdown_widget` + `AppDialog` 堆疊。新增 `fetchReleaseByVersion()` endpoint method、`ReleaseCheckNotFound` sealed 子類、`currentReleaseProvider` (Riverpod `FutureProvider.family`，自帶 in-memory cache)、抽出共用 `ReleaseNotesContent` widget、`CurrentReleaseDialog` (loading / error / data 三態殼)。
+
+**Tech Stack:** Flutter (Dart 3 sealed classes)、`flutter_riverpod` (FutureProvider.family)、`http` + `package:http/testing.dart` MockClient、`pub_semver` (`Version.parse`)、`markdown_widget` (`MarkdownBlock`)、`logging` (`Logger`)、`fake_async` (timeout 測試)。
+
+**Spec:** `docs/superpowers/specs/2026-05-28-current-version-release-notes-design.md`
+
+---
+
+## File Structure
+
+| 檔案 | 動作 | 責任 |
+|---|---|---|
+| `lib/services/app_release_checker.dart` | 修改 | + `fetchReleaseByVersion()` + `ReleaseCheckNotFound` sealed 子類 |
+| `lib/state/current_release.dart` | 新增 | `currentReleaseProvider = FutureProvider.family<AppRelease, String>` |
+| `lib/widgets/dialogs/release_notes_content.dart` | 新增 | 共用 `ReleaseNotesContent` widget + `releaseNotesMarkdownConfig` helper |
+| `lib/widgets/dialogs/new_version_dialog.dart` | 修改 | 移除 `_ReleaseCard` + `_markdownConfig`，改用 `ReleaseNotesContent` |
+| `lib/widgets/dialogs/current_release_dialog.dart` | 新增 | `CurrentReleaseDialog` (ConsumerWidget) — 三態 dialog 殼 |
+| `lib/pages/settings_page.dart` | 修改 | `_AboutContent` Row 加 `OutlinedButton.icon`「查看更新內容」 |
+| `lib/l10n/app_zh.arb` (template) | 修改 | + 5 個新 keys |
+| `lib/l10n/app_{zh_Hans,en,es,fr,ja,pt_BR,th,vi}.arb` | 修改 | + 對應翻譯 |
+| `test/services/app_release_checker_test.dart` | 修改 | + `group 'fetchReleaseByVersion'` |
+| `test/state/current_release_test.dart` | 新增 | provider cache / invalidate / error path 測試 |
+| `test/widgets/dialogs/current_release_dialog_test.dart` | 新增 | 三態 + actions 測試 |
+
+---
+
+## Task 1: 實作 `fetchReleaseByVersion()` + `ReleaseCheckNotFound` (TDD)
+
+**Files:**
+- Modify: `lib/services/app_release_checker.dart` (尾端 append)
+- Test: `test/services/app_release_checker_test.dart` (尾端 append)
+
+### Step 1.1: 寫 happy path 測試
+
+- [ ] 在 `test/services/app_release_checker_test.dart` `void main()` 最後加新 `group`：
+
+```dart
+  group('fetchReleaseByVersion — happy path', () {
+    test('200 + valid JSON → AppRelease', () async {
+      late Uri requested;
+      final client = MockClient((req) async {
+        requested = req.url;
+        return http.Response(
+          jsonEncode(_release(
+            tag: 'v1.1.0',
+            published: '2026-05-27T00:00:00Z',
+            name: 'v1.1.0',
+            body: '## Features\n- foo\n- bar',
+            htmlUrl: 'https://github.com/o/r/releases/tag/v1.1.0',
+          )),
+          200,
+        );
+      });
+
+      final release = await fetchReleaseByVersion(
+        version: '1.1.0',
+        client: client,
+      );
+
+      expect(requested.path, endsWith('/releases/tags/v1.1.0'));
+      expect(release.tagName, 'v1.1.0');
+      expect(release.version, '1.1.0');
+      expect(release.name, 'v1.1.0');
+      expect(release.body, '## Features\n- foo\n- bar');
+      expect(release.htmlUrl, 'https://github.com/o/r/releases/tag/v1.1.0');
+      expect(release.publishedAt, DateTime.utc(2026, 5, 27));
+    });
+
+    test('version 帶 build metadata → endpoint 用核心 SemVer', () async {
+      late Uri requested;
+      final client = MockClient((req) async {
+        requested = req.url;
+        return http.Response(
+          jsonEncode(_release(
+            tag: 'v1.1.0',
+            published: '2026-05-27T00:00:00Z',
+          )),
+          200,
+        );
+      });
+
+      await fetchReleaseByVersion(version: '1.1.0+2', client: client);
+
+      expect(requested.path, endsWith('/releases/tags/v1.1.0'));
+    });
+  });
+```
+
+註：`_release()` helper 已在檔案上方既有；只多了一個 `htmlUrl` 參數有預設值，傳什麼都 OK。
+
+### Step 1.2: 跑測試確認 fail
+
+- [ ] 執行：
+
+```
+flutter test test/services/app_release_checker_test.dart --plain-name "fetchReleaseByVersion"
+```
+
+Expected: FAIL 並提示 `fetchReleaseByVersion` 未定義。
+
+### Step 1.3: 實作 `ReleaseCheckNotFound` + `fetchReleaseByVersion`
+
+- [ ] 在 `lib/services/app_release_checker.dart` 既有 `ReleaseCheckFormat` 類別後面（約第 77 行後）加：
+
+```dart
+/// 找不到指定 tag 對應的 release（HTTP 404）。
+class ReleaseCheckNotFound extends ReleaseCheckError {
+  /// 建立 [ReleaseCheckNotFound]，[tag] 為查詢的 tag（含 v 前綴）。
+  const ReleaseCheckNotFound(this.tag);
+
+  /// 查詢的 tag，例如 `v1.1.0`。
+  final String tag;
+}
+```
+
+- [ ] 在檔案最尾端（`fetchNewerReleases` 函式結束後）加：
+
+```dart
+/// 抓指定 [version] 對應的單一 GitHub Release。
+///
+/// [version] 可帶 SemVer build metadata（例如 `1.1.0+2`，這是 Flutter
+/// `pubspec.yaml` / `PackageInfo.version` 的標準格式）；內部會剝掉 build
+/// metadata、補上 `v` 前綴後組成 tag（如 `v1.1.0`）查詢。
+///
+/// 與 [fetchNewerReleases] 不同，這個函式不過濾 `draft` / `prerelease`；
+/// 使用者主動查指定 tag 即表示想看那個版本，無論其發佈狀態。
+///
+/// 失敗時拋 [ReleaseCheckError] 的具體子類；指定 tag 不存在時拋
+/// [ReleaseCheckNotFound]。
+Future<AppRelease> fetchReleaseByVersion({
+  required String version,
+  required http.Client client,
+}) async {
+  final Version parsed;
+  try {
+    parsed = Version.parse(version);
+  } catch (_) {
+    throw const ReleaseCheckFormat();
+  }
+  final core = '${parsed.major}.${parsed.minor}.${parsed.patch}';
+  final tag = 'v$core';
+  final uri = Uri.parse('${AppRepo.apiBase}/releases/tags/$tag');
+
+  final http.Response resp;
+  try {
+    resp = await client
+        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
+        .timeout(const Duration(seconds: 10));
+  } on TimeoutException {
+    throw const ReleaseCheckTimeout();
+  } on SocketException {
+    throw const ReleaseCheckNetwork();
+  } on http.ClientException {
+    throw const ReleaseCheckNetwork();
+  }
+
+  if (resp.statusCode == 404) {
+    throw ReleaseCheckNotFound(tag);
+  }
+  if (resp.statusCode == 429 ||
+      (resp.statusCode == 403 &&
+          resp.headers['x-ratelimit-remaining'] == '0')) {
+    throw const ReleaseCheckRateLimited();
+  }
+  if (resp.statusCode != 200) {
+    throw ReleaseCheckServer(resp.statusCode);
+  }
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(resp.body);
+  } on FormatException {
+    throw const ReleaseCheckFormat();
+  }
+  if (decoded is! Map) throw const ReleaseCheckFormat();
+  final raw = decoded;
+  final tagName = raw['tag_name'];
+  if (tagName is! String) throw const ReleaseCheckFormat();
+  final parsedTag = _parseTag(tagName);
+  if (parsedTag == null) throw const ReleaseCheckFormat();
+  final published = DateTime.tryParse(raw['published_at']?.toString() ?? '');
+  if (published == null) throw const ReleaseCheckFormat();
+
+  return AppRelease(
+    tagName: tagName,
+    version: parsedTag.toString(),
+    name: (raw['name'] as String?) ?? '',
+    body: (raw['body'] as String?) ?? '',
+    htmlUrl: (raw['html_url'] as String?) ?? '',
+    publishedAt: published,
+  );
+}
+```
+
+### Step 1.4: 跑 happy path 測試確認 pass
+
+- [ ] 執行：
+
+```
+flutter test test/services/app_release_checker_test.dart --plain-name "fetchReleaseByVersion"
+```
+
+Expected: 兩個 happy path 測試 PASS。
+
+### Step 1.5: 加完整錯誤情境測試
+
+- [ ] 在 Step 1.1 加的 group 之後再加：
+
+```dart
+  group('fetchReleaseByVersion — errors', () {
+    test('404 → ReleaseCheckNotFound (tag = v1.1.0)', () async {
+      final client = MockClient(
+        (_) async => http.Response('Not Found', 404),
+      );
+      try {
+        await fetchReleaseByVersion(version: '1.1.0', client: client);
+        fail('expected throw');
+      } on ReleaseCheckNotFound catch (e) {
+        expect(e.tag, 'v1.1.0');
+      }
+    });
+
+    test('5xx → ReleaseCheckServer(status)', () async {
+      final client = MockClient(
+        (_) async => http.Response('boom', 503),
+      );
+      try {
+        await fetchReleaseByVersion(version: '1.1.0', client: client);
+        fail('expected throw');
+      } on ReleaseCheckServer catch (e) {
+        expect(e.status, 503);
+      }
+    });
+
+    test('429 → ReleaseCheckRateLimited', () async {
+      final client = MockClient(
+        (_) async => http.Response('rate limited', 429),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckRateLimited>()),
+      );
+    });
+
+    test('403 + x-ratelimit-remaining: 0 → ReleaseCheckRateLimited', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          'forbidden',
+          403,
+          headers: const {'x-ratelimit-remaining': '0'},
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckRateLimited>()),
+      );
+    });
+
+    test('200 但 body 不是 JSON object → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode([1, 2, 3]), 200),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('200 但缺 tag_name → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'published_at': '2026-05-27T00:00:00Z'}),
+          200,
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('200 但 tag_name 無法 parse → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'tag_name': 'weird-tag',
+            'published_at': '2026-05-27T00:00:00Z',
+          }),
+          200,
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('SocketException → ReleaseCheckNetwork', () async {
+      final client = MockClient((_) async {
+        throw const SocketException('offline');
+      });
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckNetwork>()),
+      );
+    });
+
+    test('http.ClientException → ReleaseCheckNetwork', () async {
+      final client = MockClient((_) async {
+        throw http.ClientException('connection reset');
+      });
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckNetwork>()),
+      );
+    });
+
+    test('TimeoutException 觸發 → ReleaseCheckTimeout', () {
+      fakeAsync((async) {
+        final client = MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 15));
+          return http.Response(
+            jsonEncode(_release(
+              tag: 'v1.1.0',
+              published: '2026-05-27T00:00:00Z',
+            )),
+            200,
+          );
+        });
+
+        Object? caught;
+        fetchReleaseByVersion(version: '1.1.0', client: client).then(
+          (_) {},
+          onError: (Object e) {
+            caught = e;
+          },
+        );
+
+        async.elapse(const Duration(seconds: 11));
+
+        expect(caught, isA<ReleaseCheckTimeout>());
+      });
+    });
+
+    test('version 無法 parse → ReleaseCheckFormat', () async {
+      final client = MockClient((_) async => http.Response('', 200));
+      expect(
+        () => fetchReleaseByVersion(version: 'not-a-version', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+  });
+```
+
+### Step 1.6: 跑全部 fetchReleaseByVersion 測試確認 pass
+
+- [ ] 執行：
+
+```
+flutter test test/services/app_release_checker_test.dart
+```
+
+Expected: All tests passed!（含既有 + 新加的）
+
+### Step 1.7: 提交前品質檢查
+
+- [ ] 依 CLAUDE.md 規矩：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: `dart format` 無 issue、`flutter analyze` 顯示 `No issues found!`、`flutter test` 顯示 `All tests passed!`。
+
+### Step 1.8: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/services/app_release_checker.dart test/services/app_release_checker_test.dart
+git commit -m "$(cat <<'EOF'
+feat(release-checker): add fetchReleaseByVersion + ReleaseCheckNotFound
+
+Add a new endpoint method to fetch a single GitHub release by version,
+plus a sealed subclass for 404 responses. Strips SemVer build metadata
+before composing the v-prefixed tag (e.g. "1.1.0+2" -> "v1.1.0"). Does
+NOT filter draft/prerelease — caller explicitly asked for that tag.
+
+Used by the upcoming "view current version release notes" entry in the
+Settings > About section.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: 新增 `currentReleaseProvider` (FutureProvider.family) + 測試
+
+**Files:**
+- Create: `lib/state/current_release.dart`
+- Create: `test/state/current_release_test.dart`
+
+### Step 2.1: 寫 provider 測試
+
+- [ ] 建立新檔 `test/state/current_release_test.dart`：
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
+    show httpClientProvider;
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+
+Map<String, dynamic> _releaseJson(String tag, String published) => {
+  'tag_name': tag,
+  'name': tag,
+  'body': '## body for $tag',
+  'prerelease': false,
+  'draft': false,
+  'html_url': 'https://github.com/o/r/releases/tag/$tag',
+  'published_at': published,
+};
+
+ProviderContainer _container(http.Client client) {
+  final container = ProviderContainer(
+    overrides: [httpClientProvider.overrideWithValue(client)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('首次 watch → 打一次 API，state 變 AsyncData', () async {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      ),
+    );
+    final container = _container(client);
+
+    final release = await container.read(
+      currentReleaseProvider('1.1.0').future,
+    );
+
+    expect(release.tagName, 'v1.1.0');
+    final state = container.read(currentReleaseProvider('1.1.0'));
+    expect(state.hasValue, isTrue);
+    expect(state.value?.tagName, 'v1.1.0');
+  });
+
+  test('重複 read 同一 version → 不重打 API（FutureProvider.family cache）', () async {
+    var callCount = 0;
+    final client = MockClient((_) async {
+      callCount++;
+      return http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.1.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+
+    expect(callCount, 1);
+  });
+
+  test('不同 version key → 各自打一次 API', () async {
+    final calledFor = <String>[];
+    final client = MockClient((req) async {
+      calledFor.add(req.url.path);
+      final tag = req.url.path.split('/').last;
+      return http.Response(
+        jsonEncode(_releaseJson(tag, '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.0.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+
+    expect(calledFor.where((p) => p.endsWith('v1.0.0')).length, 1);
+    expect(calledFor.where((p) => p.endsWith('v1.1.0')).length, 1);
+  });
+
+  test('ref.invalidate → 重新 fetch', () async {
+    var callCount = 0;
+    final client = MockClient((_) async {
+      callCount++;
+      return http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.1.0').future);
+    expect(callCount, 1);
+
+    container.invalidate(currentReleaseProvider('1.1.0'));
+    await container.read(currentReleaseProvider('1.1.0').future);
+    expect(callCount, 2);
+  });
+
+  test('service 拋 ReleaseCheckNotFound → state 變 AsyncError', () async {
+    final client = MockClient(
+      (_) async => http.Response('Not Found', 404),
+    );
+    final container = _container(client);
+
+    try {
+      await container.read(currentReleaseProvider('1.1.0').future);
+      fail('expected throw');
+    } on ReleaseCheckNotFound catch (e) {
+      expect(e.tag, 'v1.1.0');
+    }
+    final state = container.read(currentReleaseProvider('1.1.0'));
+    expect(state.hasError, isTrue);
+    expect(state.error, isA<ReleaseCheckNotFound>());
+  });
+
+  test('service 拋 ReleaseCheckServer → state 變 AsyncError', () async {
+    final client = MockClient(
+      (_) async => http.Response('boom', 503),
+    );
+    final container = _container(client);
+
+    try {
+      await container.read(currentReleaseProvider('1.1.0').future);
+      fail('expected throw');
+    } on ReleaseCheckServer catch (e) {
+      expect(e.status, 503);
+    }
+    expect(
+      container.read(currentReleaseProvider('1.1.0')).error,
+      isA<ReleaseCheckServer>(),
+    );
+  });
+}
+```
+
+### Step 2.2: 跑測試確認 fail
+
+- [ ] 執行：
+
+```
+flutter test test/state/current_release_test.dart
+```
+
+Expected: FAIL 並提示 `current_release.dart` 找不到。
+
+### Step 2.3: 建檔實作 provider
+
+- [ ] 建立新檔 `lib/state/current_release.dart`：
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
+    show httpClientProvider;
+
+/// 依 version key 抓對應的 GitHub Release，自帶 in-memory cache。
+///
+/// 同一 `version` 重複 watch 不會重打 API；要強制重新 fetch，呼叫
+/// `ref.invalidate(currentReleaseProvider(version))`。
+///
+/// 失敗時 future 會拋 [ReleaseCheckError] 的具體子類，UI 端用
+/// `AsyncValue.when(error: ...)` 處理。
+final currentReleaseProvider = FutureProvider.family<AppRelease, String>(
+  (ref, version) async {
+    Logger('release.notes').info('fetch start version=$version');
+    final client = ref.read(httpClientProvider);
+    try {
+      final release = await fetchReleaseByVersion(
+        version: version,
+        client: client,
+      );
+      Logger('release.notes').info('fetch success tag=${release.tagName}');
+      return release;
+    } on ReleaseCheckError catch (e) {
+      Logger('release.notes').warning('fetch failed version=$version: $e');
+      rethrow;
+    }
+  },
+);
+```
+
+### Step 2.4: 跑測試確認 pass
+
+- [ ] 執行：
+
+```
+flutter test test/state/current_release_test.dart
+```
+
+Expected: All tests passed!
+
+### Step 2.5: 提交前品質檢查
+
+- [ ] 執行：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。
+
+### Step 2.6: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/state/current_release.dart test/state/current_release_test.dart
+git commit -m "$(cat <<'EOF'
+feat(state): add currentReleaseProvider FutureProvider.family
+
+A version-keyed FutureProvider that fetches the GitHub release for the
+given version. FutureProvider.family provides in-memory caching for free
+(same version key is not refetched within app lifetime); UI calls
+ref.invalidate(currentReleaseProvider(version)) to force a refresh.
+
+Errors propagate as the native ReleaseCheckError sealed subclasses so
+UI layer can render specific messages per error type.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: 抽出 `ReleaseNotesContent` widget + 重構 `NewVersionDialog`
+
+**Files:**
+- Create: `lib/widgets/dialogs/release_notes_content.dart`
+- Modify: `lib/widgets/dialogs/new_version_dialog.dart`
+
+### Step 3.1: 建立共用 content widget
+
+- [ ] 建立新檔 `lib/widgets/dialogs/release_notes_content.dart`：
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/relative_time_text.dart';
+
+/// 單一 release 的內容卡片：版本標題 + 發布時間 + Markdown body。
+/// 由 `NewVersionDialog` 與 `CurrentReleaseDialog` 共用。
+class ReleaseNotesContent extends StatelessWidget {
+  /// 建立 [ReleaseNotesContent]。
+  const ReleaseNotesContent({super.key, required this.release});
+
+  /// 要呈現的 release 資料。
+  final AppRelease release;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.m),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  release.tagName,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    color: theme.colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.s),
+                RelativeTimeText(
+                  time: release.publishedAt,
+                  templateBuilder: l.updateReleasedAt,
+                  useDateOnly: true,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: tokens.textMuted,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Divider(height: 1, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            if (release.body.isNotEmpty)
+              MarkdownBlock(
+                data: release.body,
+                config: releaseNotesMarkdownConfig(theme),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 依 [theme] 亮暗模式建立 markdown 渲染設定，統一連結樣式。
+MarkdownConfig releaseNotesMarkdownConfig(ThemeData theme) {
+  final base = theme.brightness == Brightness.dark
+      ? MarkdownConfig.darkConfig
+      : MarkdownConfig.defaultConfig;
+  return base.copy(
+    configs: [LinkConfig(style: TextStyle(color: linkBaseColor(theme)))],
+  );
+}
+```
+
+### Step 3.2: 重構 `NewVersionDialog` 改用 `ReleaseNotesContent`
+
+- [ ] 修改 `lib/widgets/dialogs/new_version_dialog.dart`，整檔覆寫為：
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+/// 新版本通知 dialog，列出自上次版本以來的所有 release notes。
+class NewVersionDialog extends ConsumerWidget {
+  /// 建立 [NewVersionDialog]，需傳入要顯示的 release 列表。
+  const NewVersionDialog({super.key, required this.releases});
+
+  /// 需要顯示的 release 列表（最新版在前）。
+  final List<AppRelease> releases;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final latest = releases.first;
+
+    return AppDialog(
+      size: AppDialogSize.lg,
+      scrollable: true,
+      title: Row(
+        children: [
+          Icon(Icons.system_update, color: tokens.stateSuccess),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(child: Text(l.updateTitle(latest.tagName))),
+        ],
+      ),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (int i = 0; i < releases.length; i++) ...[
+            ReleaseNotesContent(release: releases[i]),
+            if (i < releases.length - 1) const SizedBox(height: AppSpacing.m),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () async {
+            await ref
+                .read(appReleaseProvider.notifier)
+                .skipVersion(latest.tagName);
+            if (context.mounted) Navigator.of(context).pop();
+          },
+          child: Text(l.updateButtonSkip),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.updateButtonLater),
+        ),
+        FilledButton.icon(
+          icon: const Icon(Icons.download),
+          label: Text(l.updateButtonDownload),
+          onPressed: () async {
+            await openExternalUrl(Uri.parse(latest.htmlUrl));
+            if (context.mounted) Navigator.of(context).pop();
+          },
+        ),
+      ],
+    );
+  }
+}
+```
+
+註：移除了既有的 `_ReleaseCard` private 類別與 `_markdownConfig` private 函式，視覺與行為完全等價，但程式碼移到 `release_notes_content.dart`。
+
+### Step 3.3: 提交前品質檢查
+
+- [ ] 執行：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。本 task 沒新增測試（重構，依靠 analyze 守住型別、靠人工驗證視覺），但既有測試應不受影響。
+
+### Step 3.4: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/widgets/dialogs/release_notes_content.dart lib/widgets/dialogs/new_version_dialog.dart
+git commit -m "$(cat <<'EOF'
+refactor(dialogs): extract ReleaseNotesContent shared widget
+
+Pull the single-release rendering ("_ReleaseCard" + "_markdownConfig")
+out of new_version_dialog.dart into a standalone widget that the
+upcoming CurrentReleaseDialog can reuse. NewVersionDialog now composes
+it; visual and behavioural output is unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: 新增 i18n keys 到 `app_zh.arb` (template) 並 gen-l10n
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`
+
+### Step 4.1: 加 5 個 keys 到 template
+
+- [ ] 編輯 `lib/l10n/app_zh.arb`，在 `updateErrorFormat` 後（第 536 行附近）插入：
+
+```json
+  "currentReleaseTitle": "目前版本更新內容",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "找不到 {version} 對應的更新內容",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "在 GitHub 上開啟",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "開啟 GitHub Releases 頁面",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "查看更新內容",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
+```
+
+確認 JSON 語法仍有效（前面條目的 `,` 結尾、自己的條目之間也用 `,`、最後一個條目接續到原本檔案的下一條，最後不要殘留 `,,`）。
+
+### Step 4.2: 跑 gen-l10n
+
+- [ ] 執行：
+
+```
+flutter gen-l10n
+```
+
+Expected: 重新產生 `lib/l10n/generated/app_localizations*.dart`。無錯誤輸出。
+
+### Step 4.3: 提交前品質檢查
+
+- [ ] 執行：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。Generated 檔會被 format 改動，這正常。
+
+### Step 4.4: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/l10n/app_zh.arb lib/l10n/generated/
+git commit -m "$(cat <<'EOF'
+feat(i18n): add zh-Hant strings for current-version release notes dialog
+
+Add 5 new keys (currentReleaseTitle, currentReleaseNotFound,
+currentReleaseOpenOnGithub, currentReleaseOpenReleasesPage,
+aboutViewReleaseNotes) to the template ARB and regenerate. Reuses
+existing update*/actionClose/actionRetry strings for everything else.
+
+Translations for other non-empty locales follow in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 翻譯 i18n keys 到其他 8 個非空殼 ARB
+
+**Files (each modified):**
+- `lib/l10n/app_zh_Hans.arb`
+- `lib/l10n/app_en.arb`
+- `lib/l10n/app_es.arb`
+- `lib/l10n/app_fr.arb`
+- `lib/l10n/app_ja.arb`
+- `lib/l10n/app_pt_BR.arb`
+- `lib/l10n/app_th.arb`
+- `lib/l10n/app_vi.arb`
+
+22 個空殼 ARB（`af, ar, ca, cs, da, de, el, fi, he, hu, it, ko, nl, no, pl, pt, ro, ru, sr, sv, tr, uk`）**不動**，依專案規矩留給 Crowdin pipeline 同步。
+
+每個 ARB 的插入位置都是「`updateErrorFormat` 條目之後」（找該 key 確定位置；不同檔案附近可能有其他 `update*` 變體例如 `updateErrorWipeHoyoWikiCache`，插在 `updateErrorFormat` 後但 `updateErrorWipeHoyoWikiCache` 前即可，或統一插在所有 `update*` 結束後）。`@metadata` 區塊與 zh 範本相同（description 用英文、placeholder 結構相同），下面表格只列 value 字串。
+
+### Step 5.1: 加翻譯到 `app_zh_Hans.arb` (簡中)
+
+- [ ] 在 `lib/l10n/app_zh_Hans.arb` 內加：
+
+```json
+  "currentReleaseTitle": "当前版本更新内容",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "找不到 {version} 对应的更新内容",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "在 GitHub 上打开",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "打开 GitHub Releases 页面",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "查看更新内容",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.2: 加翻譯到 `app_en.arb` (英文)
+
+- [ ] 在 `lib/l10n/app_en.arb` 內加（注意 metadata 完整與 zh template 對齊）：
+
+```json
+  "currentReleaseTitle": "Current release notes",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "Release notes not found for {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Open on GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "Open GitHub Releases page",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "View release notes",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.3: 加翻譯到 `app_es.arb` (西班牙文)
+
+- [ ] 在 `lib/l10n/app_es.arb` 內加：
+
+```json
+  "currentReleaseTitle": "Notas de la versión actual",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "Notas de la versión no encontradas para {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Abrir en GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "Abrir página de GitHub Releases",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "Ver notas de la versión",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.4: 加翻譯到 `app_fr.arb` (法文)
+
+- [ ] 在 `lib/l10n/app_fr.arb` 內加：
+
+```json
+  "currentReleaseTitle": "Notes de version actuelles",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "Notes de version introuvables pour {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Ouvrir sur GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "Ouvrir la page des versions GitHub",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "Voir les notes de version",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.5: 加翻譯到 `app_ja.arb` (日文)
+
+- [ ] 在 `lib/l10n/app_ja.arb` 內加：
+
+```json
+  "currentReleaseTitle": "現在のバージョンの更新内容",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "{version} に対応するリリースノートが見つかりません",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "GitHub で開く",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "GitHub Releases ページを開く",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "更新内容を表示",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.6: 加翻譯到 `app_pt_BR.arb` (巴西葡文)
+
+- [ ] 在 `lib/l10n/app_pt_BR.arb` 內加：
+
+```json
+  "currentReleaseTitle": "Notas da versão atual",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "Notas da versão não encontradas para {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Abrir no GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "Abrir página de Releases do GitHub",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "Ver notas da versão",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.7: 加翻譯到 `app_th.arb` (泰文)
+
+- [ ] 在 `lib/l10n/app_th.arb` 內加：
+
+```json
+  "currentReleaseTitle": "บันทึกการอัปเดตเวอร์ชันปัจจุบัน",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "ไม่พบบันทึกการอัปเดตสำหรับ {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "เปิดใน GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "เปิดหน้า GitHub Releases",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "ดูบันทึกการอัปเดต",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.8: 加翻譯到 `app_vi.arb` (越南文)
+
+- [ ] 在 `lib/l10n/app_vi.arb` 內加：
+
+```json
+  "currentReleaseTitle": "Ghi chú phát hành phiên bản hiện tại",
+  "@currentReleaseTitle": { "description": "Title of the dialog showing release notes for the currently installed version." },
+  "currentReleaseNotFound": "Không tìm thấy ghi chú phát hành cho {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Mở trên GitHub",
+  "@currentReleaseOpenOnGithub": { "description": "Action button: open this release page on github.com in the external browser." },
+  "currentReleaseOpenReleasesPage": "Mở trang GitHub Releases",
+  "@currentReleaseOpenReleasesPage": { "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing." },
+  "aboutViewReleaseNotes": "Xem ghi chú phát hành",
+  "@aboutViewReleaseNotes": { "description": "Settings > About: button next to the version label that opens the current-release dialog." },
+```
+
+### Step 5.9: 跑 gen-l10n + 提交前品質檢查
+
+- [ ] 執行：
+
+```
+flutter gen-l10n
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。Generated 檔會更新。
+
+### Step 5.10: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/l10n/app_zh_Hans.arb lib/l10n/app_en.arb lib/l10n/app_es.arb lib/l10n/app_fr.arb lib/l10n/app_ja.arb lib/l10n/app_pt_BR.arb lib/l10n/app_th.arb lib/l10n/app_vi.arb lib/l10n/generated/
+git commit -m "$(cat <<'EOF'
+feat(i18n): translate current-release dialog strings to 8 locales
+
+Add zh_Hans/en/es/fr/ja/pt_BR/th/vi translations for the 5 new keys.
+Empty-shell ARBs (af/ar/ca/cs/da/de/el/fi/he/hu/it/ko/nl/no/pl/pt/ro/
+ru/sr/sv/tr/uk) are left untouched per project convention — they are
+synced from Crowdin downstream.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: 實作 `CurrentReleaseDialog` + widget 測試
+
+**Files:**
+- Create: `lib/widgets/dialogs/current_release_dialog.dart`
+- Create: `test/widgets/dialogs/current_release_dialog_test.dart`
+
+### Step 6.1: 寫 widget 測試
+
+- [ ] 建立新檔 `test/widgets/dialogs/current_release_dialog_test.dart`：
+
+```dart
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/current_release_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+AppRelease _release({
+  String tag = 'v1.1.0',
+  String body = '## Hi',
+}) => AppRelease(
+  tagName: tag,
+  version: tag.startsWith('v') ? tag.substring(1) : tag,
+  name: tag,
+  body: body,
+  htmlUrl: 'https://github.com/o/r/releases/tag/$tag',
+  publishedAt: DateTime.utc(2026, 5, 27),
+);
+
+/// Pump a Riverpod-scoped app that opens [CurrentReleaseDialog] with the
+/// given provider override and waits for the dialog to settle.
+Future<void> _pumpDialog(
+  WidgetTester tester, {
+  required Override currentReleaseOverride,
+  String version = '1.1.0',
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [currentReleaseOverride],
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () => showDialog<void>(
+                  context: ctx,
+                  builder: (_) => CurrentReleaseDialog(version: version),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pump(); // open dialog frame
+}
+
+void main() {
+  testWidgets('data state → renders ReleaseNotesContent + [Open on GitHub] [Close]',
+      (tester) async {
+    final release = _release();
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) async => release),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ReleaseNotesContent), findsOneWidget);
+    expect(find.text('Open on GitHub'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('loading state → no ReleaseNotesContent yet, only [Close]',
+      (tester) async {
+    final completer = Completer<AppRelease>();
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) => completer.future),
+    );
+    // 不 pumpAndSettle，保持 loading 狀態
+
+    expect(find.byType(ReleaseNotesContent), findsNothing);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('Open on GitHub'), findsNothing);
+
+    completer.complete(_release());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('ReleaseCheckNotFound → renders not-found message + [Open Releases page] [Close]',
+      (tester) async {
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) => Future.error(const ReleaseCheckNotFound('v1.1.0'))),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Release notes not found for 1.1.0'), findsOneWidget);
+    expect(find.text('Open GitHub Releases page'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('ReleaseCheckRateLimited → [Open Releases page] [Close]',
+      (tester) async {
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) => Future.error(const ReleaseCheckRateLimited())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('quota'), findsOneWidget); // updateErrorRateLimited
+    expect(find.text('Open GitHub Releases page'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('ReleaseCheckNetwork → [Retry] [Close]', (tester) async {
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) => Future.error(const ReleaseCheckNetwork())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('Open GitHub Releases page'), findsNothing);
+  });
+
+  testWidgets('ReleaseCheckServer(503) → [Retry] [Close] with status code visible',
+      (tester) async {
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) => Future.error(const ReleaseCheckServer(503))),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('503'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('Retry → ref.invalidate triggers refetch', (tester) async {
+    var fetches = 0;
+    Override buildOverride() => currentReleaseProvider('1.1.0').overrideWith(
+          (ref) {
+            fetches++;
+            if (fetches == 1) {
+              return Future.error(const ReleaseCheckNetwork());
+            }
+            return Future.value(_release());
+          },
+        );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [buildOverride()],
+        child: MaterialApp(
+          theme: buildDarkTheme(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) => Center(
+                child: ElevatedButton(
+                  onPressed: () => showDialog<void>(
+                    context: ctx,
+                    builder: (_) => const CurrentReleaseDialog(version: '1.1.0'),
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Retry'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(fetches, greaterThanOrEqualTo(2));
+    expect(find.byType(ReleaseNotesContent), findsOneWidget);
+  });
+
+  testWidgets('Close → dialog dismissed', (tester) async {
+    await _pumpDialog(
+      tester,
+      currentReleaseOverride: currentReleaseProvider('1.1.0')
+          .overrideWith((ref) async => _release()),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(CurrentReleaseDialog), findsOneWidget);
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CurrentReleaseDialog), findsNothing);
+  });
+}
+```
+
+### Step 6.2: 跑測試確認 fail
+
+- [ ] 執行：
+
+```
+flutter test test/widgets/dialogs/current_release_dialog_test.dart
+```
+
+Expected: FAIL，`current_release_dialog.dart` 找不到。
+
+### Step 6.3: 實作 `CurrentReleaseDialog`
+
+- [ ] 建立新檔 `lib/widgets/dialogs/current_release_dialog.dart`：
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/data/app_repo.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+/// 顯示「目前版本」對應 GitHub Release 內容的 dialog。
+class CurrentReleaseDialog extends ConsumerWidget {
+  /// 建立 [CurrentReleaseDialog]，[version] 為要查詢的版本字串
+  /// （pubspec / `PackageInfo` 版本，可帶 build metadata，例如 `1.1.0+2`）。
+  const CurrentReleaseDialog({super.key, required this.version});
+
+  /// 要查詢的版本字串。
+  final String version;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final async = ref.watch(currentReleaseProvider(version));
+
+    return AppDialog(
+      size: AppDialogSize.lg,
+      scrollable: true,
+      title: Row(
+        children: [
+          Icon(
+            Icons.description_outlined,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(child: Text(l.currentReleaseTitle)),
+        ],
+      ),
+      content: async.when(
+        loading: () => _LoadingSkeleton(theme: theme),
+        data: (release) => ReleaseNotesContent(release: release),
+        error: (e, _) => _ErrorBlock(
+          error: e,
+          version: version,
+          l: l,
+          theme: theme,
+        ),
+      ),
+      actions: _actionsFor(context, ref, l, async),
+    );
+  }
+
+  List<Widget> _actionsFor(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+    AsyncValue<AppRelease> async,
+  ) {
+    final closeButton = TextButton(
+      onPressed: () => Navigator.of(context).pop(),
+      child: Text(l.actionClose),
+    );
+
+    return async.when(
+      loading: () => [closeButton],
+      data: (release) => [
+        closeButton,
+        FilledButton.icon(
+          icon: const Icon(Icons.open_in_new),
+          label: Text(l.currentReleaseOpenOnGithub),
+          onPressed: () async {
+            await openExternalUrl(Uri.parse(release.htmlUrl));
+            if (context.mounted) Navigator.of(context).pop();
+          },
+        ),
+      ],
+      error: (e, _) {
+        // not-found / rate-limited：重試無意義，改提供「開 Releases 頁面」
+        final terminalError =
+            e is ReleaseCheckNotFound || e is ReleaseCheckRateLimited;
+        if (terminalError) {
+          return [
+            closeButton,
+            FilledButton.icon(
+              icon: const Icon(Icons.open_in_new),
+              label: Text(l.currentReleaseOpenReleasesPage),
+              onPressed: () async {
+                await openExternalUrl(
+                  Uri.parse('${AppRepo.githubUrl}/releases'),
+                );
+                if (context.mounted) Navigator.of(context).pop();
+              },
+            ),
+          ];
+        }
+        return [
+          closeButton,
+          FilledButton.icon(
+            icon: const Icon(Icons.refresh),
+            label: Text(l.actionRetry),
+            onPressed: () => ref.invalidate(currentReleaseProvider(version)),
+          ),
+        ];
+      },
+    );
+  }
+}
+
+/// 三態 loading 狀態下的灰色占位卡片。不引入 shimmer 套件，視覺極簡。
+class _LoadingSkeleton extends StatelessWidget {
+  const _LoadingSkeleton({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = theme.gacha;
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.m),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _bar(width: 120, height: 24, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            _bar(width: double.infinity, height: 1, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            _bar(width: double.infinity, height: 14, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.xs),
+            _bar(width: double.infinity, height: 14, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.xs),
+            _bar(width: 240, height: 14, color: tokens.borderSubtle),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _bar({required double width, required double height, required Color color}) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(4),
+      ),
+    );
+  }
+}
+
+/// 三態 error 狀態下的訊息區塊。把 [error] 對應到 i18n 字串。
+class _ErrorBlock extends StatelessWidget {
+  const _ErrorBlock({
+    required this.error,
+    required this.version,
+    required this.l,
+    required this.theme,
+  });
+
+  final Object error;
+  final String version;
+  final AppLocalizations l;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = _messageFor(error);
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.m),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.error_outline, color: theme.colorScheme.error),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 把 [ReleaseCheckError] 子類對應到既有 `update*` i18n 字串，
+  /// 維持與「檢查更新」流程的訊息一致性。
+  String _messageFor(Object e) {
+    if (e is ReleaseCheckNotFound) return l.currentReleaseNotFound(version);
+    if (e is ReleaseCheckNetwork) return l.updateErrorNetwork;
+    if (e is ReleaseCheckTimeout) return l.updateErrorTimeout;
+    if (e is ReleaseCheckRateLimited) return l.updateErrorRateLimited;
+    if (e is ReleaseCheckServer) return l.updateErrorServer(e.status.toString());
+    if (e is ReleaseCheckFormat) return l.updateErrorFormat;
+    return e.toString();
+  }
+}
+```
+
+### Step 6.4: 跑測試確認 pass
+
+- [ ] 執行：
+
+```
+flutter test test/widgets/dialogs/current_release_dialog_test.dart
+```
+
+Expected: All tests passed!（8 個 widget test 全綠）。
+
+若 retry 那個測試的 fetches 計數不到 2，可能是 `ref.invalidate` 觸發後 provider 未自動 read。改寫 retry 按鈕為：
+
+```dart
+onPressed: () {
+  ref.invalidate(currentReleaseProvider(version));
+  ref.read(currentReleaseProvider(version)); // 主動觸發重 fetch
+},
+```
+
+並重跑測試。
+
+### Step 6.5: 提交前品質檢查
+
+- [ ] 執行：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。
+
+### Step 6.6: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/widgets/dialogs/current_release_dialog.dart test/widgets/dialogs/current_release_dialog_test.dart
+git commit -m "$(cat <<'EOF'
+feat(dialogs): add CurrentReleaseDialog with three-state UI
+
+A new dialog that loads the GitHub release for a given version via
+currentReleaseProvider and renders one of:
+- loading: a minimal grey skeleton card
+- data: ReleaseNotesContent (shared with NewVersionDialog)
+- error: an inline error block, reusing existing update* i18n strings
+
+Actions adapt to state: data shows [Open on GitHub], not-found and
+rate-limited show [Open GitHub Releases page] (retry is pointless),
+other errors show [Retry] which invalidates the provider.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: 設定頁加按鈕
+
+**Files:**
+- Modify: `lib/pages/settings_page.dart`
+
+### Step 7.1: 在 `_AboutContent` Row 加按鈕
+
+- [ ] 編輯 `lib/pages/settings_page.dart`，定位到 `_AboutContent.build` 內第一個 `Row`（約第 273-293 行）。原本：
+
+```dart
+        Row(
+          children: [
+            Expanded(child: Text(l.settingsAboutVersion(version))),
+            const SizedBox(width: AppSpacing.s),
+            OutlinedButton.icon(
+              onPressed: checking
+                  ? null
+                  : () => ref
+                        .read(appReleaseProvider.notifier)
+                        .check(manual: true),
+              icon: checking
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh, size: 18),
+              label: Text(checking ? l.updateChecking : l.updateCheckButton),
+            ),
+          ],
+        ),
+```
+
+改為（在「檢查更新」按鈕**右側**新增「查看更新內容」按鈕）：
+
+```dart
+        Row(
+          children: [
+            Expanded(child: Text(l.settingsAboutVersion(version))),
+            const SizedBox(width: AppSpacing.s),
+            OutlinedButton.icon(
+              onPressed: checking
+                  ? null
+                  : () => ref
+                        .read(appReleaseProvider.notifier)
+                        .check(manual: true),
+              icon: checking
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh, size: 18),
+              label: Text(checking ? l.updateChecking : l.updateCheckButton),
+            ),
+            const SizedBox(width: AppSpacing.s),
+            OutlinedButton.icon(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => CurrentReleaseDialog(version: version),
+              ),
+              icon: const Icon(Icons.description_outlined, size: 18),
+              label: Text(l.aboutViewReleaseNotes),
+            ),
+          ],
+        ),
+```
+
+- [ ] 在 `lib/pages/settings_page.dart` 頂端 imports 加入：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/current_release_dialog.dart';
+```
+
+放在 dialogs/ 既有 import 附近，保持 alphabetical。
+
+### Step 7.2: 提交前品質檢查
+
+- [ ] 執行：
+
+```
+dart format lib/ test/
+flutter analyze
+flutter test
+```
+
+Expected: 全綠。
+
+### Step 7.3: 人工視覺驗證
+
+- [ ] 執行：
+
+```
+flutter run -d windows
+```
+
+開啟設定頁，捲到「關於」section，確認：
+
+1. 版本號右側有兩個按鈕：[檢查更新] [查看更新內容]
+2. 兩按鈕視覺一致（OutlinedButton.icon、間距相同）
+3. 視窗變窄時 Row 不溢出（按鈕會被 `Expanded` 推到右、必要時 wrap）
+4. 點「查看更新內容」→ dialog 開啟、內容載入後顯示當前版本 `v1.1.0` (或 pubspec 對應版本) release notes
+
+Ctrl+C 結束。
+
+### Step 7.4: Commit
+
+- [ ] 執行：
+
+```bash
+git add lib/pages/settings_page.dart
+git commit -m "$(cat <<'EOF'
+feat(settings): add "view release notes" button in About section
+
+Place a new OutlinedButton.icon next to the existing "Check for
+updates" button, so users can open CurrentReleaseDialog and review
+what changed in the version they're running.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: 最終驗證（人工 smoke test）
+
+**Files:** 無修改
+
+### Step 8.1: 跑全套測試
+
+- [ ] 執行：
+
+```
+flutter test
+```
+
+Expected: `All tests passed!`，無新 flaky。
+
+### Step 8.2: 跑全套 analyze
+
+- [ ] 執行：
+
+```
+flutter analyze
+```
+
+Expected: `No issues found!`。
+
+### Step 8.3: 人工 smoke test
+
+- [ ] 啟動 app：
+
+```
+flutter run -d windows
+```
+
+依序驗證 9 個情境（取自 spec § 測試策略「人工驗證」）：
+
+1. **入口可見性**：設定頁「關於」section 版本號右側出現「查看更新內容」按鈕。
+2. **基本開啟**：點按鈕 → dialog 立即開啟，短暫顯示 skeleton（灰色占位）→ 切換成 content。
+3. **內容渲染**：標題顯示「目前版本更新內容」、卡片內顯示 `v{version}` 標題、發布日期、Markdown body 正確渲染（連結、列表、粗體都對）。
+4. **Open on GitHub**：按「在 GitHub 上開啟」→ 外部瀏覽器跳到 `https://github.com/.../releases/tag/v{version}`、dialog 關閉。
+5. **網路錯誤**：把 hosts 暫時擋 `api.github.com`（或關 wifi）→ 重開 app → 點按鈕 → dialog 顯示「無法連線，請檢查網路」+ [重試] [關閉] 按鈕。
+6. **重試成功**：解除網路擋阻 → 按 [重試] → 重新 fetch、成功顯示內容。
+7. **找不到 release**：暫時把 `pubspec.yaml` `version:` 改成不存在的版本（例如 `9.9.9+1`）→ 重 build → 點按鈕 → dialog 顯示「找不到 9.9.9 對應的更新內容」+ [開啟 GitHub Releases 頁面] [關閉]。完成後**還原** `pubspec.yaml`。
+8. **語系切換**：把 app 語系切到日文、英文，重新打開 dialog → 文字依語系正確顯示。
+9. **NewVersionDialog 不退步**：手動把本地 version 改成低於最新 release 的版本（例如 `0.1.0+1`），重新啟動 → 既有「新版本通知」dialog 仍應正常彈出、視覺與行為和重構前一致。完成後**還原** `pubspec.yaml`。
+
+- [ ] 如有任何上述情境失敗，記錄並回到對應 Task 修正；全部通過才視為功能完成。
+
+### Step 8.4: 確認 log 行為
+
+- [ ] 在 app 內觸發一次「查看更新內容」（成功）+ 一次（失敗，網路擋）。
+- [ ] 從「設定 → 日誌」匯出 logs。
+- [ ] 確認 `release.notes` logger 有以下 entries：
+  - `fetch start version=<version>`
+  - `fetch success tag=v<version>` 或 `fetch failed version=<version>: <error>`
+- [ ] 無 unintended sensitive data（公開 repo + 公開 version，本來就沒）。
+
+### Step 8.5: （無 commit）功能完成
+
+本 task 不產生 commit。若先前 task 流程中發現需要修正，請回到對應 task 步驟修正後再過來。
+
+---
+
+## Self-Review Notes
+
+下面是寫完 plan 後對著 spec 做的 self-review，記在這裡供 review 用：
+
+**1. Spec coverage check**
+
+| Spec 章節 / 需求 | 對應 task |
+|---|---|
+| § 詳細設計 #1 Service 層（`fetchReleaseByVersion` + `ReleaseCheckNotFound`） | Task 1 |
+| § 詳細設計 #2 State 層（`currentReleaseProvider`） | Task 2 |
+| § 詳細設計 #3 抽出 `ReleaseNotesContent` + 重構 `NewVersionDialog` | Task 3 |
+| § 詳細設計 #4 `CurrentReleaseDialog` 三態 + actions | Task 6 |
+| § 詳細設計 #5 設定頁按鈕 | Task 7 |
+| § 詳細設計 #6 i18n 新增 5 keys × 9 個非空殼 ARB | Task 4 + Task 5 |
+| § 詳細設計 #7 Logger `release.notes` | Task 2 內實作 |
+| § 測試策略 — service tests | Task 1 |
+| § 測試策略 — state tests | Task 2 |
+| § 測試策略 — widget tests | Task 6 |
+| § 測試策略 — new_version_dialog 重構後仍綠 | Task 3 Step 3.3（analyze + 既有 test） + Task 8 Step 8.3 #9 人工驗證 |
+| § 測試策略 — 人工驗證 9 情境 | Task 8 Step 8.3 |
+
+無遺漏。
+
+**2. Placeholder scan**
+
+無 TBD/TODO，所有 step 都有具體 code/command/expected。Task 5 內 8 個語系翻譯都列出完整字串。Task 6 內所有 widget test 都列出完整 code（包含 Completer 修正說明）。
+
+**3. Type consistency**
+
+- `fetchReleaseByVersion({version, client})` — 簽名一致跨 Task 1, 2
+- `ReleaseCheckNotFound(this.tag)` — `tag` 屬性一致跨 Task 1, 6
+- `currentReleaseProvider` 是 `FutureProvider.family<AppRelease, String>` — 跨 Task 2, 6
+- `releaseNotesMarkdownConfig(theme)` 命名跨 Task 3
+- `ReleaseNotesContent({required release})` 簽名跨 Task 3, 6
+- `CurrentReleaseDialog({required version})` 簽名跨 Task 6, 7
+- i18n key 命名跨 Task 4, 5, 6, 7：`currentReleaseTitle` / `currentReleaseNotFound` / `currentReleaseOpenOnGithub` / `currentReleaseOpenReleasesPage` / `aboutViewReleaseNotes`，沿用 `actionClose` / `actionRetry`，全部一致
+
+無不一致。

--- a/docs/superpowers/specs/2026-05-28-current-version-release-notes-design.md
+++ b/docs/superpowers/specs/2026-05-28-current-version-release-notes-design.md
@@ -1,0 +1,484 @@
+# 目前版本更新內容（Current Version Release Notes）設計
+
+在「設定頁 → 關於」區塊新增入口，讓使用者隨時主動查看「**目前安裝這個版本**」對應的 GitHub release notes，補上既有「新版本通知」（只在偵測到更新時跳）所沒有的回顧能力。
+
+## 背景
+
+現況（見 [2026-05-13 新版本通知設計](2026-05-13-new-version-notification-design.md)）：
+
+- `AppReleaseChecker.fetchNewerReleases()` 只回傳比目前版本「**更新**」的 releases，沒有抓「目前版本本身」的能力
+- `NewVersionDialog` 用 `markdown_widget` 渲染 release notes，但只能由「啟動自動檢查偵測到新版」或「設定頁手動檢查回報有新版」觸發
+- 使用者升級到最新版後，無法在 app 內回頭看「我這版到底做了什麼」，只能自己去 GitHub
+- 設定頁「關於」區塊已有版本號 + 「檢查更新」按鈕，是天然的延伸點
+
+新功能補上這個缺口：版本號旁加一個按鈕，點下開 dialog 顯示「目前版本」對應的 release notes。
+
+## 需求決定
+
+| 項目 | 決定 |
+|---|---|
+| 入口位置 | 設定頁「關於」section，版本號右側加 `OutlinedButton.icon`「查看更新內容」，與既有「檢查更新」按鈕並列 |
+| Dialog 樣式 | 沿用 `AppDialog` `size: lg, scrollable: true`，與 `NewVersionDialog` 視覺一致 |
+| 顯示範圍 | 只顯示「目前版本」對應的單一 release（YAGNI；不做歷史 N 版） |
+| 元件重用 | 抽出 `ReleaseNotesContent` 共用 widget，`NewVersionDialog` 與新建的 `CurrentReleaseDialog` 都用它；不另造輪子 |
+| API endpoint | `GET /repos/{owner}/{repo}/releases/tags/{tag}`（單筆抓，比 list filter 省 quota） |
+| 「找不到」處理 | dialog 內顯示「找不到 {version} 對應的 release」訊息 + [在 GitHub Releases 開啟] [關閉] |
+| 錯誤處理 | 沿用 `ReleaseCheckError` 家族；新增 `ReleaseCheckNotFound` 子類對應 404；UI 顯示既有 `update*` 錯誤字串 |
+| 快取 | in-memory（Riverpod `FutureProvider.family` 自帶），同 app 生命週期內不重打；按「重試」呼叫 `ref.invalidate` 清快取重 fetch |
+| Loading 行為 | dialog 立即開啟，內部三態：loading skeleton / error / content |
+| i18n 範圍 | 新增字串加在 **所有非空殼 ARB**（9 個：`zh, zh_Hans, en, es, fr, ja, pt_BR, th, vi`），空殼 22 個不動 |
+| Logger 命名 | `release.notes` |
+
+## 架構總覽
+
+```
+[新增]
+lib/state/current_release.dart                          新 Riverpod FutureProvider.family
+lib/widgets/dialogs/release_notes_content.dart          抽出的共用 content widget + _markdownConfig
+lib/widgets/dialogs/current_release_dialog.dart         新 dialog 殼，三態 + actions
+
+[修改]
+lib/services/app_release_checker.dart                   + fetchReleaseByVersion()
+                                                        + ReleaseCheckNotFound 子類
+lib/widgets/dialogs/new_version_dialog.dart             _ReleaseCard / _markdownConfig 抽出到 release_notes_content
+lib/pages/settings_page.dart                            _AboutContent 加按鈕
+lib/l10n/app_{zh,zh_Hans,en,es,fr,ja,pt_BR,th,vi}.arb   新增 i18n keys
+```
+
+職責切分：
+
+- `CurrentReleaseDialog` 只負責「殼」（標題、actions、三態切換）
+- `ReleaseNotesContent` 只負責「單筆 release 視覺呈現」（共用）
+- `currentReleaseProvider` 只負責「以 version key 抓單筆 release + cache」
+- `fetchReleaseByVersion` 只負責「API 呼叫 + parsing + 錯誤分類」（純函式）
+
+## 詳細設計
+
+### 1. Service 層擴充
+
+`lib/services/app_release_checker.dart`：
+
+```dart
+/// 找不到指定 tag 對應的 release（HTTP 404）。
+class ReleaseCheckNotFound extends ReleaseCheckError {
+  /// 建立 [ReleaseCheckNotFound]，[tag] 為查詢的 tag（含 v 前綴）。
+  const ReleaseCheckNotFound(this.tag);
+
+  /// 查詢的 tag，例如 `v1.1.0`。
+  final String tag;
+}
+
+/// 抓指定 [version] 對應的 GitHub Release。
+///
+/// [version] 可帶 SemVer build metadata（例如 `1.1.0+2`），內部會剝掉
+/// build metadata 並補上 `v` 前綴，組成 tag `v1.1.0` 後查詢。
+///
+/// 失敗時拋 [ReleaseCheckError] 的具體子類；找不到 release 時拋
+/// [ReleaseCheckNotFound]。
+Future<AppRelease> fetchReleaseByVersion({
+  required String version,
+  required http.Client client,
+}) async {
+  final Version parsed;
+  try {
+    parsed = Version.parse(version);
+  } catch (_) {
+    throw const ReleaseCheckFormat();
+  }
+  final core = '${parsed.major}.${parsed.minor}.${parsed.patch}'; // 剝 build metadata
+  final tag = 'v$core';
+  final uri = Uri.parse('${AppRepo.apiBase}/releases/tags/$tag');
+
+  final http.Response resp;
+  try {
+    resp = await client
+        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
+        .timeout(const Duration(seconds: 10));
+  } on TimeoutException {
+    throw const ReleaseCheckTimeout();
+  } on SocketException {
+    throw const ReleaseCheckNetwork();
+  } on http.ClientException {
+    throw const ReleaseCheckNetwork();
+  }
+
+  if (resp.statusCode == 404) {
+    throw ReleaseCheckNotFound(tag);
+  }
+  if (resp.statusCode == 429 ||
+      (resp.statusCode == 403 &&
+          resp.headers['x-ratelimit-remaining'] == '0')) {
+    throw const ReleaseCheckRateLimited();
+  }
+  if (resp.statusCode != 200) {
+    throw ReleaseCheckServer(resp.statusCode);
+  }
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(resp.body);
+  } on FormatException {
+    throw const ReleaseCheckFormat();
+  }
+  if (decoded is! Map) throw const ReleaseCheckFormat();
+  final raw = decoded;
+  final tagName = raw['tag_name'];
+  if (tagName is! String) throw const ReleaseCheckFormat();
+  final parsedTag = _parseTag(tagName);
+  if (parsedTag == null) throw const ReleaseCheckFormat();
+  final published = DateTime.tryParse(raw['published_at']?.toString() ?? '');
+  if (published == null) throw const ReleaseCheckFormat();
+
+  return AppRelease(
+    tagName: tagName,
+    version: parsedTag.toString(),
+    name: (raw['name'] as String?) ?? '',
+    body: (raw['body'] as String?) ?? '',
+    htmlUrl: (raw['html_url'] as String?) ?? '',
+    publishedAt: published,
+  );
+}
+```
+
+注意：
+
+- `_parseTag` 是檔內既有 private helper，重用
+- 不過濾 `draft` / `prerelease`：使用者明確查指定 tag，若該 tag 是 pre-release 也照顯（這場景下使用者「裝了那個版本」就代表他想看那個版本的 notes）
+
+### 2. State 層
+
+`lib/state/current_release.dart`（新檔）：
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
+    show httpClientProvider;
+
+/// 依 version key 抓對應的 GitHub Release，自帶 in-memory cache。
+/// 重試呼叫 `ref.invalidate(currentReleaseProvider(version))`。
+final currentReleaseProvider = FutureProvider.family<AppRelease, String>(
+  (ref, version) async {
+    Logger('release.notes').info('fetch start version=$version');
+    final client = ref.read(httpClientProvider);
+    try {
+      final release = await fetchReleaseByVersion(
+        version: version,
+        client: client,
+      );
+      Logger('release.notes').info('fetch success tag=${release.tagName}');
+      return release;
+    } on ReleaseCheckError catch (e) {
+      Logger('release.notes').warning('fetch failed: $e');
+      rethrow;
+    }
+  },
+);
+```
+
+`httpClientProvider` 從 `state/app_release.dart` 重用，不另建。
+
+### 3. UI — 抽出共用 content widget
+
+`lib/widgets/dialogs/release_notes_content.dart`（新檔）：
+
+從 `new_version_dialog.dart` 把 `_ReleaseCard` 改寫升格為 public widget，並把 `_markdownConfig` 一併搬過來：
+
+```dart
+/// 單一 release 的內容卡片：版本標題 + 發布時間 + Markdown body。
+/// 由 `NewVersionDialog` 與 `CurrentReleaseDialog` 共用。
+class ReleaseNotesContent extends StatelessWidget {
+  /// 建立 [ReleaseNotesContent]。
+  const ReleaseNotesContent({super.key, required this.release});
+
+  /// 要呈現的 release 資料。
+  final AppRelease release;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.m),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  release.tagName,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    color: theme.colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.s),
+                RelativeTimeText(
+                  time: release.publishedAt,
+                  templateBuilder: l.updateReleasedAt,
+                  useDateOnly: true,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: tokens.textMuted,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Divider(height: 1, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            if (release.body.isNotEmpty)
+              MarkdownBlock(
+                data: release.body,
+                config: releaseNotesMarkdownConfig(theme),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 依 [theme] 亮暗模式建立 markdown 渲染設定，統一連結樣式。
+MarkdownConfig releaseNotesMarkdownConfig(ThemeData theme) {
+  final base = theme.brightness == Brightness.dark
+      ? MarkdownConfig.darkConfig
+      : MarkdownConfig.defaultConfig;
+  return base.copy(
+    configs: [LinkConfig(style: TextStyle(color: linkBaseColor(theme)))],
+  );
+}
+```
+
+`new_version_dialog.dart` 同步調整：
+
+- 刪除檔內 `_ReleaseCard` 與 `_markdownConfig`
+- 在 `for` 迴圈內改用 `ReleaseNotesContent(release: releases[i])`
+- 視覺與行為完全不變（既有測試應全綠）
+
+### 4. UI — Dialog 殼
+
+`lib/widgets/dialogs/current_release_dialog.dart`（新檔）：
+
+```dart
+/// 顯示「目前版本」對應 GitHub Release 內容的 dialog。
+class CurrentReleaseDialog extends ConsumerWidget {
+  /// 建立 [CurrentReleaseDialog]，需傳入要查的 [version]
+  /// （pubspec 版本，例如 `1.1.0+2`）。
+  const CurrentReleaseDialog({super.key, required this.version});
+
+  /// 要查詢的版本字串。
+  final String version;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final async = ref.watch(currentReleaseProvider(version));
+
+    return AppDialog(
+      size: AppDialogSize.lg,
+      scrollable: true,
+      title: Row(
+        children: [
+          Icon(Icons.description_outlined, color: theme.colorScheme.primary),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(child: Text(l.currentReleaseTitle)),
+        ],
+      ),
+      content: async.when(
+        loading: () => _LoadingSkeleton(tokens: tokens),
+        data: (release) => ReleaseNotesContent(release: release),
+        error: (e, _) => _ErrorBlock(error: e, version: version, l: l, tokens: tokens),
+      ),
+      actions: _actionsFor(context, ref, l, async, version),
+    );
+  }
+
+  List<Widget> _actionsFor(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+    AsyncValue<AppRelease> async,
+    String version,
+  ) {
+    // 三態 actions：
+    // loading      → [關閉]
+    // data         → [在 GitHub 上開啟] [關閉]
+    // rate limited → [在 GitHub Releases 開啟] [關閉]（重試無意義）
+    // not found    → [在 GitHub Releases 開啟] [關閉]（重試也找不到）
+    // 其他 error    → [重試] [關閉]
+    // 實作見下方完整版
+  }
+}
+```
+
+三態 UI 細節：
+
+- **Loading skeleton**：尺寸近似 `ReleaseNotesContent` 的卡片，內含灰色 `Container`（標題列高度 + 數行 body 寬高），用 `tokens.borderSubtle` 色塊；不引入額外 shimmer 套件（YAGNI）
+- **Data**：直接 `ReleaseNotesContent(release: release)`
+- **Error**：
+  - 取 i18n message 對應 `ReleaseCheckError` 子類：
+    - `ReleaseCheckNotFound` → `l.currentReleaseNotFound(version)`
+    - 其餘沿用既有 `l.updateErrorXxx`
+  - 視覺：`Icon(Icons.error_outline)` + 訊息文字
+- **Actions 對應**：
+
+| 狀態                       | Actions                                            |
+|--------------------------|----------------------------------------------------|
+| loading                  | `[Close]`                                          |
+| data                     | `[OpenOnGitHub (release.htmlUrl)] [Close]`         |
+| ReleaseCheckNotFound     | `[OpenReleasesPage (.../releases)] [Close]`        |
+| ReleaseCheckRateLimited  | `[OpenReleasesPage (.../releases)] [Close]`        |
+| 其他 ReleaseCheckError    | `[Retry (ref.invalidate)] [Close]`                 |
+
+「在 GitHub 上開啟」用既有 `openExternalUrl(Uri.parse(...))`。
+
+### 5. UI — 設定頁按鈕
+
+`lib/pages/settings_page.dart` `_AboutContent`（第 243-349 行範圍）：
+
+版本號右側 `Row` 內加一顆按鈕，與既有「檢查更新」按鈕並列：
+
+```dart
+OutlinedButton.icon(
+  onPressed: () => showDialog(
+    context: context,
+    builder: (_) => CurrentReleaseDialog(version: version),
+  ),
+  icon: const Icon(Icons.description_outlined, size: 18),
+  label: Text(l.aboutViewReleaseNotes),
+),
+```
+
+按鈕擺在「檢查更新」按鈕**右側**，順序：[檢查更新] [查看更新內容]。
+
+Hover/cursor 處理：`OutlinedButton` 自帶；不需顯式 `mouseCursor`（記憶 `feedback_inkwell_explicit_mouse_cursor.md` 只針對 `InkWell`）。
+
+### 6. i18n 字串
+
+新增 5 個 keys（template 為 `app_zh.arb`，按專案慣例「繁中起手」）。`actionClose`（關閉）、`actionRetry`（重試）、`actionCancel`（取消）等共用按鈕字串 ARB 已有，直接重用，不新增：
+
+| key | 繁中 (zh) | 英文 (en) | 說明 |
+|---|---|---|---|
+| `aboutViewReleaseNotes` | 查看更新內容 | View release notes | 設定頁按鈕文字 |
+| `currentReleaseTitle` | 目前版本更新內容 | Current release notes | Dialog 標題 |
+| `currentReleaseNotFound` | 找不到 {version} 對應的更新內容 | Release notes not found for {version} | 404 訊息（含 `version` placeholder） |
+| `currentReleaseOpenOnGithub` | 在 GitHub 上開啟 | Open on GitHub | data 狀態的主按鈕 |
+| `currentReleaseOpenReleasesPage` | 開啟 GitHub Releases 頁面 | Open GitHub Releases page | error/not-found 狀態的主按鈕 |
+
+**翻譯範圍**：依使用者明確指示與 [`feedback_i18n_skip_empty_arbs.md`](記憶)，新增字串加在 **9 個非空殼 ARB**：
+
+```
+app_zh.arb       (source, 繁中)
+app_zh_Hans.arb  (簡中)
+app_en.arb       (英文)
+app_es.arb       (西班牙文)
+app_fr.arb       (法文)
+app_ja.arb       (日文)
+app_pt_BR.arb    (巴西葡文)
+app_th.arb       (泰文)
+app_vi.arb       (越南文)
+```
+
+22 個空殼 ARB（`af, ar, ca, cs, da, de, el, fi, he, hu, it, ko, nl, no, pl, pt, ro, ru, sr, sv, tr, uk`）不動，留給 Crowdin pipeline 同步。
+
+**翻譯流程**：
+
+1. 先在 `app_zh.arb` 加 key + `@metadata`（placeholders）
+2. 以繁中為基準，依術語表 `docs/術語表.md` 翻其他 8 個語系
+3. 跑 `flutter gen-l10n` 重產 `app_localizations*.dart`
+4. CLAUDE.md 提交前品質檢查：`dart format` + `flutter analyze` + `flutter test`
+
+### 7. Logger
+
+新樹 `release.notes`（與既有 `release`、`release.notes` 對齊 `release.*` 命名）：
+
+- `Logger('release.notes').info('fetch start version=$version')`
+- `Logger('release.notes').info('fetch success tag=${release.tagName}')`
+- `Logger('release.notes').warning('fetch failed: $e')`
+
+URL 不含敏感資料（公開 repo + 公開 version），無需 `sanitizeUrl`。
+
+## 套件依賴
+
+無新增。完全重用既有 `http`、`pub_semver`、`markdown_widget`、`flutter_riverpod`、`logging`。
+
+## 測試策略
+
+### `test/services/app_release_checker_test.dart` 擴充
+
+```
+group 'fetchReleaseByVersion':
+  - happy path: 200 + valid JSON → AppRelease 正確 parse
+  - 404 → throws ReleaseCheckNotFound(tag: 'v1.1.0')
+  - 5xx → throws ReleaseCheckServer(status)
+  - 403 + x-ratelimit-remaining: 0 → throws ReleaseCheckRateLimited
+  - 200 但 body 不是 JSON object → throws ReleaseCheckFormat
+  - 200 但缺 tag_name → throws ReleaseCheckFormat
+  - SocketException → throws ReleaseCheckNetwork
+  - TimeoutException → throws ReleaseCheckTimeout
+  - version 帶 build metadata（'1.1.0+2'）→ 打的 endpoint 是 .../releases/tags/v1.1.0
+  - version 不合法（'foo'）→ throws ReleaseCheckFormat
+```
+
+`MockClient` 用 `package:http/testing.dart`，並驗 `request.url.path` 確保 endpoint 正確。
+
+### `test/state/current_release_test.dart`（新檔）
+
+```
+- 首次 watch → 打一次 API，state 變 AsyncData
+- 重複 watch 同一 version → 不重打 API（FutureProvider.family 自帶 cache）
+- 不同 version key → 各自打一次 API
+- ref.invalidate(currentReleaseProvider(version)) → 重新 fetch
+- service 拋 ReleaseCheckError → state 變 AsyncError，error 為對應子類
+```
+
+用 `ProviderContainer` + override `httpClientProvider` 為 `MockClient`。
+
+### `test/widgets/dialogs/current_release_dialog_test.dart`（新檔）
+
+```
+- loading 狀態：render skeleton；actions 只有 [Close]
+- data 狀態：render ReleaseNotesContent；actions 有 [OpenOnGitHub] [Close]
+- ReleaseCheckNotFound：render not-found 訊息（含 version）；actions [OpenReleasesPage] [Close]
+- ReleaseCheckRateLimited：render rate-limited 訊息；actions [OpenReleasesPage] [Close]
+- ReleaseCheckNetwork：render network 訊息；actions [Retry] [Close]
+- 按 [Retry] → ref.invalidate 被呼叫（用 ProviderObserver 驗）
+- 按 [Close] → Navigator.pop
+```
+
+UI 測試用 `ProviderScope` override `currentReleaseProvider` family 為 stub。
+
+### `test/widgets/new_version_dialog_test.dart`
+
+既有測試需確認 `_ReleaseCard` → `ReleaseNotesContent` 重構後仍全綠。若既有測試是用 `find.byType(_ReleaseCard)` 之類的 private type，改用 `find.byType(ReleaseNotesContent)`。
+
+### 人工驗證（`flutter run -d windows`）
+
+1. 設定頁「關於」section：版本號右側出現「查看更新內容」按鈕
+2. 點按鈕 → dialog 立即開啟，內部短暫 skeleton → 切換成 content
+3. 內容渲染正確（標題、發布日期、Markdown body）
+4. 按「在 GitHub 上開啟」→ 外部瀏覽器跳到正確 release URL，dialog 關閉
+5. 把 hosts 擋 api.github.com → 重開 app 點按鈕 → dialog 顯示 network error + [Retry] [Close]
+6. 按 [Retry] → 重新 fetch（仍失敗，仍顯示 error）
+7. 解除 hosts 擋 → 按 [Retry] → 成功顯示內容
+8. 暫時把 `pubspec.yaml` version 改成不存在的（例 `9.9.9+1`）重 build → 點按鈕 → 顯示 not-found 訊息 + [OpenReleasesPage]
+9. 切換語系（中/英/日）→ 文字正確翻譯
+
+## YAGNI 邊界（明確不做）
+
+- **歷史 N 版列表**：使用者需求字面是「目前版本」，不延伸做歷史；要看歷史請走「Open GitHub Releases page」按鈕
+- **持久化快取**：release notes 偶爾會被作者更新（補錯字、補圖），同 app 生命週期內快取即可；不寫 SharedPreferences
+- **預先 fetch**：設定頁開啟時不背景 fetch，只在使用者點按鈕才打 API（節省 quota、避免 settings 頁 first-frame lag）
+- **「在 GitHub 上開啟」的內嵌 webview**：跳外部瀏覽器即可，與既有 `NewVersionDialog` 行為一致
+- **「複製連結」按鈕**：不放，使用者用「在 GitHub 上開啟」+ 瀏覽器位址列複製即可
+- **新通用按鈕字串**：「重試」「關閉」沿用既有 `actionRetry` / `actionClose`，不為這次新功能新增任何 `common*` 通用 key

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "Unexpected response format",
+  "currentReleaseTitle": "Current release notes",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "Release notes not found for {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "View on GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "Go to GitHub Releases page",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "View release notes",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "Failed to clear item-image cache: {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "Formato de respuesta inesperado",
+  "currentReleaseTitle": "Notas de la versión actual",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "Notas de la versión no encontradas para {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Ver en GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "Ir a la página de Releases de GitHub",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "Ver notas de la versión",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "Error al limpiar caché de imágenes: {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "Format de réponse inattendu",
+  "currentReleaseTitle": "Notes de version actuelles",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "Notes de version introuvables pour {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Voir sur GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "Aller à la page des versions GitHub",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "Voir les notes de version",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "Échec du vidage du cache d'images : {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -740,7 +740,7 @@
   "@currentReleaseOpenOnGithub": {
     "description": "Action button: open this release page on github.com in the external browser."
   },
-  "currentReleaseOpenReleasesPage": "Aller à la page des versions GitHub",
+  "currentReleaseOpenReleasesPage": "Aller à la page Releases de GitHub",
   "@currentReleaseOpenReleasesPage": {
     "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
   },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -731,7 +731,7 @@
   "@currentReleaseTitle": {
     "description": "Title of the dialog showing release notes for the currently installed version."
   },
-  "currentReleaseNotFound": "{version} に対応するリリースノートが見つかりません",
+  "currentReleaseNotFound": "{version} に対応する更新内容が見つかりません",
   "@currentReleaseNotFound": {
     "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
     "placeholders": { "version": { "type": "String" } }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "応答フォーマットが異常です",
+  "currentReleaseTitle": "現在のバージョンの更新内容",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "{version} に対応するリリースノートが見つかりません",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "GitHub で表示",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "GitHub の Releases ページを開く",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "更新内容を表示",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "アイテム画像キャッシュのクリアに失敗：{detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "Formato de resposta inválido",
+  "currentReleaseTitle": "Notas da versão atual",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "Notas da versão não encontradas para {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Ver no GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "Ir para a página de Releases do GitHub",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "Ver notas da versão",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "Falha ao limpar cache de imagens: {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "รูปแบบการตอบกลับผิดปกติ",
+  "currentReleaseTitle": "บันทึกการอัปเดตเวอร์ชันปัจจุบัน",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "ไม่พบบันทึกการอัปเดตสำหรับ {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "ดูบน GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "ไปที่หน้า GitHub Releases",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "ดูบันทึกการอัปเดต",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "ล้างแคชภาพไม่สำเร็จ: {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -727,6 +727,27 @@
     }
   },
   "updateErrorFormat": "Định dạng phản hồi bất thường",
+  "currentReleaseTitle": "Ghi chú phát hành phiên bản hiện tại",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "Không tìm thấy ghi chú phát hành cho {version}",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "Xem trên GitHub",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "Đến trang GitHub Releases",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "Xem ghi chú phát hành",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "Không xóa được bộ nhớ đệm ảnh: {detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -534,6 +534,27 @@
     "placeholders": { "status": { "type": "String" } }
   },
   "updateErrorFormat": "回應格式異常",
+  "currentReleaseTitle": "目前版本更新內容",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "找不到 {version} 對應的更新內容",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "在 GitHub 上開啟",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "開啟 GitHub Releases 頁面",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "查看更新內容",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "清除物品圖片快取失敗：{detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -534,7 +534,7 @@
     "placeholders": { "status": { "type": "String" } }
   },
   "updateErrorFormat": "回應格式異常",
-  "currentReleaseTitle": "目前版本更新內容",
+  "currentReleaseTitle": "目前版本的更新內容",
   "@currentReleaseTitle": {
     "description": "Title of the dialog showing release notes for the currently installed version."
   },
@@ -543,11 +543,11 @@
     "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
     "placeholders": { "version": { "type": "String" } }
   },
-  "currentReleaseOpenOnGithub": "在 GitHub 上開啟",
+  "currentReleaseOpenOnGithub": "前往 GitHub 查看",
   "@currentReleaseOpenOnGithub": {
     "description": "Action button: open this release page on github.com in the external browser."
   },
-  "currentReleaseOpenReleasesPage": "開啟 GitHub Releases 頁面",
+  "currentReleaseOpenReleasesPage": "前往 GitHub Releases 頁面",
   "@currentReleaseOpenReleasesPage": {
     "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
   },

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -723,6 +723,27 @@
     }
   },
   "updateErrorFormat": "响应格式异常",
+  "currentReleaseTitle": "当前版本的更新内容",
+  "@currentReleaseTitle": {
+    "description": "Title of the dialog showing release notes for the currently installed version."
+  },
+  "currentReleaseNotFound": "找不到 {version} 对应的更新内容",
+  "@currentReleaseNotFound": {
+    "description": "Shown inside the current-release dialog when GitHub returns 404 for the version's tag.",
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "currentReleaseOpenOnGithub": "前往 GitHub 查看",
+  "@currentReleaseOpenOnGithub": {
+    "description": "Action button: open this release page on github.com in the external browser."
+  },
+  "currentReleaseOpenReleasesPage": "前往 GitHub Releases 页面",
+  "@currentReleaseOpenReleasesPage": {
+    "description": "Action button shown when no release was found / rate-limited: open the repo's GitHub Releases listing."
+  },
+  "aboutViewReleaseNotes": "查看更新内容",
+  "@aboutViewReleaseNotes": {
+    "description": "Settings > About: button next to the version label that opens the current-release dialog."
+  },
   "updateErrorWipeHoyoWikiCache": "清除物品图片缓存失败：{detail}",
   "@updateErrorWipeHoyoWikiCache": {
     "description": "Force-refetch flow: failed to clear hoyowiki_index.json or hoyowiki_cache/ directory. {detail} is the sanitized exception message.",

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -35,6 +35,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/section_card.da
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/accounts_picker_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/confirm_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/current_release_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/export_result_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/page_header.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/translator_text.dart';
@@ -288,6 +289,15 @@ class _AboutContent extends ConsumerWidget {
                     )
                   : const Icon(Icons.refresh, size: 18),
               label: Text(checking ? l.updateChecking : l.updateCheckButton),
+            ),
+            const SizedBox(width: AppSpacing.s),
+            OutlinedButton.icon(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => CurrentReleaseDialog(version: version),
+              ),
+              icon: const Icon(Icons.description_outlined, size: 18),
+              label: Text(l.aboutViewReleaseNotes),
             ),
           ],
         ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -276,6 +276,15 @@ class _AboutContent extends ConsumerWidget {
             Expanded(child: Text(l.settingsAboutVersion(version))),
             const SizedBox(width: AppSpacing.s),
             OutlinedButton.icon(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => CurrentReleaseDialog(version: version),
+              ),
+              icon: const Icon(Icons.description_outlined, size: 18),
+              label: Text(l.aboutViewReleaseNotes),
+            ),
+            const SizedBox(width: AppSpacing.s),
+            OutlinedButton.icon(
               onPressed: checking
                   ? null
                   : () => ref
@@ -289,15 +298,6 @@ class _AboutContent extends ConsumerWidget {
                     )
                   : const Icon(Icons.refresh, size: 18),
               label: Text(checking ? l.updateChecking : l.updateCheckButton),
-            ),
-            const SizedBox(width: AppSpacing.s),
-            OutlinedButton.icon(
-              onPressed: () => showDialog<void>(
-                context: context,
-                builder: (_) => CurrentReleaseDialog(version: version),
-              ),
-              icon: const Icon(Icons.description_outlined, size: 18),
-              label: Text(l.aboutViewReleaseNotes),
             ),
           ],
         ),

--- a/lib/services/app_release_checker.dart
+++ b/lib/services/app_release_checker.dart
@@ -76,6 +76,15 @@ class ReleaseCheckFormat extends ReleaseCheckError {
   const ReleaseCheckFormat();
 }
 
+/// 找不到指定 tag 對應的 release（HTTP 404）。
+class ReleaseCheckNotFound extends ReleaseCheckError {
+  /// 建立 [ReleaseCheckNotFound]，[tag] 為查詢的 tag（含 v 前綴）。
+  const ReleaseCheckNotFound(this.tag);
+
+  /// 查詢的 tag，例如 `v1.1.0`。
+  final String tag;
+}
+
 /// 內部 helper：剝掉 leading 'v' 後嘗試 Version.parse；無法 parse 則回 null。
 Version? _parseTag(String tag) {
   final stripped = tag.startsWith('v') ? tag.substring(1) : tag;
@@ -166,4 +175,79 @@ Future<List<AppRelease>> fetchNewerReleases({
     (a, b) => Version.parse(b.version).compareTo(Version.parse(a.version)),
   );
   return out;
+}
+
+/// 抓指定 [version] 對應的單一 GitHub Release。
+///
+/// [version] 可帶 SemVer build metadata（例如 `1.1.0+2`，這是 Flutter
+/// `pubspec.yaml` / `PackageInfo.version` 的標準格式）；內部會剝掉 build
+/// metadata、補上 `v` 前綴後組成 tag（如 `v1.1.0`）查詢。
+///
+/// 與 [fetchNewerReleases] 不同，這個函式不過濾 `draft` / `prerelease`；
+/// 使用者主動查指定 tag 即表示想看那個版本，無論其發佈狀態。
+///
+/// 失敗時拋 [ReleaseCheckError] 的具體子類；指定 tag 不存在時拋
+/// [ReleaseCheckNotFound]。
+Future<AppRelease> fetchReleaseByVersion({
+  required String version,
+  required http.Client client,
+}) async {
+  final Version parsed;
+  try {
+    parsed = Version.parse(version);
+  } catch (_) {
+    throw const ReleaseCheckFormat();
+  }
+  final core = '${parsed.major}.${parsed.minor}.${parsed.patch}';
+  final tag = 'v$core';
+  final uri = Uri.parse('${AppRepo.apiBase}/releases/tags/$tag');
+
+  final http.Response resp;
+  try {
+    resp = await client
+        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
+        .timeout(const Duration(seconds: 10));
+  } on TimeoutException {
+    throw const ReleaseCheckTimeout();
+  } on SocketException {
+    throw const ReleaseCheckNetwork();
+  } on http.ClientException {
+    throw const ReleaseCheckNetwork();
+  }
+
+  if (resp.statusCode == 404) {
+    throw ReleaseCheckNotFound(tag);
+  }
+  if (resp.statusCode == 429 ||
+      (resp.statusCode == 403 &&
+          resp.headers['x-ratelimit-remaining'] == '0')) {
+    throw const ReleaseCheckRateLimited();
+  }
+  if (resp.statusCode != 200) {
+    throw ReleaseCheckServer(resp.statusCode);
+  }
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(resp.body);
+  } on FormatException {
+    throw const ReleaseCheckFormat();
+  }
+  if (decoded is! Map) throw const ReleaseCheckFormat();
+  final raw = decoded;
+  final tagName = raw['tag_name'];
+  if (tagName is! String) throw const ReleaseCheckFormat();
+  final parsedTag = _parseTag(tagName);
+  if (parsedTag == null) throw const ReleaseCheckFormat();
+  final published = DateTime.tryParse(raw['published_at']?.toString() ?? '');
+  if (published == null) throw const ReleaseCheckFormat();
+
+  return AppRelease(
+    tagName: tagName,
+    version: parsedTag.toString(),
+    name: (raw['name'] as String?) ?? '',
+    body: (raw['body'] as String?) ?? '',
+    htmlUrl: (raw['html_url'] as String?) ?? '',
+    publishedAt: published,
+  );
 }

--- a/lib/services/app_release_checker.dart
+++ b/lib/services/app_release_checker.dart
@@ -95,6 +95,54 @@ Version? _parseTag(String tag) {
   }
 }
 
+/// 共用 GET + 解析骨架：對 [uri] 發 GitHub API 請求，統一處理
+/// 超時 / 網路 / rate limit / 一般非 200 / JSON 解碼錯誤，回傳已
+/// `jsonDecode` 的 body。
+///
+/// [specialStatusErrors] 讓 caller 宣告「特定 status code 要對應到自訂
+/// [ReleaseCheckError]」（例如 `fetchReleaseByVersion` 用 `{404:
+/// ReleaseCheckNotFound(tag)}`）；這些 status 會在 rate limit / 一般非 200
+/// 檢查之前優先觸發，避免被通用分支吃掉。
+///
+/// 失敗時拋 [ReleaseCheckError] 的具體子類。
+Future<dynamic> _githubGet(
+  Uri uri, {
+  required http.Client client,
+  Map<int, ReleaseCheckError> specialStatusErrors = const {},
+}) async {
+  final http.Response resp;
+  try {
+    resp = await client
+        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
+        .timeout(const Duration(seconds: 10));
+  } on TimeoutException {
+    throw const ReleaseCheckTimeout();
+  } on SocketException {
+    throw const ReleaseCheckNetwork();
+  } on http.ClientException {
+    throw const ReleaseCheckNetwork();
+  }
+
+  final special = specialStatusErrors[resp.statusCode];
+  if (special != null) {
+    throw special;
+  }
+  if (resp.statusCode == 429 ||
+      (resp.statusCode == 403 &&
+          resp.headers['x-ratelimit-remaining'] == '0')) {
+    throw const ReleaseCheckRateLimited();
+  }
+  if (resp.statusCode != 200) {
+    throw ReleaseCheckServer(resp.statusCode);
+  }
+
+  try {
+    return jsonDecode(resp.body);
+  } on FormatException {
+    throw const ReleaseCheckFormat();
+  }
+}
+
 /// 抓 GitHub Releases API，過濾 prerelease/draft，回傳比 [currentVersion]
 /// 新的 release（新到舊）。空 list = 無更新。
 ///
@@ -117,34 +165,7 @@ Future<List<AppRelease>> fetchNewerReleases({
   }
 
   final uri = Uri.parse('${AppRepo.apiBase}/releases');
-  final http.Response resp;
-  try {
-    resp = await client
-        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
-        .timeout(const Duration(seconds: 10));
-  } on TimeoutException {
-    throw const ReleaseCheckTimeout();
-  } on SocketException {
-    throw const ReleaseCheckNetwork();
-  } on http.ClientException {
-    throw const ReleaseCheckNetwork();
-  }
-
-  if (resp.statusCode == 429 ||
-      (resp.statusCode == 403 &&
-          resp.headers['x-ratelimit-remaining'] == '0')) {
-    throw const ReleaseCheckRateLimited();
-  }
-  if (resp.statusCode != 200) {
-    throw ReleaseCheckServer(resp.statusCode);
-  }
-
-  final dynamic decoded;
-  try {
-    decoded = jsonDecode(resp.body);
-  } on FormatException {
-    throw const ReleaseCheckFormat();
-  }
+  final decoded = await _githubGet(uri, client: client);
   if (decoded is! List) throw const ReleaseCheckFormat();
 
   final out = <AppRelease>[];
@@ -202,37 +223,11 @@ Future<AppRelease> fetchReleaseByVersion({
   final tag = 'v$core';
   final uri = Uri.parse('${AppRepo.apiBase}/releases/tags/$tag');
 
-  final http.Response resp;
-  try {
-    resp = await client
-        .get(uri, headers: const {'Accept': 'application/vnd.github+json'})
-        .timeout(const Duration(seconds: 10));
-  } on TimeoutException {
-    throw const ReleaseCheckTimeout();
-  } on SocketException {
-    throw const ReleaseCheckNetwork();
-  } on http.ClientException {
-    throw const ReleaseCheckNetwork();
-  }
-
-  if (resp.statusCode == 404) {
-    throw ReleaseCheckNotFound(tag);
-  }
-  if (resp.statusCode == 429 ||
-      (resp.statusCode == 403 &&
-          resp.headers['x-ratelimit-remaining'] == '0')) {
-    throw const ReleaseCheckRateLimited();
-  }
-  if (resp.statusCode != 200) {
-    throw ReleaseCheckServer(resp.statusCode);
-  }
-
-  final dynamic decoded;
-  try {
-    decoded = jsonDecode(resp.body);
-  } on FormatException {
-    throw const ReleaseCheckFormat();
-  }
+  final decoded = await _githubGet(
+    uri,
+    client: client,
+    specialStatusErrors: {404: ReleaseCheckNotFound(tag)},
+  );
   if (decoded is! Map) throw const ReleaseCheckFormat();
   final raw = decoded;
   final tagName = raw['tag_name'];

--- a/lib/state/app_release.dart
+++ b/lib/state/app_release.dart
@@ -117,16 +117,26 @@ class AppReleaseNotifier extends Notifier<ReleaseCheckState> {
   }
 
   /// 把 service error 轉成穩定 token，UI 端拿 token 解 i18n。
+  ///
+  /// 注意：此 helper 目前**只**服務 [fetchNewerReleases] 流（list
+  /// endpoint，不會 404）。`ReleaseCheckNotFound` 由 `CurrentReleaseDialog`
+  /// 走 `fetchReleaseByVersion` 自行 i18n。若日後要把這個 helper 接到
+  /// 任何**可能 404** 的新流程，請先加上專屬的 `notFound` token 與對應
+  /// i18n 字串，再來修這個 switch；別偷懶 fallback 成 `'format'`，否則
+  /// 404 會被使用者看成「格式錯誤」。
   String _localizeError(ReleaseCheckError e) => switch (e) {
     ReleaseCheckNetwork() => 'network',
     ReleaseCheckTimeout() => 'timeout',
     ReleaseCheckRateLimited() => 'rateLimited',
     ReleaseCheckServer(:final status) => 'server:$status',
     ReleaseCheckFormat() => 'format',
-    // fetchNewerReleases 走 /releases（list endpoint）不會 404，此分支
-    // 為 sealed exhaustiveness 而存在；真正消費 404 的是
-    // CurrentReleaseDialog（fetchReleaseByVersion 流）。
-    ReleaseCheckNotFound() => 'format',
+    ReleaseCheckNotFound() => throw UnsupportedError(
+      'AppReleaseNotifier._localizeError received ReleaseCheckNotFound. '
+      'This error is only producible by fetchReleaseByVersion (currently '
+      'consumed by CurrentReleaseDialog, which does its own i18n). '
+      'If you are reusing _localizeError for a flow that can hit 404, '
+      'add a proper "notFound" token and i18n string instead.',
+    ),
   };
 }
 

--- a/lib/state/app_release.dart
+++ b/lib/state/app_release.dart
@@ -123,6 +123,10 @@ class AppReleaseNotifier extends Notifier<ReleaseCheckState> {
     ReleaseCheckRateLimited() => 'rateLimited',
     ReleaseCheckServer(:final status) => 'server:$status',
     ReleaseCheckFormat() => 'format',
+    // fetchNewerReleases 走 /releases（list endpoint）不會 404，此分支
+    // 為 sealed exhaustiveness 而存在；真正消費 404 的是
+    // CurrentReleaseDialog（fetchReleaseByVersion 流）。
+    ReleaseCheckNotFound() => 'format',
   };
 }
 

--- a/lib/state/current_release.dart
+++ b/lib/state/current_release.dart
@@ -5,6 +5,9 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.
 import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
     show httpClientProvider;
 
+/// Logger 實例（當期版本 release notes 抓取）。
+final _log = Logger('release.notes');
+
 /// 依 version key 抓對應的 GitHub Release，自帶 in-memory cache。
 ///
 /// 同一 `version` 重複 watch 不會重打 API；要強制重新 fetch，呼叫
@@ -12,21 +15,26 @@ import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
 ///
 /// 失敗時 future 會拋 [ReleaseCheckError] 的具體子類，UI 端用
 /// `AsyncValue.when(error: ...)` 處理。
+//
+// Riverpod 3 預設指數退避自動重試（200ms → 6.4s），會在 dialog 顯示
+// [重試] 按鈕的同時偷偷重打 API、把 AsyncError 翻成 AsyncData，違反「使用者
+// 主動按重試才重 fetch」的 UX 設計（spec § 快取）。重試一律走
+// ref.invalidate(currentReleaseProvider(version))。
 final currentReleaseProvider = FutureProvider.family<AppRelease, String>((
   ref,
   version,
 ) async {
-  Logger('release.notes').info('fetch start version=$version');
+  _log.info('fetch start version=$version');
   final client = ref.read(httpClientProvider);
   try {
     final release = await fetchReleaseByVersion(
       version: version,
       client: client,
     );
-    Logger('release.notes').info('fetch success tag=${release.tagName}');
+    _log.info('fetch success tag=${release.tagName}');
     return release;
   } on ReleaseCheckError catch (e) {
-    Logger('release.notes').warning('fetch failed version=$version: $e');
+    _log.warning('fetch failed version=$version: $e');
     rethrow;
   }
-});
+}, retry: (_, _) => null);

--- a/lib/state/current_release.dart
+++ b/lib/state/current_release.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
+    show httpClientProvider;
+
+/// 依 version key 抓對應的 GitHub Release，自帶 in-memory cache。
+///
+/// 同一 `version` 重複 watch 不會重打 API；要強制重新 fetch，呼叫
+/// `ref.invalidate(currentReleaseProvider(version))`。
+///
+/// 失敗時 future 會拋 [ReleaseCheckError] 的具體子類，UI 端用
+/// `AsyncValue.when(error: ...)` 處理。
+final currentReleaseProvider = FutureProvider.family<AppRelease, String>((
+  ref,
+  version,
+) async {
+  Logger('release.notes').info('fetch start version=$version');
+  final client = ref.read(httpClientProvider);
+  try {
+    final release = await fetchReleaseByVersion(
+      version: version,
+      client: client,
+    );
+    Logger('release.notes').info('fetch success tag=${release.tagName}');
+    return release;
+  } on ReleaseCheckError catch (e) {
+    Logger('release.notes').warning('fetch failed version=$version: $e');
+    rethrow;
+  }
+});

--- a/lib/widgets/dialogs/current_release_dialog.dart
+++ b/lib/widgets/dialogs/current_release_dialog.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/data/app_repo.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+/// 顯示「目前版本」對應 GitHub Release 內容的 dialog，整合 loading／data／
+/// error 三態，並依錯誤類型提供合理的後續操作（重試或開 Releases 頁面）。
+class CurrentReleaseDialog extends ConsumerWidget {
+  /// 建立 [CurrentReleaseDialog]，[version] 為要查詢的版本字串
+  /// （pubspec／`PackageInfo` 版本，可帶 build metadata，例如 `1.1.0+2`）。
+  const CurrentReleaseDialog({super.key, required this.version});
+
+  /// 要查詢的版本字串。
+  final String version;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final async = ref.watch(currentReleaseProvider(version));
+
+    return AppDialog(
+      size: AppDialogSize.lg,
+      scrollable: true,
+      title: Row(
+        children: [
+          Icon(Icons.description_outlined, color: theme.colorScheme.primary),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(child: Text(l.currentReleaseTitle)),
+        ],
+      ),
+      content: async.when(
+        loading: () => _LoadingSkeleton(theme: theme),
+        data: (release) => ReleaseNotesContent(release: release),
+        error: (e, _) =>
+            _ErrorBlock(error: e, version: version, l: l, theme: theme),
+      ),
+      actions: _actionsFor(context, ref, l, async),
+    );
+  }
+
+  /// 依目前 [async] 狀態組出對應的 dialog 底部按鈕清單。
+  List<Widget> _actionsFor(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+    AsyncValue<AppRelease> async,
+  ) {
+    final closeButton = TextButton(
+      onPressed: () => Navigator.of(context).pop(),
+      child: Text(l.actionClose),
+    );
+
+    return async.when(
+      loading: () => [closeButton],
+      data: (release) => [
+        closeButton,
+        FilledButton.icon(
+          icon: const Icon(Icons.open_in_new),
+          label: Text(l.currentReleaseOpenOnGithub),
+          onPressed: () async {
+            await openExternalUrl(Uri.parse(release.htmlUrl));
+            if (context.mounted) Navigator.of(context).pop();
+          },
+        ),
+      ],
+      error: (e, _) {
+        final terminalError =
+            e is ReleaseCheckNotFound || e is ReleaseCheckRateLimited;
+        if (terminalError) {
+          return [
+            closeButton,
+            FilledButton.icon(
+              icon: const Icon(Icons.open_in_new),
+              label: Text(l.currentReleaseOpenReleasesPage),
+              onPressed: () async {
+                await openExternalUrl(
+                  Uri.parse('${AppRepo.githubUrl}/releases'),
+                );
+                if (context.mounted) Navigator.of(context).pop();
+              },
+            ),
+          ];
+        }
+        return [
+          closeButton,
+          FilledButton.icon(
+            icon: const Icon(Icons.refresh),
+            label: Text(l.actionRetry),
+            onPressed: () => ref.invalidate(currentReleaseProvider(version)),
+          ),
+        ];
+      },
+    );
+  }
+}
+
+/// 三態 loading 狀態下的灰色占位卡片，視覺極簡（不引入 shimmer 套件）。
+class _LoadingSkeleton extends StatelessWidget {
+  /// 建立 [_LoadingSkeleton]，[theme] 用於取出 token 配色。
+  const _LoadingSkeleton({required this.theme});
+
+  /// 取色用的主題。
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = theme.gacha;
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.m),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _bar(width: 120, height: 24, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            _bar(width: double.infinity, height: 1, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            _bar(
+              width: double.infinity,
+              height: 14,
+              color: tokens.borderSubtle,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            _bar(
+              width: double.infinity,
+              height: 14,
+              color: tokens.borderSubtle,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            _bar(width: 240, height: 14, color: tokens.borderSubtle),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 畫一個指定尺寸與顏色的圓角矩形占位。
+  Widget _bar({
+    required double width,
+    required double height,
+    required Color color,
+  }) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(4),
+      ),
+    );
+  }
+}
+
+/// 三態 error 狀態下的訊息區塊，把 [error] 對應到 i18n 字串並顯示在 icon 旁。
+class _ErrorBlock extends StatelessWidget {
+  /// 建立 [_ErrorBlock]。
+  const _ErrorBlock({
+    required this.error,
+    required this.version,
+    required this.l,
+    required this.theme,
+  });
+
+  /// 來自 provider 的錯誤物件，應為 [ReleaseCheckError] 子類。
+  final Object error;
+
+  /// 目前查詢的版本字串，用於 not-found 訊息插值。
+  final String version;
+
+  /// 訊息字串取用的 localizations。
+  final AppLocalizations l;
+
+  /// 取色與字體用的主題。
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = _messageFor(error);
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.m),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.error_outline, color: theme.colorScheme.error),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(child: Text(message, style: theme.textTheme.bodyMedium)),
+        ],
+      ),
+    );
+  }
+
+  /// 把 [ReleaseCheckError] 子類對應到既有 `update*` i18n 字串，
+  /// 維持與「檢查更新」流程的訊息一致性。
+  String _messageFor(Object e) {
+    if (e is ReleaseCheckNotFound) return l.currentReleaseNotFound(version);
+    if (e is ReleaseCheckNetwork) return l.updateErrorNetwork;
+    if (e is ReleaseCheckTimeout) return l.updateErrorTimeout;
+    if (e is ReleaseCheckRateLimited) return l.updateErrorRateLimited;
+    if (e is ReleaseCheckServer) {
+      return l.updateErrorServer(e.status.toString());
+    }
+    if (e is ReleaseCheckFormat) return l.updateErrorFormat;
+    return e.toString();
+  }
+}

--- a/lib/widgets/dialogs/current_release_dialog.dart
+++ b/lib/widgets/dialogs/current_release_dialog.dart
@@ -37,10 +37,10 @@ class CurrentReleaseDialog extends ConsumerWidget {
         ],
       ),
       content: async.when(
-        loading: () => _LoadingSkeleton(theme: theme),
+        loading: () => const _LoadingSkeleton(),
         data: (release) => ReleaseNotesContent(release: release),
         error: (e, _) =>
-            _ErrorBlock(error: e, version: version, l: l, theme: theme),
+            _ErrorBlock(error: e as ReleaseCheckError, version: version),
       ),
       actions: _actionsFor(context, ref, l, async),
     );
@@ -72,8 +72,9 @@ class CurrentReleaseDialog extends ConsumerWidget {
         ),
       ],
       error: (e, _) {
+        final err = e as ReleaseCheckError;
         final terminalError =
-            e is ReleaseCheckNotFound || e is ReleaseCheckRateLimited;
+            err is ReleaseCheckNotFound || err is ReleaseCheckRateLimited;
         if (terminalError) {
           return [
             closeButton,
@@ -104,14 +105,12 @@ class CurrentReleaseDialog extends ConsumerWidget {
 
 /// 三態 loading 狀態下的灰色占位卡片，視覺極簡（不引入 shimmer 套件）。
 class _LoadingSkeleton extends StatelessWidget {
-  /// 建立 [_LoadingSkeleton]，[theme] 用於取出 token 配色。
-  const _LoadingSkeleton({required this.theme});
-
-  /// 取色用的主題。
-  final ThemeData theme;
+  /// 建立 [_LoadingSkeleton]。
+  const _LoadingSkeleton();
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final tokens = theme.gacha;
     return Card(
       margin: EdgeInsets.zero,
@@ -163,28 +162,19 @@ class _LoadingSkeleton extends StatelessWidget {
 /// 三態 error 狀態下的訊息區塊，把 [error] 對應到 i18n 字串並顯示在 icon 旁。
 class _ErrorBlock extends StatelessWidget {
   /// 建立 [_ErrorBlock]。
-  const _ErrorBlock({
-    required this.error,
-    required this.version,
-    required this.l,
-    required this.theme,
-  });
+  const _ErrorBlock({required this.error, required this.version});
 
-  /// 來自 provider 的錯誤物件，應為 [ReleaseCheckError] 子類。
-  final Object error;
+  /// 來自 provider 的錯誤物件。
+  final ReleaseCheckError error;
 
   /// 目前查詢的版本字串，用於 not-found 訊息插值。
   final String version;
 
-  /// 訊息字串取用的 localizations。
-  final AppLocalizations l;
-
-  /// 取色與字體用的主題。
-  final ThemeData theme;
-
   @override
   Widget build(BuildContext context) {
-    final message = _messageFor(error);
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context)!;
+    final message = _messageFor(l, error);
     return Padding(
       padding: const EdgeInsets.all(AppSpacing.m),
       child: Row(
@@ -200,15 +190,16 @@ class _ErrorBlock extends StatelessWidget {
 
   /// 把 [ReleaseCheckError] 子類對應到既有 `update*` i18n 字串，
   /// 維持與「檢查更新」流程的訊息一致性。
-  String _messageFor(Object e) {
-    if (e is ReleaseCheckNotFound) return l.currentReleaseNotFound(version);
-    if (e is ReleaseCheckNetwork) return l.updateErrorNetwork;
-    if (e is ReleaseCheckTimeout) return l.updateErrorTimeout;
-    if (e is ReleaseCheckRateLimited) return l.updateErrorRateLimited;
-    if (e is ReleaseCheckServer) {
-      return l.updateErrorServer(e.status.toString());
-    }
-    if (e is ReleaseCheckFormat) return l.updateErrorFormat;
-    return e.toString();
+  String _messageFor(AppLocalizations l, ReleaseCheckError e) {
+    return switch (e) {
+      ReleaseCheckNotFound() => l.currentReleaseNotFound(version),
+      ReleaseCheckNetwork() => l.updateErrorNetwork,
+      ReleaseCheckTimeout() => l.updateErrorTimeout,
+      ReleaseCheckRateLimited() => l.updateErrorRateLimited,
+      ReleaseCheckServer(:final status) => l.updateErrorServer(
+        status.toString(),
+      ),
+      ReleaseCheckFormat() => l.updateErrorFormat,
+    };
   }
 }

--- a/lib/widgets/dialogs/new_version_dialog.dart
+++ b/lib/widgets/dialogs/new_version_dialog.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:markdown_widget/markdown_widget.dart';
+
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/widgets/relative_time_text.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
 
 /// 新版本通知 dialog，列出自上次版本以來的所有 release notes。
 class NewVersionDialog extends ConsumerWidget {
@@ -37,7 +37,7 @@ class NewVersionDialog extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           for (int i = 0; i < releases.length; i++) ...[
-            _ReleaseCard(release: releases[i], l: l),
+            ReleaseNotesContent(release: releases[i]),
             if (i < releases.length - 1) const SizedBox(height: AppSpacing.m),
           ],
         ],
@@ -65,72 +65,6 @@ class NewVersionDialog extends ConsumerWidget {
           },
         ),
       ],
-    );
-  }
-}
-
-/// 依 [theme] 亮暗模式建立 markdown 渲染設定，統一連結樣式。
-MarkdownConfig _markdownConfig(ThemeData theme) {
-  final base = theme.brightness == Brightness.dark
-      ? MarkdownConfig.darkConfig
-      : MarkdownConfig.defaultConfig;
-  return base.copy(
-    configs: [LinkConfig(style: TextStyle(color: linkBaseColor(theme)))],
-  );
-}
-
-/// 單一 release 的卡片，顯示版本號、發布時間與 markdown release notes。
-class _ReleaseCard extends StatelessWidget {
-  const _ReleaseCard({required this.release, required this.l});
-
-  /// 該卡片對應的 release 資料。
-  final AppRelease release;
-
-  /// 在地化資源，用於時間格式文案。
-  final AppLocalizations l;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final tokens = theme.gacha;
-
-    return Card(
-      margin: EdgeInsets.zero,
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.m),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              textBaseline: TextBaseline.alphabetic,
-              children: [
-                Text(
-                  release.tagName,
-                  style: theme.textTheme.titleLarge?.copyWith(
-                    color: theme.colorScheme.primary,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.s),
-                RelativeTimeText(
-                  time: release.publishedAt,
-                  templateBuilder: l.updateReleasedAt,
-                  useDateOnly: true,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: tokens.textMuted,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Divider(height: 1, color: tokens.borderSubtle),
-            const SizedBox(height: AppSpacing.s),
-            if (release.body.isNotEmpty)
-              MarkdownBlock(data: release.body, config: _markdownConfig(theme)),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/widgets/dialogs/release_notes_content.dart
+++ b/lib/widgets/dialogs/release_notes_content.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/relative_time_text.dart';
+
+/// 單一 release 的內容卡片：版本標題 + 發布時間 + Markdown body。
+/// 由 `NewVersionDialog` 與 `CurrentReleaseDialog` 共用。
+class ReleaseNotesContent extends StatelessWidget {
+  /// 建立 [ReleaseNotesContent]。
+  const ReleaseNotesContent({super.key, required this.release});
+
+  /// 要呈現的 release 資料。
+  final AppRelease release;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.m),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  release.tagName,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    color: theme.colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.s),
+                RelativeTimeText(
+                  time: release.publishedAt,
+                  templateBuilder: l.updateReleasedAt,
+                  useDateOnly: true,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: tokens.textMuted,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Divider(height: 1, color: tokens.borderSubtle),
+            const SizedBox(height: AppSpacing.s),
+            if (release.body.isNotEmpty)
+              MarkdownBlock(
+                data: release.body,
+                config: releaseNotesMarkdownConfig(theme),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 依 [theme] 亮暗模式建立 markdown 渲染設定，統一連結樣式。
+MarkdownConfig releaseNotesMarkdownConfig(ThemeData theme) {
+  final base = theme.brightness == Brightness.dark
+      ? MarkdownConfig.darkConfig
+      : MarkdownConfig.defaultConfig;
+  return base.copy(
+    configs: [LinkConfig(style: TextStyle(color: linkBaseColor(theme)))],
+  );
+}

--- a/test/services/app_release_checker_test.dart
+++ b/test/services/app_release_checker_test.dart
@@ -261,4 +261,194 @@ void main() {
       );
     });
   });
+
+  group('fetchReleaseByVersion — happy path', () {
+    test('200 + valid JSON → AppRelease', () async {
+      late Uri requested;
+      final client = MockClient((req) async {
+        requested = req.url;
+        return http.Response(
+          jsonEncode(
+            _release(
+              tag: 'v1.1.0',
+              published: '2026-05-27T00:00:00Z',
+              name: 'v1.1.0',
+              body: '## Features\n- foo\n- bar',
+              htmlUrl: 'https://github.com/o/r/releases/tag/v1.1.0',
+            ),
+          ),
+          200,
+        );
+      });
+
+      final release = await fetchReleaseByVersion(
+        version: '1.1.0',
+        client: client,
+      );
+
+      expect(requested.path, endsWith('/releases/tags/v1.1.0'));
+      expect(release.tagName, 'v1.1.0');
+      expect(release.version, '1.1.0');
+      expect(release.name, 'v1.1.0');
+      expect(release.body, '## Features\n- foo\n- bar');
+      expect(release.htmlUrl, 'https://github.com/o/r/releases/tag/v1.1.0');
+      expect(release.publishedAt, DateTime.utc(2026, 5, 27));
+    });
+
+    test('version 帶 build metadata → endpoint 用核心 SemVer', () async {
+      late Uri requested;
+      final client = MockClient((req) async {
+        requested = req.url;
+        return http.Response(
+          jsonEncode(
+            _release(tag: 'v1.1.0', published: '2026-05-27T00:00:00Z'),
+          ),
+          200,
+        );
+      });
+
+      await fetchReleaseByVersion(version: '1.1.0+2', client: client);
+
+      expect(requested.path, endsWith('/releases/tags/v1.1.0'));
+    });
+  });
+
+  group('fetchReleaseByVersion — errors', () {
+    test('404 → ReleaseCheckNotFound (tag = v1.1.0)', () async {
+      final client = MockClient((_) async => http.Response('Not Found', 404));
+      try {
+        await fetchReleaseByVersion(version: '1.1.0', client: client);
+        fail('expected throw');
+      } on ReleaseCheckNotFound catch (e) {
+        expect(e.tag, 'v1.1.0');
+      }
+    });
+
+    test('5xx → ReleaseCheckServer(status)', () async {
+      final client = MockClient((_) async => http.Response('boom', 503));
+      try {
+        await fetchReleaseByVersion(version: '1.1.0', client: client);
+        fail('expected throw');
+      } on ReleaseCheckServer catch (e) {
+        expect(e.status, 503);
+      }
+    });
+
+    test('429 → ReleaseCheckRateLimited', () async {
+      final client = MockClient(
+        (_) async => http.Response('rate limited', 429),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckRateLimited>()),
+      );
+    });
+
+    test('403 + x-ratelimit-remaining: 0 → ReleaseCheckRateLimited', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          'forbidden',
+          403,
+          headers: const {'x-ratelimit-remaining': '0'},
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckRateLimited>()),
+      );
+    });
+
+    test('200 但 body 不是 JSON object → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode([1, 2, 3]), 200),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('200 但缺 tag_name → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'published_at': '2026-05-27T00:00:00Z'}),
+          200,
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('200 但 tag_name 無法 parse → ReleaseCheckFormat', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'tag_name': 'weird-tag',
+            'published_at': '2026-05-27T00:00:00Z',
+          }),
+          200,
+        ),
+      );
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+
+    test('SocketException → ReleaseCheckNetwork', () async {
+      final client = MockClient((_) async {
+        throw const SocketException('offline');
+      });
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckNetwork>()),
+      );
+    });
+
+    test('http.ClientException → ReleaseCheckNetwork', () async {
+      final client = MockClient((_) async {
+        throw http.ClientException('connection reset');
+      });
+      expect(
+        () => fetchReleaseByVersion(version: '1.1.0', client: client),
+        throwsA(isA<ReleaseCheckNetwork>()),
+      );
+    });
+
+    test('TimeoutException 觸發 → ReleaseCheckTimeout', () {
+      fakeAsync((async) {
+        final client = MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 15));
+          return http.Response(
+            jsonEncode(
+              _release(tag: 'v1.1.0', published: '2026-05-27T00:00:00Z'),
+            ),
+            200,
+          );
+        });
+
+        Object? caught;
+        fetchReleaseByVersion(version: '1.1.0', client: client).then(
+          (_) {},
+          onError: (Object e) {
+            caught = e;
+          },
+        );
+
+        async.elapse(const Duration(seconds: 11));
+
+        expect(caught, isA<ReleaseCheckTimeout>());
+      });
+    });
+
+    test('version 無法 parse → ReleaseCheckFormat', () async {
+      final client = MockClient((_) async => http.Response('', 200));
+      expect(
+        () => fetchReleaseByVersion(version: 'not-a-version', client: client),
+        throwsA(isA<ReleaseCheckFormat>()),
+      );
+    });
+  });
 }

--- a/test/state/current_release_test.dart
+++ b/test/state/current_release_test.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/app_release.dart'
+    show httpClientProvider;
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+
+Map<String, dynamic> _releaseJson(String tag, String published) => {
+  'tag_name': tag,
+  'name': tag,
+  'body': '## body for $tag',
+  'prerelease': false,
+  'draft': false,
+  'html_url': 'https://github.com/o/r/releases/tag/$tag',
+  'published_at': published,
+};
+
+ProviderContainer _container(http.Client client) {
+  // Riverpod 3 預設對失敗 provider 做指數退避自動重試（最長 6.4s × N 次），
+  // 會把錯誤測試的 await .future 卡到 30s test timeout；測試容器一律
+  // 關掉 retry，讓錯誤立刻反映到 AsyncValue 上。
+  final container = ProviderContainer(
+    retry: (_, _) => null,
+    overrides: [httpClientProvider.overrideWithValue(client)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('首次 watch → 打一次 API，state 變 AsyncData', () async {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      ),
+    );
+    final container = _container(client);
+
+    final release = await container.read(
+      currentReleaseProvider('1.1.0').future,
+    );
+
+    expect(release.tagName, 'v1.1.0');
+    final state = container.read(currentReleaseProvider('1.1.0'));
+    expect(state.hasValue, isTrue);
+    expect(state.value?.tagName, 'v1.1.0');
+  });
+
+  test('重複 read 同一 version → 不重打 API（FutureProvider.family cache）', () async {
+    var callCount = 0;
+    final client = MockClient((_) async {
+      callCount++;
+      return http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.1.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+
+    expect(callCount, 1);
+  });
+
+  test('不同 version key → 各自打一次 API', () async {
+    final calledFor = <String>[];
+    final client = MockClient((req) async {
+      calledFor.add(req.url.path);
+      final tag = req.url.path.split('/').last;
+      return http.Response(
+        jsonEncode(_releaseJson(tag, '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.0.0').future);
+    await container.read(currentReleaseProvider('1.1.0').future);
+
+    expect(calledFor.where((p) => p.endsWith('v1.0.0')).length, 1);
+    expect(calledFor.where((p) => p.endsWith('v1.1.0')).length, 1);
+  });
+
+  test('ref.invalidate → 重新 fetch', () async {
+    var callCount = 0;
+    final client = MockClient((_) async {
+      callCount++;
+      return http.Response(
+        jsonEncode(_releaseJson('v1.1.0', '2026-05-27T00:00:00Z')),
+        200,
+      );
+    });
+    final container = _container(client);
+
+    await container.read(currentReleaseProvider('1.1.0').future);
+    expect(callCount, 1);
+
+    container.invalidate(currentReleaseProvider('1.1.0'));
+    await container.read(currentReleaseProvider('1.1.0').future);
+    expect(callCount, 2);
+  });
+
+  test('service 拋 ReleaseCheckNotFound → state 變 AsyncError', () async {
+    final client = MockClient((_) async => http.Response('Not Found', 404));
+    final container = _container(client);
+
+    try {
+      await container.read(currentReleaseProvider('1.1.0').future);
+      fail('expected throw');
+    } on ReleaseCheckNotFound catch (e) {
+      expect(e.tag, 'v1.1.0');
+    }
+    final state = container.read(currentReleaseProvider('1.1.0'));
+    expect(state.hasError, isTrue);
+    expect(state.error, isA<ReleaseCheckNotFound>());
+  });
+
+  test('service 拋 ReleaseCheckServer → state 變 AsyncError', () async {
+    final client = MockClient((_) async => http.Response('boom', 503));
+    final container = _container(client);
+
+    try {
+      await container.read(currentReleaseProvider('1.1.0').future);
+      fail('expected throw');
+    } on ReleaseCheckServer catch (e) {
+      expect(e.status, 503);
+    }
+    expect(
+      container.read(currentReleaseProvider('1.1.0')).error,
+      isA<ReleaseCheckServer>(),
+    );
+  });
+}

--- a/test/widgets/dialogs/current_release_dialog_test.dart
+++ b/test/widgets/dialogs/current_release_dialog_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/current_release.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/current_release_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+AppRelease _release({String tag = 'v1.1.0', String body = '## Hi'}) =>
+    AppRelease(
+      tagName: tag,
+      version: tag.startsWith('v') ? tag.substring(1) : tag,
+      name: tag,
+      body: body,
+      htmlUrl: 'https://github.com/o/r/releases/tag/$tag',
+      publishedAt: DateTime.utc(2026, 5, 27),
+    );
+
+/// Pump a Riverpod-scoped app that opens [CurrentReleaseDialog] with the
+/// given fake fetcher and waits for the open animation to start. Caller is
+/// responsible for `pumpAndSettle()` when ready.
+Future<void> _pumpDialog(
+  WidgetTester tester, {
+  required Future<AppRelease> Function(Ref ref) fetcher,
+  String version = '1.1.0',
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [currentReleaseProvider(version).overrideWith(fetcher)],
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () => showDialog<void>(
+                  context: ctx,
+                  builder: (_) => CurrentReleaseDialog(version: version),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pump();
+}
+
+void main() {
+  testWidgets(
+    'data state → renders ReleaseNotesContent + [View on GitHub] [Close]',
+    (tester) async {
+      final release = _release();
+      await _pumpDialog(tester, fetcher: (ref) async => release);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ReleaseNotesContent), findsOneWidget);
+      expect(find.text('View on GitHub'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+      expect(find.text('Retry'), findsNothing);
+    },
+  );
+
+  testWidgets('loading state → no ReleaseNotesContent yet, only [Close]', (
+    tester,
+  ) async {
+    final completer = Completer<AppRelease>();
+    await _pumpDialog(tester, fetcher: (ref) => completer.future);
+
+    expect(find.byType(ReleaseNotesContent), findsNothing);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('View on GitHub'), findsNothing);
+
+    completer.complete(_release());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'ReleaseCheckNotFound → renders not-found message + [Go to Releases page] [Close]',
+    (tester) async {
+      await _pumpDialog(
+        tester,
+        fetcher: (ref) => Future.error(const ReleaseCheckNotFound('v1.1.0')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Release notes not found for 1.1.0'),
+        findsOneWidget,
+      );
+      expect(find.text('Go to GitHub Releases page'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+      expect(find.text('Retry'), findsNothing);
+    },
+  );
+
+  testWidgets('ReleaseCheckRateLimited → [Go to Releases page] [Close]', (
+    tester,
+  ) async {
+    await _pumpDialog(
+      tester,
+      fetcher: (ref) => Future.error(const ReleaseCheckRateLimited()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('quota'), findsOneWidget);
+    expect(find.text('Go to GitHub Releases page'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('ReleaseCheckNetwork → [Retry] [Close]', (tester) async {
+    await _pumpDialog(
+      tester,
+      fetcher: (ref) => Future.error(const ReleaseCheckNetwork()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+    expect(find.text('Go to GitHub Releases page'), findsNothing);
+  });
+
+  testWidgets(
+    'ReleaseCheckServer(503) → [Retry] [Close] with status code visible',
+    (tester) async {
+      await _pumpDialog(
+        tester,
+        fetcher: (ref) => Future.error(const ReleaseCheckServer(503)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('503'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    },
+  );
+
+  testWidgets('Retry → ref.invalidate triggers refetch', (tester) async {
+    var fetches = 0;
+    await _pumpDialog(
+      tester,
+      fetcher: (ref) {
+        fetches++;
+        if (fetches == 1) {
+          return Future.error(const ReleaseCheckNetwork());
+        }
+        return Future.value(_release());
+      },
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Retry'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(fetches, greaterThanOrEqualTo(2));
+    expect(find.byType(ReleaseNotesContent), findsOneWidget);
+  });
+
+  testWidgets('Close → dialog dismissed', (tester) async {
+    await _pumpDialog(tester, fetcher: (ref) async => _release());
+    await tester.pumpAndSettle();
+    expect(find.byType(CurrentReleaseDialog), findsOneWidget);
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CurrentReleaseDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## 摘要

- 在設定頁「關於」section 新增「查看更新內容」按鈕，點擊開啟 dialog 顯示**目前安裝版本**對應的 GitHub release notes（Markdown）。
- 補上既有「新版本通知」（只在偵測到更新時跳）所沒有的回顧能力：使用者升到最新版後仍可在 app 內看「我這版做了什麼」。
- 重用既有 `AppReleaseChecker` + `markdown_widget` + `AppDialog` 堆疊；零新增套件依賴。

## 變更內容

- **service**：新增 `fetchReleaseByVersion()` + `ReleaseCheckNotFound`（404）sealed 子類；抽出共用 `_githubGet` 消除與 `fetchNewerReleases` 的網路骨架重複。
- **state**：新增 `currentReleaseProvider` `FutureProvider.family<AppRelease, String>`，自帶 in-memory cache，停用 Riverpod 3 預設指數退避自動重試（重試一律走 `ref.invalidate` 與 dialog 內 [重試] 按鈕）。
- **共用 widget**：把 `_ReleaseCard` 從 `NewVersionDialog` 抽出成公開的 `ReleaseNotesContent`，新舊 dialog 共用，避免重複造輪子。
- **新 dialog**：`CurrentReleaseDialog` 三態（loading skeleton / data / error）。底部按鈕依錯誤類型決定：
  - 成功：[前往 GitHub 查看] [關閉]
  - 404 / rate-limited：[前往 GitHub Releases 頁面] [關閉]（重試無意義）
  - 其他錯誤：[重試] [關閉]
- **設定頁**：版本號右側加 `OutlinedButton.icon`「查看更新內容」，與既有「檢查更新」按鈕並列。
- **i18n**：5 個新 keys（`currentReleaseTitle` / `currentReleaseNotFound` / `currentReleaseOpenOnGithub` / `currentReleaseOpenReleasesPage` / `aboutViewReleaseNotes`），翻譯 9 個非空殼語系（zh / zh_Hans / en / es / fr / ja / pt_BR / th / vi）；22 個空殼語系依專案慣例留給 Crowdin pipeline。
- **Logger**：新增 `release.notes` 樹，記錄 fetch start / success / failure。
- **`AppReleaseNotifier._localizeError` 強化**：把 `ReleaseCheckNotFound() => 'format'` 的 silent fallback 換成 `throw UnsupportedError(...)`，避免未來有人把 `_localizeError` 接到 404-capable 流程時悄悄顯示「格式錯誤」。

## 測試覆蓋

- 13 個新 service 測試（happy + 11 種錯誤情境，含 build metadata strip）。
- 6 個新 state 測試（cache hit、distinct keys、invalidate、AsyncError 各子類）。
- 8 個新 widget 測試（三態渲染、actions 對應、retry / close 互動）。
- 全套 **788 tests pass**、`flutter analyze` 全綠、`dart format` 乾淨。

## 文件

- spec：`docs/superpowers/specs/2026-05-28-current-version-release-notes-design.md`
- plan：`docs/superpowers/plans/2026-05-28-current-version-release-notes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)