### PR TITLE
feat(release): linkify GitHub references in release notes display

### DIFF
--- a/lib/utils/github_release_linkify.dart
+++ b/lib/utils/github_release_linkify.dart
@@ -22,7 +22,7 @@ final RegExp _commitRe = RegExp('(?<![(<])$_repo/commit/([0-9a-fA-F]{7,40})');
 /// 比對 `@提及`：群組 1 為使用者名（GitHub 命名規則），群組 2 為可選的
 /// `[bot]` 後綴。前置 negative lookbehind 擋掉 email／路徑樣式。
 final RegExp _mentionRe = RegExp(
-  r'(?<![A-Za-z0-9._%+@/-])@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(\[bot\])?',
+  r'(?<![A-Za-z0-9._%+@/\[-])@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(\[bot\])?',
 );
 
 /// 把 release notes Markdown [body] 內本專案的 GitHub 連結與 `@提及`，改寫成

--- a/lib/utils/github_release_linkify.dart
+++ b/lib/utils/github_release_linkify.dart
@@ -1,0 +1,50 @@
+import 'package:genshin_impact_wish_gacha_analyzer/data/app_repo.dart';
+
+/// 把 [s] 內的 regex 特殊字元跳脫，使其可安全嵌入 [RegExp] pattern 作為字面值。
+String _escapeRegExp(String s) =>
+    s.replaceAllMapped(RegExp(r'[.*+?^${}()|[\]\\]'), (m) => '\\${m[0]}');
+
+/// 本專案 repo 網址前綴（已 regex 跳脫），供各連結 pattern 共用。
+final String _repo = _escapeRegExp(AppRepo.githubUrl);
+
+/// 比對本 repo PR 連結，捕捉群組 1 為 PR 編號。
+final RegExp _prRe = RegExp('(?<![(<])$_repo/pull/(\\d+)');
+
+/// 比對本 repo Issue 連結，捕捉群組 1 為 Issue 編號。
+final RegExp _issueRe = RegExp('(?<![(<])$_repo/issues/(\\d+)');
+
+/// 比對本 repo compare 連結，捕捉群組 1 為比較區間（例 `v1.0.0...v1.1.0`）。
+final RegExp _compareRe = RegExp('(?<![(<])$_repo/compare/([^\\s)]+)');
+
+/// 比對本 repo commit 連結，捕捉群組 1 為 7～40 碼 SHA。
+final RegExp _commitRe = RegExp('(?<![(<])$_repo/commit/([0-9a-fA-F]{7,40})');
+
+/// 比對 `@提及`：群組 1 為使用者名（GitHub 命名規則），群組 2 為可選的
+/// `[bot]` 後綴。前置 negative lookbehind 擋掉 email／路徑樣式。
+final RegExp _mentionRe = RegExp(
+  r'(?<![A-Za-z0-9._%+@/-])@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(\[bot\])?',
+);
+
+/// 把 release notes Markdown [body] 內本專案的 GitHub 連結與 `@提及`，改寫成
+/// 與 GitHub 網頁一致的精簡顯示樣式：PR/Issue → `#N`、compare → 比較區間、
+/// commit → 前 7 碼短 SHA、`@user` → 使用者連結（`[bot]` → app 連結）。
+///
+/// 純字串轉換、無副作用，供呈現層在丟給 Markdown 渲染器前呼叫；不更動來源
+/// 資料。已是 `[文字](url)` 或 `<url>` 形式的網址不會被重複包裝。
+String linkifyGithubReferences(String body) {
+  var out = body;
+  out = out.replaceAllMapped(_prRe, (m) => '[#${m[1]}](${m[0]})');
+  out = out.replaceAllMapped(_issueRe, (m) => '[#${m[1]}](${m[0]})');
+  out = out.replaceAllMapped(_compareRe, (m) => '[${m[1]}](${m[0]})');
+  out = out.replaceAllMapped(
+    _commitRe,
+    (m) => '[${m[1]!.substring(0, 7)}](${m[0]})',
+  );
+  out = out.replaceAllMapped(_mentionRe, (m) {
+    final name = m[1]!;
+    return m[2] != null
+        ? '[@$name[bot]](https://github.com/apps/$name)'
+        : '[@$name](https://github.com/$name)';
+  });
+  return out;
+}

--- a/lib/widgets/dialogs/release_notes_content.dart
+++ b/lib/widgets/dialogs/release_notes_content.dart
@@ -59,6 +59,7 @@ class ReleaseNotesContent extends StatelessWidget {
               MarkdownBlock(
                 data: linkifyGithubReferences(release.body),
                 config: releaseNotesMarkdownConfig(theme),
+                generator: releaseNotesMarkdownGenerator(),
               ),
           ],
         ),
@@ -75,4 +76,48 @@ MarkdownConfig releaseNotesMarkdownConfig(ThemeData theme) {
   return base.copy(
     configs: [LinkConfig(style: TextStyle(color: linkBaseColor(theme)))],
   );
+}
+
+/// 建立 release notes 專用的 Markdown generator，覆寫連結節點為 [_ReleaseLinkNode]。
+///
+/// markdown_widget 內建的 `LinkNode` 會在每個連結尾端硬塞一個空白 `TextSpan`
+/// （其原始碼註解標為待 Flutter 修正的 workaround），導致連結後緊接文字時多
+/// 一個空格（例 `@GoneTone  in`）。改用 [_ReleaseLinkNode] 移除該尾端空白，
+/// 讓顯示與 GitHub 一致。
+MarkdownGenerator releaseNotesMarkdownGenerator() => MarkdownGenerator(
+  generators: [
+    SpanNodeGeneratorWithTag(
+      tag: MarkdownTag.a.name,
+      generator: (e, config, visitor) =>
+          _ReleaseLinkNode(e.attributes, config.a),
+    ),
+  ],
+);
+
+/// 與內建 `LinkNode` 行為相同，但移除其在連結尾端附加的多餘空白 `TextSpan`。
+///
+/// 透過 `super.build()` 重用上游的點擊與樣式邏輯，僅在結果為「最後一個 child
+/// 是純空白 `TextSpan`」時剝掉它；若上游日後移除該 workaround，最後一個 child
+/// 不再是空白，便自動 no-op，不會把連結與後文黏在一起。
+class _ReleaseLinkNode extends LinkNode {
+  /// 建立 [_ReleaseLinkNode]。
+  _ReleaseLinkNode(super.attributes, super.linkConfig);
+
+  @override
+  InlineSpan build() {
+    final span = super.build();
+    if (span is! TextSpan) return span;
+    final children = span.children;
+    if (children == null || children.isEmpty) return span;
+    final last = children.last;
+    final hasTrailingSpace =
+        last is TextSpan && last.text == ' ' && last.children == null;
+    if (!hasTrailingSpace) return span;
+    return TextSpan(
+      text: span.text,
+      style: span.style,
+      recognizer: span.recognizer,
+      children: children.sublist(0, children.length - 1),
+    );
+  }
 }

--- a/lib/widgets/dialogs/release_notes_content.dart
+++ b/lib/widgets/dialogs/release_notes_content.dart
@@ -4,6 +4,7 @@ import 'package:markdown_widget/markdown_widget.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/app_release_checker.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/github_release_linkify.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/relative_time_text.dart';
 
@@ -56,7 +57,7 @@ class ReleaseNotesContent extends StatelessWidget {
             const SizedBox(height: AppSpacing.s),
             if (release.body.isNotEmpty)
               MarkdownBlock(
-                data: release.body,
+                data: linkifyGithubReferences(release.body),
                 config: releaseNotesMarkdownConfig(theme),
               ),
           ],

--- a/test/utils/github_release_linkify_test.dart
+++ b/test/utils/github_release_linkify_test.dart
@@ -74,6 +74,13 @@ void main() {
     test('autolink <url> 形式不被改寫', () {
       expect(linkifyGithubReferences('<$base/pull/70>'), '<$base/pull/70>');
     });
+
+    test('已是 markdown 連結的 @提及 不再被包一層', () {
+      expect(
+        linkifyGithubReferences('[@GoneTone](https://github.com/GoneTone)'),
+        '[@GoneTone](https://github.com/GoneTone)',
+      );
+    });
   });
 
   group('linkifyGithubReferences — 組合', () {

--- a/test/utils/github_release_linkify_test.dart
+++ b/test/utils/github_release_linkify_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/utils/github_release_linkify.dart';
+
+void main() {
+  const base = 'https://github.com/GoneTone/genshin-impact-wish-gacha-analyzer';
+
+  group('linkifyGithubReferences — 網址型', () {
+    test('PR 連結轉成 #N', () {
+      expect(linkifyGithubReferences('$base/pull/70'), '[#70]($base/pull/70)');
+    });
+
+    test('Issue 連結轉成 #N', () {
+      expect(
+        linkifyGithubReferences('$base/issues/123'),
+        '[#123]($base/issues/123)',
+      );
+    });
+
+    test('compare 連結轉成比較區間', () {
+      expect(
+        linkifyGithubReferences('$base/compare/v1.0.0...v1.1.0'),
+        '[v1.0.0...v1.1.0]($base/compare/v1.0.0...v1.1.0)',
+      );
+    });
+
+    test('commit 連結轉成前 7 碼短 SHA', () {
+      const sha = '0123456789abcdef0123456789abcdef01234567';
+      expect(
+        linkifyGithubReferences('$base/commit/$sha'),
+        '[0123456]($base/commit/$sha)',
+      );
+    });
+  });
+
+  group('linkifyGithubReferences — @提及', () {
+    test('一般使用者轉成個人頁連結', () {
+      expect(
+        linkifyGithubReferences('@GoneTone'),
+        '[@GoneTone](https://github.com/GoneTone)',
+      );
+    });
+
+    test('[bot] 後綴轉成 app 連結並保留 [bot] 顯示', () {
+      expect(
+        linkifyGithubReferences('@dependabot[bot]'),
+        '[@dependabot[bot]](https://github.com/apps/dependabot)',
+      );
+    });
+
+    test('email 樣式不被誤判為提及', () {
+      expect(
+        linkifyGithubReferences('contact foo@example.com please'),
+        'contact foo@example.com please',
+      );
+    });
+  });
+
+  group('linkifyGithubReferences — 不該動的情況', () {
+    test('非 GitHub 網址維持原樣', () {
+      expect(
+        linkifyGithubReferences('https://genshininfo.reh.tw/archives/97'),
+        'https://genshininfo.reh.tw/archives/97',
+      );
+    });
+
+    test('已是 markdown 連結的網址不再被包一層', () {
+      expect(
+        linkifyGithubReferences('[#70]($base/pull/70)'),
+        '[#70]($base/pull/70)',
+      );
+    });
+
+    test('autolink <url> 形式不被改寫', () {
+      expect(linkifyGithubReferences('<$base/pull/70>'), '<$base/pull/70>');
+    });
+  });
+
+  group('linkifyGithubReferences — 組合', () {
+    test('同一行的提及與 PR 連結皆正確轉換', () {
+      expect(
+        linkifyGithubReferences('* feat by @GoneTone in $base/pull/70'),
+        '* feat by [@GoneTone](https://github.com/GoneTone) '
+        'in [#70]($base/pull/70)',
+      );
+    });
+  });
+}

--- a/test/widgets/dialogs/release_notes_content_test.dart
+++ b/test/widgets/dialogs/release_notes_content_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/utils/github_release_linkify.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/release_notes_content.dart';
+
+/// 蒐集目前畫面上所有 [RichText] 的純文字並串接，用來檢查渲染後的空白。
+String _renderedText(WidgetTester tester) {
+  final buffer = StringBuffer();
+  for (final element in find.byType(RichText).evaluate()) {
+    buffer.write((element.widget as RichText).text.toPlainText());
+  }
+  return buffer.toString();
+}
+
+void main() {
+  testWidgets('連結後不應出現 markdown_widget 注入的多餘空格', (tester) async {
+    final data = linkifyGithubReferences(
+      'images by @GoneTone in '
+      'https://github.com/GoneTone/genshin-impact-wish-gacha-analyzer/pull/70',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MarkdownBlock(
+            data: data,
+            config: releaseNotesMarkdownConfig(ThemeData.light()),
+            generator: releaseNotesMarkdownGenerator(),
+          ),
+        ),
+      ),
+    );
+
+    final text = _renderedText(tester);
+    expect(text, contains('@GoneTone in #70'));
+    expect(text, isNot(contains('@GoneTone  in')));
+  });
+}


### PR DESCRIPTION
## 摘要

App 內「更新內容」（`NewVersionDialog` 與 `CurrentReleaseDialog` 共用的 `ReleaseNotesContent`）原本直接把 GitHub Releases API 回傳的原始 Markdown 丟給 `markdown_widget` 渲染，於是 PR、compare 等裸網址會以又長又雜的完整 URL 顯示，與 GitHub 網頁不一致。

本 PR 在渲染前將本專案的 GitHub 連結與 `@提及` 改寫成 GitHub 風格的精簡顯示：

| 來源 | 轉成 |
|---|---|
| `…/pull/70` | `#70` |
| `…/issues/123` | `#123` |
| `…/compare/v1.0.0...v1.1.0` | `v1.0.0...v1.1.0` |
| `…/commit/{40 碼 sha}` | 前 7 碼短 SHA |
| `@GoneTone` | 連到使用者頁 |
| `@dependabot[bot]` | 連到 app 頁 |

## 做法

- 新增純函式 `lib/utils/github_release_linkify.dart`（`linkifyGithubReferences`），以一連串 `RegExp` 改寫；只認本 repo 網址、不動非 GitHub 連結、不重複包裝已是 `[文字](url)`／`<url>` 的連結、不誤判 email。屬呈現層轉換，`AppRelease.body` 維持 API 原樣。
- 接到 `ReleaseNotesContent` 渲染流程（一處改動，兩個 dialog 自動生效）。
- 修正 `markdown_widget` 的渲染副作用：其內建 `LinkNode` 會在每個連結尾端硬塞一個空白 `TextSpan`（上游標為待修的 workaround），導致連結後緊接文字時出現雙空格（`@GoneTone  in`）。以自訂 `_ReleaseLinkNode` 覆寫 `a` 標籤節點移除該尾端空白；上游若移除 workaround 則自動 no-op。

## 測試

- `test/utils/github_release_linkify_test.dart`：六種轉換 + 邊界（非 GitHub 不動、已連結不重複包裝、email 不誤判、組合行）。
- `test/widgets/dialogs/release_notes_content_test.dart`：渲染後連結不應出現多餘空格。
- 全套 `flutter analyze`（`No issues found!`）、`flutter test`（801 passed）皆綠。

設計與計畫文件：`docs/superpowers/specs/2026-05-29-github-release-linkify-design.md`、`docs/superpowers/plans/2026-05-29-github-release-linkify.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)