### PR TITLE
feat(wish): add five-star overview strip on banner/overview pages and share images

### DIFF
--- a/docs/superpowers/plans/2026-05-29-five-star-overview-strip.md
+++ b/docs/superpowers/plans/2026-05-29-five-star-overview-strip.md
@@ -1,0 +1,1296 @@
+# 五星一覽（橫向圓形 Icon 列）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在所有非頌願卡池頁、綜合數據頁祈願段、以及卡池／綜合分享圖最尾端，新增「五星一覽」區塊：去重後每個五星物品一個圓形 Icon，右下角金色徽章標示累計抽到次數。
+
+**Architecture:** 一個純函式 service（`five_star_collection.dart`）把 records 聚合成「不重複五星清單（代表 record + 次數）」，以 HoYoWiki id 為合併鍵（缺則名稱）支援跨語系合併；一個 widget（`FiveStarOverview` + `_FiveStarChip`）以 `Wrap` 呈現，重用既有 `GachaItemIcon`（擴充圓形模式）；banner_page／overview_page／share_card 三處接線。
+
+**Tech Stack:** Flutter、Riverpod、Dart、flutter gen-l10n（ARB）。測試用 `flutter_test`。
+
+參考 spec：`docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md`
+
+---
+
+## 檔案結構
+
+- **Create** `lib/services/five_star_collection.dart` — `FiveStarCollectionItem` + `buildFiveStarCollection` + `buildFiveStarCollectionAcrossBanners`。
+- **Create** `test/services/five_star_collection_test.dart` — 聚合／排序／跨卡池／跨語系／fallback 單元測試。
+- **Create** `lib/widgets/cards/five_star_overview.dart` — `FiveStarOverview` + 私有 `_FiveStarChip`。
+- **Create** `test/widgets/cards/five_star_overview_test.dart` — widget 測試。
+- **Modify** `lib/widgets/gacha_item_icon.dart` — 加 `circular` 參數（圓形模式）。
+- **Modify** `test/widgets/gacha_item_icon_test.dart`（不存在則 Create）— 圓形 placeholder 測試。
+- **Modify** `lib/l10n/app_zh.arb`（template）+ 已翻譯 ARB（`app_zh_Hans` / `app_en` / `app_es` / `app_fr` / `app_ja` / `app_pt_BR` / `app_th` / `app_vi`）— 新增 `fiveStarOverviewTitle`。
+- **Modify** `lib/pages/banner_page.dart` — 記錄列表上方插入五星一覽區塊 + 分享圖 factory 傳 index。
+- **Modify** `lib/pages/overview_page.dart` — 祈願段時間軸上方插入五星一覽 + 分享圖 factory 傳 index。
+- **Modify** `lib/widgets/share/share_card.dart` — factory 加 `index` 參數、build 尾端加五星一覽區塊。
+- **Modify** `test/services/share_image_renderer_test.dart` 或新增 share 測試 — 驗證分享圖含五星一覽。
+
+---
+
+## Task 1: 五星聚合 service
+
+**Files:**
+- Create: `lib/services/five_star_collection.dart`
+- Test: `test/services/five_star_collection_test.dart`
+
+- [ ] **Step 1: 寫失敗測試**
+
+Create `test/services/five_star_collection_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+GachaRecord _r({
+  required String id,
+  required int rank,
+  required DateTime time,
+  String gachaType = '301',
+  String name = 'x',
+  String lang = 'zh-tw',
+}) => GachaRecord(
+  id: id,
+  uid: '1',
+  gachaType: gachaType,
+  name: name,
+  itemType: '角色',
+  rankType: rank,
+  time: time,
+  lang: lang,
+);
+
+void main() {
+  const emptyIndex = HoYoWikiIndex.empty();
+
+  group('buildFiveStarCollection', () {
+    test('empty records → empty list', () {
+      expect(buildFiveStarCollection(const [], index: emptyIndex), isEmpty);
+    });
+
+    test('只取 5★，排除 4★／3★', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 4, name: 'B', time: DateTime(2025, 1, 2)),
+        _r(id: '3', rank: 3, name: 'C', time: DateTime(2025, 1, 3)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(1));
+      expect(result.single.representative.name, 'A');
+      expect(result.single.count, 1);
+    });
+
+    test('同名去重計數，代表 record 取最近一次', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 5, name: 'A', time: DateTime(2025, 3, 1)),
+        _r(id: '3', rank: 5, name: 'A', time: DateTime(2025, 2, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(1));
+      expect(result.single.count, 3);
+      expect(result.single.representative.id, '2'); // 2025-03-01 最近
+    });
+
+    test('排序：次數降冪，同次數以最近時間降冪', () {
+      final records = [
+        _r(id: 'a1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: 'a2', rank: 5, name: 'A', time: DateTime(2025, 1, 2)),
+        _r(id: 'b1', rank: 5, name: 'B', time: DateTime(2025, 5, 1)),
+        _r(id: 'c1', rank: 5, name: 'C', time: DateTime(2025, 4, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      // A=2 → 最前；B/C 各 1，B(5/1) 比 C(4/1) 新 → B 在 C 前
+      expect(result.map((e) => e.representative.name).toList(), ['A', 'B', 'C']);
+    });
+
+    test('跨語系：同 id 不同語系名稱合併為一', () {
+      const index = HoYoWikiIndex(
+        searchMap: {'zh-tw::雷電將軍': '10000052', 'en::Raiden Shogun': '10000052'},
+        entries: {},
+        menuIds: {},
+      );
+      final records = [
+        _r(id: '1', rank: 5, name: '雷電將軍', lang: 'zh-tw', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 5, name: 'Raiden Shogun', lang: 'en', time: DateTime(2025, 2, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: index);
+      expect(result, hasLength(1));
+      expect(result.single.count, 2);
+      expect(result.single.representative.lang, 'en'); // 最近一筆
+    });
+
+    test('fallback：index lookup miss 時以名稱為鍵，不誤併不同物', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 5, name: 'B', time: DateTime(2025, 2, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(2));
+    });
+  });
+
+  group('buildFiveStarCollectionAcrossBanners', () {
+    test('同物品跨卡池合併、次數相加', () {
+      const index = HoYoWikiIndex(
+        searchMap: {'zh-tw::琴': '10000003'},
+        entries: {},
+        menuIds: {},
+      );
+      final banners = {
+        '301': [
+          _r(id: 'c1', rank: 5, name: '琴', time: DateTime(2025, 1, 1)),
+        ],
+        '200': [
+          _r(id: 's1', rank: 5, name: '琴', gachaType: '200', time: DateTime(2025, 3, 1)),
+          _r(id: 's2', rank: 5, name: '琴', gachaType: '200', time: DateTime(2025, 2, 1)),
+        ],
+      };
+      final result = buildFiveStarCollectionAcrossBanners(banners, index: index);
+      expect(result, hasLength(1));
+      expect(result.single.count, 3);
+      expect(result.single.representative.id, 's1'); // 2025-03-01 最近
+    });
+
+    test('empty banners → empty list', () {
+      expect(
+        buildFiveStarCollectionAcrossBanners(const {}, index: emptyIndex),
+        isEmpty,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `flutter test test/services/five_star_collection_test.dart`
+Expected: FAIL（`five_star_collection.dart` 不存在，編譯錯誤）。
+
+- [ ] **Step 3: 寫最小實作**
+
+Create `lib/services/five_star_collection.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+/// 五星一覽聚合的 logger。
+final _log = Logger('wish.fiveStar');
+
+/// 五星一覽的單一條目：一個不重複的五星物品 + 其累計抽到次數。
+@immutable
+class FiveStarCollectionItem {
+  /// 建立 [FiveStarCollectionItem]。
+  const FiveStarCollectionItem({
+    required this.representative,
+    required this.count,
+  });
+
+  /// 該物品最近一次被抽到的紀錄；決定 icon 查找與 tooltip 顯示名稱。
+  final GachaRecord representative;
+
+  /// 該物品（同合併鍵）在來源中被抽到的總次數。
+  final int count;
+}
+
+/// 內部累積桶：記住該合併鍵目前的代表 record（最近一次）與出現次數。
+class _Bucket {
+  /// 以首次遇到的 record 初始化，count 由呼叫端累加。
+  _Bucket(this.representative) : count = 0;
+
+  /// 目前該合併鍵最近一次的 record。
+  GachaRecord representative;
+
+  /// 出現次數。
+  int count;
+}
+
+/// 計算合併鍵：優先用 HoYoWiki id（可跨語系合併），lookup miss 時退化以名稱為鍵。
+String _mergeKey(GachaRecord r, HoYoWikiIndex index) =>
+    index.lookupId(name: r.name, lang: r.lang) ?? r.name;
+
+/// 由單一 records 來源建構五星一覽：取 5★，依合併鍵去重計數，
+/// 依「次數降冪 → 最近抽到時間降冪」排序。
+List<FiveStarCollectionItem> buildFiveStarCollection(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+}) {
+  final buckets = <String, _Bucket>{};
+  for (final r in records) {
+    if (r.rankType != 5) continue;
+    final b = buckets.putIfAbsent(_mergeKey(r, index), () => _Bucket(r));
+    b.count++;
+    if (r.time.isAfter(b.representative.time)) {
+      b.representative = r;
+    }
+  }
+  final items = buckets.values
+      .map(
+        (b) => FiveStarCollectionItem(
+          representative: b.representative,
+          count: b.count,
+        ),
+      )
+      .toList();
+  items.sort((a, b) {
+    final byCount = b.count.compareTo(a.count);
+    if (byCount != 0) return byCount;
+    return b.representative.time.compareTo(a.representative.time);
+  });
+  _log.info('buildFiveStarCollection: ${items.length} unique five-star item(s)');
+  return items;
+}
+
+/// 跨卡池版：攤平所有卡池 records 後委派給 [buildFiveStarCollection]，
+/// 同合併鍵跨卡池累加。
+List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
+  Map<String, List<GachaRecord>> banners, {
+  required HoYoWikiIndex index,
+}) {
+  final all = banners.values.expand((r) => r).toList(growable: false);
+  return buildFiveStarCollection(all, index: index);
+}
+```
+
+- [ ] **Step 4: 執行測試確認通過**
+
+Run: `flutter test test/services/five_star_collection_test.dart`
+Expected: PASS（全部綠）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/five_star_collection.dart test/services/five_star_collection_test.dart
+git commit -m "feat(wish): add five-star collection aggregation service"
+```
+
+---
+
+## Task 2: `GachaItemIcon` 圓形模式
+
+**Files:**
+- Modify: `lib/widgets/gacha_item_icon.dart`
+- Test: `test/widgets/gacha_item_icon_test.dart`（新建）
+
+- [ ] **Step 1: 寫失敗測試**
+
+Create `test/widgets/gacha_item_icon_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+
+GachaRecord _record() => GachaRecord(
+  id: '1',
+  uid: '1',
+  gachaType: '301',
+  name: '夜蘭',
+  itemType: '角色',
+  rankType: 5,
+  time: DateTime(2025, 1, 1),
+  lang: 'zh-tw',
+);
+
+void main() {
+  testWidgets('circular=true → placeholder 用圓形 BoxShape.circle', (tester) async {
+    late Directory tempDir;
+    await tester.runAsync(() async {
+      tempDir = await Directory.systemTemp.createTemp('gacha_icon_test_');
+    });
+    addTearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
+    final container = ProviderContainer(
+      overrides: [
+        hoyowikiIndexStorageProvider.overrideWithValue(
+          HoYoWikiIndexStorage(tempDir),
+        ),
+        hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.runAsync(
+      () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildDarkTheme(),
+          home: Scaffold(
+            body: GachaItemIcon(record: _record(), size: 48, circular: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final deco = tester
+        .widget<Container>(
+          find.descendant(
+            of: find.byType(GachaItemIcon),
+            matching: find.byType(Container),
+          ),
+        )
+        .decoration as BoxDecoration;
+    expect(deco.shape, BoxShape.circle);
+  });
+}
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `flutter test test/widgets/gacha_item_icon_test.dart`
+Expected: FAIL（`circular` 具名參數不存在，編譯錯誤）。
+
+- [ ] **Step 3: 寫最小實作**
+
+Modify `lib/widgets/gacha_item_icon.dart`：
+
+3a. 建構子加 `circular` 參數（`GachaItemIcon` class 內，`size` 後）：
+
+```dart
+  /// 建立 [GachaItemIcon]。
+  const GachaItemIcon({
+    super.key,
+    required this.record,
+    required this.size,
+    this.circular = false,
+  });
+
+  /// 卡池記錄；用其 name / lang / rankType / gachaType。
+  final GachaRecord record;
+
+  /// icon 邊長（px，依使用情境調整：所有宿主一律 32）。
+  final double size;
+
+  /// true 時以圓形裁切／圓形 placeholder 呈現（五星一覽用）。
+  final bool circular;
+```
+
+3b. 在 `build` 內新增私有 helper（放在 `build` 方法上方，class 內）：
+
+```dart
+  /// 依 [circular] 將 icon 圖片裁成圓形或 4px 圓角方塊。
+  Widget _clipIcon(Widget child) => circular
+      ? ClipOval(child: child)
+      : ClipRRect(borderRadius: BorderRadius.circular(4), child: child);
+```
+
+3c. 把 build 內兩處 `ClipRRect(borderRadius: BorderRadius.circular(4), child: ...)` 改用 `_clipIcon(...)`：
+
+preloaded 路徑：
+
+```dart
+        return SizedBox(
+          width: size,
+          height: size,
+          child: _clipIcon(RawImage(image: preloadedImage, fit: BoxFit.cover)),
+        );
+```
+
+file 路徑：
+
+```dart
+        return SizedBox(
+          width: size,
+          height: size,
+          child: _clipIcon(Image.file(file, fit: BoxFit.cover)),
+        );
+```
+
+3d. placeholder 傳入 circular：
+
+```dart
+    return _Placeholder(
+      rankType: record.rankType,
+      size: size,
+      tokens: tokens,
+      circular: circular,
+    );
+```
+
+3e. `_Placeholder` 加 `circular` 欄位並套用 shape：
+
+```dart
+class _Placeholder extends StatelessWidget {
+  /// 建立 [_Placeholder]。
+  const _Placeholder({
+    required this.rankType,
+    required this.size,
+    required this.tokens,
+    this.circular = false,
+  });
+
+  /// 星級（3 / 4 / 5）；決定強調色。
+  final int rankType;
+
+  /// 方塊邊長（px）。
+  final double size;
+
+  /// 主題 token；提供稀有度顏色。
+  final GachaTokens tokens;
+
+  /// true 時以圓形呈現。
+  final bool circular;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = switch (rankType) {
+      5 => tokens.fiveStar,
+      4 => tokens.fourStar,
+      _ => tokens.textMuted,
+    };
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.18),
+        border: Border.all(color: accent.withValues(alpha: 0.40)),
+        shape: circular ? BoxShape.circle : BoxShape.rectangle,
+        borderRadius: circular ? null : BorderRadius.circular(4),
+      ),
+      child: Center(
+        child: Icon(Icons.question_mark, size: size * 0.55, color: accent),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: 執行測試確認通過**
+
+Run: `flutter test test/widgets/gacha_item_icon_test.dart`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/gacha_item_icon.dart test/widgets/gacha_item_icon_test.dart
+git commit -m "feat(wish): add circular mode to GachaItemIcon"
+```
+
+---
+
+## Task 3: `FiveStarOverview` widget
+
+**Files:**
+- Create: `lib/widgets/cards/five_star_overview.dart`
+- Test: `test/widgets/cards/five_star_overview_test.dart`
+
+- [ ] **Step 1: 寫失敗測試**
+
+Create `test/widgets/cards/five_star_overview_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
+
+GachaRecord _r(String id, String name, DateTime time) => GachaRecord(
+  id: id,
+  uid: '1',
+  gachaType: '301',
+  name: name,
+  itemType: '角色',
+  rankType: 5,
+  time: time,
+  lang: 'zh-tw',
+);
+
+Future<ProviderContainer> _container(WidgetTester tester) async {
+  late Directory tempDir;
+  await tester.runAsync(() async {
+    tempDir = await Directory.systemTemp.createTemp('five_star_overview_test_');
+  });
+  addTearDown(() async {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {}
+  });
+  final container = ProviderContainer(
+    overrides: [
+      hoyowikiIndexStorageProvider.overrideWithValue(
+        HoYoWikiIndexStorage(tempDir),
+      ),
+      hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.runAsync(
+    () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+  );
+  return container;
+}
+
+Widget _wrap(ProviderContainer c, Widget child) => UncontrolledProviderScope(
+  container: c,
+  child: MaterialApp(
+    theme: buildDarkTheme(),
+    home: Scaffold(body: SizedBox(width: 800, child: child)),
+  ),
+);
+
+void main() {
+  const emptyIndex = HoYoWikiIndex.empty();
+
+  testWidgets('空清單 → SizedBox.shrink，不顯示任何 chip', (tester) async {
+    final c = await _container(tester);
+    await tester.pumpWidget(_wrap(c, const FiveStarOverview(items: [])));
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsNothing);
+    expect(find.textContaining('×'), findsNothing);
+  });
+
+  testWidgets('顯示每個物品的次數徽章', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+      _r('2', 'A', DateTime(2025, 1, 2)),
+      _r('3', 'B', DateTime(2025, 1, 3)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(_wrap(c, FiveStarOverview(items: items)));
+    await tester.pump();
+    expect(find.text('2'), findsOneWidget); // A 抽到 2 次
+    expect(find.text('1'), findsOneWidget); // B 抽到 1 次
+  });
+
+  testWidgets('interactive=false → 不掛 GachaItemTapTarget', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(
+      _wrap(c, FiveStarOverview(items: items, interactive: false)),
+    );
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsNothing);
+  });
+
+  testWidgets('interactive=true → 掛 GachaItemTapTarget', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(_wrap(c, FiveStarOverview(items: items)));
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `flutter test test/widgets/cards/five_star_overview_test.dart`
+Expected: FAIL（`five_star_overview.dart` 不存在）。
+
+- [ ] **Step 3: 寫最小實作**
+
+Create `lib/widgets/cards/five_star_overview.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+
+/// 圓形 icon 邊長。
+const double _iconSize = 48;
+
+/// 金色外環寬度。
+const double _ringWidth = 2;
+
+/// 徽章高度（直徑）。
+const double _badgeSize = 19;
+
+/// 五星一覽：把不重複五星物品以橫向 [Wrap] 排列，每個 chip 為圓形 icon +
+/// 金色外環 + 右下角累計次數徽章。一行排滿自動換行、不限行數。空清單不顯示。
+class FiveStarOverview extends StatelessWidget {
+  /// 建立 [FiveStarOverview]。
+  const FiveStarOverview({
+    super.key,
+    required this.items,
+    this.interactive = true,
+  });
+
+  /// 聚合後的五星清單（已排序）。
+  final List<FiveStarCollectionItem> items;
+
+  /// true 時 chip 可點開詳情並顯示 tooltip；分享圖（靜態圖）傳 false。
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: AppSpacing.m,
+      runSpacing: AppSpacing.m,
+      children: [
+        for (final item in items)
+          _FiveStarChip(item: item, interactive: interactive),
+      ],
+    );
+  }
+}
+
+/// 單一五星 chip：圓形 icon + 金環 + 右下角次數徽章；[interactive] 時可點 / hover。
+class _FiveStarChip extends StatelessWidget {
+  /// 建立 [_FiveStarChip]。
+  const _FiveStarChip({required this.item, required this.interactive});
+
+  /// 對應的五星條目。
+  final FiveStarCollectionItem item;
+
+  /// 是否可互動。
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final gold = tokens.fiveStar;
+    // 金底徽章上的文字：dark 主題金色偏亮用深字、light 主題金色偏暗用白字，
+    // 兩個主題下都維持足夠對比。
+    final onGold = theme.brightness == Brightness.dark
+        ? tokens.surfaceBackground
+        : Colors.white;
+
+    final stack = SizedBox(
+      width: _iconSize + _ringWidth * 2,
+      height: _iconSize + _ringWidth * 2,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: gold, width: _ringWidth),
+              boxShadow: [
+                BoxShadow(color: gold.withValues(alpha: 0.35), blurRadius: 6),
+              ],
+            ),
+            child: GachaItemIcon(
+              record: item.representative,
+              size: _iconSize,
+              circular: true,
+            ),
+          ),
+          Positioned(
+            right: -2,
+            bottom: -2,
+            child: Container(
+              constraints: const BoxConstraints(minWidth: _badgeSize),
+              height: _badgeSize,
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: gold,
+                borderRadius: BorderRadius.circular(_badgeSize / 2),
+                border: Border.all(color: tokens.surfaceCard, width: 2),
+              ),
+              child: Text(
+                '${item.count}',
+                style: TextStyle(
+                  color: onGold,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (!interactive) return stack;
+    return Tooltip(
+      message: item.representative.name,
+      waitDuration: const Duration(milliseconds: 100),
+      child: GachaItemTapTarget(record: item.representative, child: stack),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: 執行測試確認通過**
+
+Run: `flutter test test/widgets/cards/five_star_overview_test.dart`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/cards/five_star_overview.dart test/widgets/cards/five_star_overview_test.dart
+git commit -m "feat(wish): add FiveStarOverview widget"
+```
+
+---
+
+## Task 4: i18n 字串 `fiveStarOverviewTitle`
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（template，含 @-metadata）
+- Modify: `lib/l10n/app_zh_Hans.arb` / `app_en.arb` / `app_es.arb` / `app_fr.arb` / `app_ja.arb` / `app_pt_BR.arb` / `app_th.arb` / `app_vi.arb`
+
+> 只動已有實體翻譯的 ARB；其餘語系空殼留給 Crowdin pipeline，不要碰。
+
+- [ ] **Step 1: 在 template `app_zh.arb` 新增 key + metadata**
+
+於 `lib/l10n/app_zh.arb` 既有 `pageBannerRecordList` 條目之後加入（若該檔已有對應 `@pageBannerRecordList` metadata，緊接其後）：
+
+```json
+  "fiveStarOverviewTitle": "五星一覽",
+  "@fiveStarOverviewTitle": {
+    "description": "Section title above the record list / timeline showing every unique five-star item the user pulled, each with a badge of how many copies were obtained."
+  },
+```
+
+- [ ] **Step 2: 在各已翻譯 ARB 新增同 key（僅 key:value，無 metadata）**
+
+於每個檔案的 `pageBannerRecordList` 條目之後加入對應翻譯：
+
+- `app_zh_Hans.arb`: `"fiveStarOverviewTitle": "五星一览",`
+- `app_en.arb`: `"fiveStarOverviewTitle": "5-Star Overview",`
+- `app_es.arb`: `"fiveStarOverviewTitle": "Resumen de 5 estrellas",`
+- `app_fr.arb`: `"fiveStarOverviewTitle": "Aperçu 5 étoiles",`
+- `app_ja.arb`: `"fiveStarOverviewTitle": "星5一覧",`
+- `app_pt_BR.arb`: `"fiveStarOverviewTitle": "Visão geral de 5 estrelas",`
+- `app_th.arb`: `"fiveStarOverviewTitle": "ภาพรวม 5 ดาว",`
+- `app_vi.arb`: `"fiveStarOverviewTitle": "Tổng quan 5 sao",`
+
+> 注意 JSON 逗號：插在中間時上一行結尾與本行皆需正確逗號；勿在物件最後一個 key 後留多餘逗號。
+
+- [ ] **Step 3: 重新產生 localizations**
+
+Run: `flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 出現 `String get fiveStarOverviewTitle`。
+
+- [ ] **Step 4: 驗證 analyze 通過**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add fiveStarOverviewTitle string"
+```
+
+---
+
+## Task 5: banner_page 接線
+
+**Files:**
+- Modify: `lib/pages/banner_page.dart`
+
+- [ ] **Step 1: 新增 import**
+
+於 `lib/pages/banner_page.dart` import 區（依字母序插入適當位置）加入：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+```
+
+- [ ] **Step 2: 計算五星清單**
+
+在 `build` 內、`availableItemTypes` 計算之後（`return SingleChildScrollView` 之前）加入：
+
+```dart
+    final fiveStarItems = buildFiveStarCollection(
+      records,
+      index: ref.watch(hoyowikiIndexProvider),
+    );
+```
+
+- [ ] **Step 3: 在記錄列表標題上方插入區塊**
+
+把現有這段：
+
+```dart
+          const SizedBox(height: AppSpacing.xl),
+          InlineSectionTitle(
+            icon: Icons.table_chart_outlined,
+            title: l.pageBannerRecordList,
+          ),
+```
+
+改為：
+
+```dart
+          const SizedBox(height: AppSpacing.xl),
+          if (fiveStarItems.isNotEmpty) ...[
+            InlineSectionTitle(
+              icon: Icons.star_outline,
+              title: l.fiveStarOverviewTitle,
+            ),
+            const SizedBox(height: AppSpacing.s),
+            FiveStarOverview(items: fiveStarItems),
+            const SizedBox(height: AppSpacing.xl),
+          ],
+          InlineSectionTitle(
+            icon: Icons.table_chart_outlined,
+            title: l.pageBannerRecordList,
+          ),
+```
+
+- [ ] **Step 4: 驗證 analyze 通過**
+
+Run: `flutter analyze lib/pages/banner_page.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pages/banner_page.dart
+git commit -m "feat(wish): show five-star overview above banner record list"
+```
+
+---
+
+## Task 6: overview_page 接線（僅祈願段）
+
+**Files:**
+- Modify: `lib/pages/overview_page.dart`
+
+- [ ] **Step 1: 新增 import**
+
+加入：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+```
+
+- [ ] **Step 2: `_OverviewSection` 加參數**
+
+於 `_OverviewSection` 建構子末尾加入具名參數（預設空 → odes 段不傳即不顯示）：
+
+```dart
+  const _OverviewSection({
+    required this.title,
+    required this.types,
+    required this.banners,
+    required this.stats,
+    required this.bannerColors,
+    required this.statCards,
+    required this.emptyTitle,
+    required this.timeline,
+    required this.timelineNowPulls,
+    required this.timelineRank,
+    this.fiveStarItems = const [],
+  });
+```
+
+並在欄位宣告區（`timelineRank` 欄位之後）加入：
+
+```dart
+  /// 此段的五星一覽清單；空清單時不顯示該區塊（odes 段一律空）。
+  final List<FiveStarCollectionItem> fiveStarItems;
+```
+
+- [ ] **Step 3: 祈願段傳入聚合清單**
+
+在 `OverviewPage.build` 內，gacha 段的 `_OverviewSection(...)` 呼叫加入 `fiveStarItems`：
+
+```dart
+          _OverviewSection(
+            title: l.pageOverviewGachaSection,
+            types: gachaSec.types,
+            banners: gachaSec.banners,
+            stats: gachaSec.stats,
+            bannerColors: bannerColors,
+            statCards: gachaStatCards,
+            emptyTitle: l.emptyNoGachaRecords,
+            timeline: gachaSec.timeline,
+            timelineNowPulls: gachaSec.timelineNowPulls,
+            timelineRank: gachaSec.timelineRank,
+            fiveStarItems: buildFiveStarCollectionAcrossBanners(
+              gachaSec.banners,
+              index: ref.watch(hoyowikiIndexProvider),
+            ),
+          ),
+```
+
+odes 段的 `_OverviewSection(...)` **不加** `fiveStarItems`（維持預設空）。
+
+- [ ] **Step 4: 在 timeline 標題上方插入區塊**
+
+於 `_OverviewSection.build` 內，把現有這段：
+
+```dart
+        const SizedBox(height: AppSpacing.xl),
+        InlineSectionTitle(
+          icon: Icons.timeline,
+          title: l.timelineTopRarityTitle(
+            l.rarityStar(timelineRank),
+            timeline.length,
+          ),
+        ),
+```
+
+改為：
+
+```dart
+        const SizedBox(height: AppSpacing.xl),
+        if (fiveStarItems.isNotEmpty) ...[
+          InlineSectionTitle(
+            icon: Icons.star_outline,
+            title: l.fiveStarOverviewTitle,
+          ),
+          const SizedBox(height: AppSpacing.s),
+          FiveStarOverview(items: fiveStarItems),
+          const SizedBox(height: AppSpacing.xl),
+        ],
+        InlineSectionTitle(
+          icon: Icons.timeline,
+          title: l.timelineTopRarityTitle(
+            l.rarityStar(timelineRank),
+            timeline.length,
+          ),
+        ),
+```
+
+- [ ] **Step 5: 驗證 analyze 通過**
+
+Run: `flutter analyze lib/pages/overview_page.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/pages/overview_page.dart
+git commit -m "feat(wish): show five-star overview in overview gacha section"
+```
+
+---
+
+## Task 7: 分享圖接線（尾端五星一覽）
+
+**Files:**
+- Modify: `lib/widgets/share/share_card.dart`
+- Modify: `lib/pages/banner_page.dart`（`_generateBannerShare` 傳 index）
+- Modify: `lib/pages/overview_page.dart`（`_generateOverviewShare` 傳 index）
+- Test: `test/widgets/cards/share_card_five_star_test.dart`（新建）
+
+- [ ] **Step 1: 寫失敗測試**
+
+Create `test/widgets/cards/share_card_five_star_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/share_image_options.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/preloaded_hoyowiki_images.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/share_card.dart';
+
+Future<ui.Image> _solidImage() async {
+  final recorder = ui.PictureRecorder();
+  Canvas(recorder).drawRect(
+    const Rect.fromLTWH(0, 0, 4, 4),
+    Paint()..color = const Color(0xFFFFFFFF),
+  );
+  return recorder.endRecording().toImage(4, 4);
+}
+
+void main() {
+  testWidgets('banner 分享圖含 FiveStarOverview（含 5★ 時）', (tester) async {
+    late Directory tempDir;
+    await tester.runAsync(() async {
+      tempDir = await Directory.systemTemp.createTemp('share_five_star_test_');
+    });
+    addTearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
+    final container = ProviderContainer(
+      overrides: [
+        hoyowikiIndexStorageProvider.overrideWithValue(
+          HoYoWikiIndexStorage(tempDir),
+        ),
+        hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.runAsync(
+      () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+    );
+
+    final icon = await tester.runAsync(_solidImage);
+    addTearDown(() => icon!.dispose());
+
+    final records = [
+      GachaRecord(
+        id: '1',
+        uid: '100000001',
+        gachaType: '301',
+        name: '夜蘭',
+        itemType: '角色',
+        rankType: 5,
+        time: DateTime(2025, 4, 1),
+        lang: 'zh-tw',
+      ),
+    ];
+
+    late AppLocalizations l;
+    final card = Builder(
+      builder: (ctx) {
+        l = AppLocalizations.of(ctx)!;
+        return ShareCard.banner(
+          l: l,
+          appVersion: '1.0.0',
+          appIcon: icon!,
+          options: const ShareImageOptions(
+            brightness: Brightness.dark,
+            showFullUid: true,
+          ),
+          uid: '100000001',
+          updatedAt: DateTime(2025, 4, 1),
+          title: 'Test',
+          records: records,
+          targetRank: 5,
+          index: container.read(hoyowikiIndexProvider),
+        );
+      },
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildDarkTheme(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PreloadedHoYoWikiImages(
+                images: const {},
+                child: card,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(FiveStarOverview), findsOneWidget);
+    expect(find.text(l.fiveStarOverviewTitle), findsOneWidget);
+  });
+}
+```
+
+> `ShareImageOptions` 建構子若參數名與此處不同，請依實際定義調整（`brightness` / `showFullUid`）。
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `flutter test test/widgets/cards/share_card_five_star_test.dart`
+Expected: FAIL（`ShareCard.banner` 無 `index` 具名參數，編譯錯誤）。
+
+- [ ] **Step 3a: share_card.dart 新增 import**
+
+於 `lib/widgets/share/share_card.dart` import 區加入：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+```
+
+- [ ] **Step 3b: 私有建構子加欄位**
+
+把 `ShareCard._({...})` 改為帶 `fiveStar`：
+
+```dart
+  const ShareCard._({
+    required this.l,
+    required this.appVersion,
+    required this.appIcon,
+    required this.options,
+    required this.uid,
+    required this.updatedAt,
+    required List<_Section> sections,
+    required List<FiveStarCollectionItem> fiveStar,
+  }) : _sections = sections,
+       _fiveStar = fiveStar;
+```
+
+並在欄位宣告區（`final List<_Section> _sections;` 之後）加入：
+
+```dart
+  /// 尾端五星一覽清單（banner = 該池；overview = 跨祈願卡池合併）。
+  final List<FiveStarCollectionItem> _fiveStar;
+```
+
+- [ ] **Step 3c: `ShareCard.banner` factory 加 `index` 並算清單**
+
+簽名加入 `required HoYoWikiIndex index,`（放 `targetRank` 之後）。`return ShareCard._(` 內加入：
+
+```dart
+      fiveStar: buildFiveStarCollection(records, index: index),
+```
+
+- [ ] **Step 3d: `ShareCard.overview` factory 加 `index` 並算清單**
+
+簽名加入 `required HoYoWikiIndex index,`（放 `banners` 之後）。`return ShareCard._(` 內加入（`s` 即既有 `buildOverviewSections(banners)` 結果）：
+
+```dart
+      fiveStar: buildFiveStarCollectionAcrossBanners(s.gacha.banners, index: index),
+```
+
+- [ ] **Step 3e: build 尾端加入五星一覽區塊**
+
+於 `build` 的 `content` Column，`for (...) ... _SectionView(...)` 迴圈結束後（`children: [` 的最後一個元素）加入：
+
+```dart
+        if (_fiveStar.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xl),
+          Divider(color: tokens.borderEmphasis, height: 1, thickness: 1),
+          const SizedBox(height: AppSpacing.xl),
+          Text(l.fiveStarOverviewTitle, style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: AppSpacing.m),
+          FiveStarOverview(items: _fiveStar, interactive: false),
+        ],
+```
+
+- [ ] **Step 4: 更新呼叫端傳 index**
+
+4a. `lib/pages/banner_page.dart` 的 `_generateBannerShare` 內 `ShareCard.banner(...)` 加入：
+
+```dart
+        targetRank: type.primaryPity.rank,
+        index: ref.read(hoyowikiIndexProvider),
+```
+
+（`ShareCard.banner` 已在 `buildCard` callback 中，`ref` 為 `_generateBannerShare` 參數。）
+
+4b. `lib/pages/overview_page.dart` 的 `_generateOverviewShare` 內 `ShareCard.overview(...)` 加入：
+
+```dart
+        banners: activeData.banners,
+        index: ref.read(hoyowikiIndexProvider),
+```
+
+> 兩處 import（`state/hoyowiki_index.dart`）已於 Task 5 / 6 加入。
+
+- [ ] **Step 5: 執行測試確認通過**
+
+Run: `flutter test test/widgets/cards/share_card_five_star_test.dart`
+Expected: PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/widgets/share/share_card.dart lib/pages/banner_page.dart lib/pages/overview_page.dart test/widgets/cards/share_card_five_star_test.dart
+git commit -m "feat(wish): append five-star overview to share image"
+```
+
+---
+
+## Task 8: 全套品質檢查
+
+**Files:** 無（驗證用）
+
+- [ ] **Step 1: 格式化**
+
+Run: `dart format lib/ test/`
+Expected: 列出已格式化檔案；無錯誤。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: 全套測試**
+
+Run: `flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 視覺確認（手動）**
+
+Run: `flutter run -d windows`（或既有 run 流程）
+確認：
+- 角色／武器等卡池頁、綜合頁祈願段「祈願記錄列表／時間軸」上方出現「五星一覽」圓形 icon 列，徽章次數正確、可點開詳情、hover 顯名。
+- 頌願個別頁與綜合頁頌願段**無**此區塊。
+- 卡池分享圖、綜合分享圖最尾端各有「五星一覽」。
+- 無五星紀錄時整段隱藏。
+
+- [ ] **Step 5: 最終 commit（若格式化有改動）**
+
+```bash
+git add -A
+git commit -m "style: format five-star overview feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 去重 + 計數、恆顯示 → Task 1（聚合）+ Task 3（徽章恆顯示，無 count==1 隱藏邏輯）。✓
+- 合併鍵 HoYoWiki id + name fallback → Task 1 `_mergeKey`，測試涵蓋跨語系與 miss fallback。✓
+- 代表 record 取最近一次 → Task 1（`isAfter` 更新），測試涵蓋。✓
+- 排序次數降冪 + 最近時間 tie-break → Task 1 sort，測試涵蓋。✓
+- 跨卡池合併、次數相加 → Task 1 across-banners，測試涵蓋。✓
+- 樣式 A（金環 + 圓形數字徽章、48px）→ Task 2 + Task 3。✓
+- 圓形 icon 重用 GachaItemIcon → Task 2 擴充。✓
+- 互動（點擊詳情 / tooltip）僅 App、分享圖靜態 → Task 3 `interactive`。✓
+- 空清單隱藏 → Task 3 `SizedBox.shrink` + 各頁 `if (...isNotEmpty)`。✓
+- banner_page 記錄列表上方 → Task 5。✓
+- overview 祈願段時間軸上方、頌願不動 → Task 6（odes 不傳 `fiveStarItems`）。✓
+- 分享圖尾端（卡池 = 該池、綜合 = 跨祈願卡池合併）→ Task 7。✓
+- i18n `fiveStarOverviewTitle`、繁中起手、只翻已翻 ARB → Task 4。✓
+- 埋 log（`wish.fiveStar`）→ Task 1。✓
+- 測試（聚合/排序/跨卡池/跨語系/空、widget 徽章/排序/空/interactive、分享圖 smoke、ImageCache tearDown）→ Task 1/3/7（tempDir tearDown 已含；本功能 widget 測試用空 index 走 placeholder，不解碼圖檔，無 ImageCache race 風險）。✓
+
+**Placeholder scan：** 無 TODO／TBD；所有 step 含實際程式碼或精確指令。
+
+**Type consistency：** `FiveStarCollectionItem`（`representative` / `count`）、`buildFiveStarCollection(records, {index})`、`buildFiveStarCollectionAcrossBanners(banners, {index})`、`FiveStarOverview({items, interactive})`、`GachaItemIcon(..., circular)`、`ShareCard.banner(..., index)` / `ShareCard.overview(..., index)` 跨 Task 命名一致。

--- a/docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md
+++ b/docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md
@@ -1,0 +1,117 @@
+# 五星一覽（橫向圓形 Icon 列）設計
+
+## 背景與目標
+
+在各祈願頁面與綜合數據頁，使用者目前只能透過時間軸與記錄列表逐筆看五星，缺少一個「我在這個卡池／整體祈願總共抽到哪些五星、各抽到幾份」的總覽視圖。
+
+本功能新增一個「五星一覽」區塊：把該範圍內所有不重複的五星物品，以**橫向排列的圓形 Icon**呈現，每個 Icon 右下角標示該物品**累計被抽到的次數**。一行排滿後自動往下換行，不限行數。
+
+## 範圍
+
+套用於下列三處：
+
+1. **所有非頌願卡池頁**（`BannerPage`）：角色、武器、常駐、集約、新手、已結束等卡池；頌願（odes，`gachaType` `2000` / `1000`）不套用。
+2. **綜合數據頁的祈願段**（`OverviewPage` 的 gacha section）：頌願段完全不動。
+3. **分享圖**（`ShareCard`）：卡池分享圖與綜合分享圖，皆放在整張圖的**最尾端**。
+
+頌願（頌願個別頁、綜合頁頌願段、分享圖頌願段）一律不納入本功能。
+
+## 核心語意
+
+- **去重 + 計數**：每個不重複的五星物品只有一個圓形 Icon；右下角徽章 = 該物品在範圍內被抽到的**總次數（份數）**，恆顯示（次數為 1 也顯示「1」）。
+- **合併鍵**：以**物品名稱**（`GachaRecord.name`）為鍵。單一帳號內語系一致，同名即同物。
+- **代表 record**：取該物品**最近一次**被抽到的 `GachaRecord`，用其 `name` / `lang` / `gachaType` 餵 `GachaItemIcon` 做圖示查找與 tooltip。
+- **排序**：依 `count` **降冪**；次數相同時，以「最近抽到時間」**降冪**作為 tie-break（抽到次數最多者排最前，左上起逐行往下）。
+- **綜合頁／綜合分享圖**：同物品**跨祈願卡池合併、次數相加**（例如某常駐五星在角色池與常駐池都出過，算同一個，次數累加），形成一條合併的五星一覽。
+- **卡池頁／卡池分享圖**：僅該卡池自身的 records。
+
+## 視覺樣式（已選定方案 A）
+
+- **圓形 Icon**：邊長 48px（預設值，實作時若觀感需要可微調），使用 HoYoWiki 物品圖示；缺圖時沿用 `GachaItemIcon` 既有 placeholder。
+- **外環**：統一 2px **金色**外環（`GachaTokens.fiveStar`，呼應五星），附輕微金色光暈。
+- **徽章**：右下角金底深字圓形徽章，僅放數字，外圍以卡片底色描邊與 Icon 區隔。
+- **互動**（僅 App 頁面）：Icon 可點擊開啟物品詳情 dialog（`GachaItemTapTarget`），hover 顯示物品名 `Tooltip`，滑鼠游標 `SystemMouseCursors.click`。分享圖為靜態圖，chip 不帶互動。
+- **排版**：`Wrap` 左對齊、隨容器寬度自動換行、不限行數，由 `Wrap` 處理 RWD，不會爆版。
+- **空狀態**：範圍內無任何五星時，整個區塊（含標題）不顯示。
+
+## 架構與元件
+
+### 1. 資料聚合（新檔 `lib/services/five_star_collection.dart`）
+
+純函式 + 不可變資料類，不依賴 Flutter widget，便於單元測試：
+
+```dart
+@immutable
+class FiveStarCollectionItem {
+  final GachaRecord representative; // 最近一次抽到的紀錄；決定 icon 與 tooltip
+  final int count;                  // 該物品被抽到的總次數
+}
+
+/// 單一 records 來源：取 rankType == 5，依 name 合併計數，依規則排序。
+List<FiveStarCollectionItem> buildFiveStarCollection(List<GachaRecord> records);
+
+/// 跨卡池：合併多卡池後，同 name 跨卡池累加，再依規則排序。
+List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
+  Map<String, List<GachaRecord>> banners,
+);
+```
+
+- 跨卡池版可在內部攤平所有 records 後委派給單一版的合併邏輯，避免重複。
+- 關鍵節點埋 `Logger('wish.fiveStar')`：聚合後不重複物品數、跨卡池合併前後筆數等；敏感資料沿用既有脫敏規則（本功能不涉 URL／UID，主要記數量級 context）。
+
+### 2. 呈現 widget（新檔 `lib/widgets/cards/five_star_overview.dart`）
+
+- `FiveStarOverview`：接收 `List<FiveStarCollectionItem>`，以 `Wrap`（`spacing` / `runSpacing` 用 `AppSpacing`）排列 `_FiveStarChip`；空清單回傳 `SizedBox.shrink()`。提供 `interactive`（預設 `true`）參數，分享圖傳 `false`。
+- `_FiveStarChip`（私有）：48px 圓形 `GachaItemIcon`（見下方擴充）+ 金色外環 + 右下角數字徽章；`interactive` 為真時外包 `GachaItemTapTarget` 與 `Tooltip`。
+
+### 3. `GachaItemIcon` 擴充（`lib/widgets/gacha_item_icon.dart`）
+
+- 新增可選參數讓它能渲染**圓形**（例如 `shape: BoxShape.rectangle`（預設）/ `circle`，或 `circular: false` 預設），預設行為與既有圓角方塊完全一致，時間軸等既有 callsite 零影響。
+- 金環與徽章不進 `GachaItemIcon`（保持其單一職責），留在 `_FiveStarChip`。
+
+### 4. 版面定位
+
+- **`banner_page.dart`**：在「祈願記錄列表」`InlineSectionTitle`（現約 `:296`）**上方**插入獨立區塊：
+  `InlineSectionTitle(icon: Icons.star_outline, title: l.fiveStarOverviewTitle)` + `FiveStarOverview(items: buildFiveStarCollection(records))`。無五星時整段隱藏。
+- **`overview_page.dart`**：`_OverviewSection` 新增一個可選參數（聚合後的 `List<FiveStarCollectionItem>`，或預建好的 widget），**只在 gacha 段**傳入；放在時間軸 `InlineSectionTitle`（現約 `:398`）**上方**。odes 段不傳 → 完全不動。
+
+### 5. 分享圖（`lib/widgets/share/share_card.dart`）
+
+- `ShareCard.banner`：以 `records` 算 `buildFiveStarCollection(records)`。
+- `ShareCard.overview`：以 `buildOverviewSections(banners).gacha.banners` 算 `buildFiveStarCollectionAcrossBanners(...)`（僅祈願卡池）。
+- 在 `build` 的 `content` Column **最尾端**（所有 `_SectionView` 之後）加一個 `_FiveStarShareSection`：標題（`l.fiveStarOverviewTitle`）+ `FiveStarOverview(interactive: false)`。資料於 factory 階段算好存入欄位，build 階段渲染。
+- 圖示渲染：沿用既有 `PreloadedHoYoWikiImages` + `UncontrolledProviderScope` 機制（`buildShareRenderTree` 已具備），`recordsForPreload` 既已涵蓋所需 records（卡池 = 該池；綜合 = 全卡池），無需新增預載管線。
+- 分享圖寬固定 1200px、高隨內容自適應；`Wrap` 自然增高即可，不需裁切。
+
+### 6. i18n
+
+- 新增字串 key `fiveStarOverviewTitle`，值「五星一覽」。
+- 先寫 `app_zh.arb`，再以繁中為基準翻譯至**已有實體翻譯**的 ARB；空殼 ARB 不碰（留給 Crowdin pipeline）。
+- 徽章僅數字、tooltip 用物品名，無需額外字串。
+
+## 錯誤處理與邊界
+
+- 缺圖：`GachaItemIcon` 既有 placeholder。
+- 物品數量很多：`Wrap` 自然換行；分享圖隨之增高（符合「放最尾端、不限行數」的需求）。
+- 無五星：整段（含標題）隱藏。
+- 頌願：`GachaItemIcon` 對 odes 本就回傳空，且本功能不在頌願範圍佈署，雙重保險。
+
+## 測試
+
+- **單元測試**（`buildFiveStarCollection` / `buildFiveStarCollectionAcrossBanners`）：
+  - 去重計數正確；
+  - 排序：次數降冪、同次數以最近時間降冪 tie-break；
+  - 跨卡池同名合併、次數相加；
+  - 只取 5★（排除 4★／3★）；
+  - 空輸入回傳空清單；
+  - 代表 record 取最近一次。
+- **Widget 測試**（`FiveStarOverview`）：徽章數字正確、Icon 依排序呈現、空清單不顯示、`interactive: false` 不掛 tap target / tooltip。
+- **分享圖**：可加一個離屏渲染 smoke test，確認尾端區塊存在且不崩。
+- 若 `testWidgets` 用到 tempDir 圖檔，`tearDown` 需清 `ImageCache`，避免跨測試 codec race（見既有慣例）。
+
+## 不做（YAGNI）
+
+- 不為單卡池頁加卡池色環（方案 A 統一金環）。
+- 不加「展開／收合」「載入更多」「上限 N 個」等控制；既然需求是不限行數，全部顯示。
+- 不動頌願任何呈現。
+- 不為跨卡池合併引入 HoYoWiki id 作為合併鍵（名稱足夠；單帳號語系一致）。

--- a/docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md
+++ b/docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md
@@ -19,8 +19,8 @@
 ## 核心語意
 
 - **去重 + 計數**：每個不重複的五星物品只有一個圓形 Icon；右下角徽章 = 該物品在範圍內被抽到的**總次數（份數）**，恆顯示（次數為 1 也顯示「1」）。
-- **合併鍵**：以**物品名稱**（`GachaRecord.name`）為鍵。單一帳號內語系一致，同名即同物。
-- **代表 record**：取該物品**最近一次**被抽到的 `GachaRecord`，用其 `name` / `lang` / `gachaType` 餵 `GachaItemIcon` 做圖示查找與 tooltip。
+- **合併鍵**：以 **HoYoWiki id** 為鍵（`HoYoWikiIndex.lookupId(name, lang)`）。如此跨語系匯入的資料（同一物品在不同語系名稱不同，例如「雷電將軍」／「Raiden Shogun」）能正確合併為同一個。lookup miss（index 無對應或尚未快取）時 fallback 用 `name` 當鍵（即 `key = id ?? name`），無法跨語系合併屬可接受的退化情形。
+- **代表 record**：取該物品（同合併鍵中）**最近一次**被抽到的 `GachaRecord`，用其 `name` / `lang` / `gachaType` 餵 `GachaItemIcon` 做圖示查找與 tooltip。圖示以 id 查找，跨語系合併時任一代表皆可正確顯圖；tooltip 顯示最近一筆的名稱（其語系）。
 - **排序**：依 `count` **降冪**；次數相同時，以「最近抽到時間」**降冪**作為 tie-break（抽到次數最多者排最前，左上起逐行往下）。
 - **綜合頁／綜合分享圖**：同物品**跨祈願卡池合併、次數相加**（例如某常駐五星在角色池與常駐池都出過，算同一個，次數累加），形成一條合併的五星一覽。
 - **卡池頁／卡池分享圖**：僅該卡池自身的 records。
@@ -47,16 +47,23 @@ class FiveStarCollectionItem {
   final int count;                  // 該物品被抽到的總次數
 }
 
-/// 單一 records 來源：取 rankType == 5，依 name 合併計數，依規則排序。
-List<FiveStarCollectionItem> buildFiveStarCollection(List<GachaRecord> records);
+/// 單一 records 來源：取 rankType == 5，依「HoYoWiki id（缺則 name）」合併
+/// 計數，依規則排序。
+List<FiveStarCollectionItem> buildFiveStarCollection(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+});
 
-/// 跨卡池：合併多卡池後，同 name 跨卡池累加，再依規則排序。
+/// 跨卡池：合併多卡池後，同合併鍵跨卡池累加，再依規則排序。
 List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
-  Map<String, List<GachaRecord>> banners,
-);
+  Map<String, List<GachaRecord>> banners, {
+  required HoYoWikiIndex index,
+});
 ```
 
+- 合併鍵由內部 helper 計算：`index.lookupId(name, lang) ?? name`。
 - 跨卡池版可在內部攤平所有 records 後委派給單一版的合併邏輯，避免重複。
+- `index` 由呼叫端從 `hoyowikiIndexProvider` 取得（頁面 / 分享圖流程皆已可存取）。
 - 關鍵節點埋 `Logger('wish.fiveStar')`：聚合後不重複物品數、跨卡池合併前後筆數等；敏感資料沿用既有脫敏規則（本功能不涉 URL／UID，主要記數量級 context）。
 
 ### 2. 呈現 widget（新檔 `lib/widgets/cards/five_star_overview.dart`）
@@ -72,13 +79,14 @@ List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
 ### 4. 版面定位
 
 - **`banner_page.dart`**：在「祈願記錄列表」`InlineSectionTitle`（現約 `:296`）**上方**插入獨立區塊：
-  `InlineSectionTitle(icon: Icons.star_outline, title: l.fiveStarOverviewTitle)` + `FiveStarOverview(items: buildFiveStarCollection(records))`。無五星時整段隱藏。
-- **`overview_page.dart`**：`_OverviewSection` 新增一個可選參數（聚合後的 `List<FiveStarCollectionItem>`，或預建好的 widget），**只在 gacha 段**傳入；放在時間軸 `InlineSectionTitle`（現約 `:398`）**上方**。odes 段不傳 → 完全不動。
+  `InlineSectionTitle(icon: Icons.star_outline, title: l.fiveStarOverviewTitle)` + `FiveStarOverview(items: buildFiveStarCollection(records, index: ref.watch(hoyowikiIndexProvider)))`。無五星時整段隱藏。
+- **`overview_page.dart`**：`_OverviewSection` 新增一個可選參數（聚合後的 `List<FiveStarCollectionItem>`，或預建好的 widget），**只在 gacha 段**傳入（以 `buildFiveStarCollectionAcrossBanners(gachaSec.banners, index: ...)` 算得）；放在時間軸 `InlineSectionTitle`（現約 `:398`）**上方**。odes 段不傳 → 完全不動。
 
 ### 5. 分享圖（`lib/widgets/share/share_card.dart`）
 
-- `ShareCard.banner`：以 `records` 算 `buildFiveStarCollection(records)`。
-- `ShareCard.overview`：以 `buildOverviewSections(banners).gacha.banners` 算 `buildFiveStarCollectionAcrossBanners(...)`（僅祈願卡池）。
+- 兩個 factory 皆新增 `required HoYoWikiIndex index` 參數；呼叫端（`banner_page._generateBannerShare` / `overview_page._generateOverviewShare`）從 `ref.read(hoyowikiIndexProvider)` 傳入（`generateAndShareImage` 流程同一容器已可取得）。
+- `ShareCard.banner`：以 `records` 算 `buildFiveStarCollection(records, index: index)`。
+- `ShareCard.overview`：以 `buildOverviewSections(banners).gacha.banners` 算 `buildFiveStarCollectionAcrossBanners(..., index: index)`（僅祈願卡池）。
 - 在 `build` 的 `content` Column **最尾端**（所有 `_SectionView` 之後）加一個 `_FiveStarShareSection`：標題（`l.fiveStarOverviewTitle`）+ `FiveStarOverview(interactive: false)`。資料於 factory 階段算好存入欄位，build 階段渲染。
 - 圖示渲染：沿用既有 `PreloadedHoYoWikiImages` + `UncontrolledProviderScope` 機制（`buildShareRenderTree` 已具備），`recordsForPreload` 既已涵蓋所需 records（卡池 = 該池；綜合 = 全卡池），無需新增預載管線。
 - 分享圖寬固定 1200px、高隨內容自適應；`Wrap` 自然增高即可，不需裁切。
@@ -101,7 +109,9 @@ List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
 - **單元測試**（`buildFiveStarCollection` / `buildFiveStarCollectionAcrossBanners`）：
   - 去重計數正確；
   - 排序：次數降冪、同次數以最近時間降冪 tie-break；
-  - 跨卡池同名合併、次數相加；
+  - 跨卡池同物品合併、次數相加；
+  - **跨語系合併**：同 id 不同語系名稱（例如「雷電將軍」／「Raiden Shogun」）合併為一；
+  - **fallback**：index lookup miss 時退化以 name 為鍵，不誤併不同物；
   - 只取 5★（排除 4★／3★）；
   - 空輸入回傳空清單；
   - 代表 record 取最近一次。
@@ -114,4 +124,3 @@ List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
 - 不為單卡池頁加卡池色環（方案 A 統一金環）。
 - 不加「展開／收合」「載入更多」「上限 N 個」等控制；既然需求是不限行數，全部顯示。
 - 不動頌願任何呈現。
-- 不為跨卡池合併引入 HoYoWiki id 作為合併鍵（名稱足夠；單帳號語系一致）。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "Wish Overview",
   "pageOverviewOdesSection": "Odes Overview",
   "pageBannerRecordList": "Record list",
+  "fiveStarOverviewTitle": "5-Star Overview",
   "settingsTitle": "Settings",
   "settingsAppearance": "Appearance",
   "settingsThemeSystem": "Follow system",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "Resumen de Gachapón",
   "pageOverviewOdesSection": "Resumen de Odas",
   "pageBannerRecordList": "Lista de registros",
+  "fiveStarOverviewTitle": "Resumen de 5 estrellas",
   "settingsTitle": "Configuración",
   "settingsAppearance": "Apariencia",
   "settingsThemeSystem": "Seguir el sistema",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "Vue d'ensemble des vœux",
   "pageOverviewOdesSection": "Vue d'ensemble des odes",
   "pageBannerRecordList": "Liste des enregistrements",
+  "fiveStarOverviewTitle": "Aperçu 5 étoiles",
   "settingsTitle": "Paramètres",
   "settingsAppearance": "Apparence",
   "settingsThemeSystem": "Suivre le système",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "祈願総合",
   "pageOverviewOdesSection": "星願総合",
   "pageBannerRecordList": "記録一覧",
+  "fiveStarOverviewTitle": "星5一覧",
   "settingsTitle": "設定",
   "settingsAppearance": "外観",
   "settingsThemeSystem": "システムに合わせる",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "Resumo de Orações",
   "pageOverviewOdesSection": "Resumo de Odes",
   "pageBannerRecordList": "Lista de registros",
+  "fiveStarOverviewTitle": "Visão geral de 5 estrelas",
   "settingsTitle": "Configurações",
   "settingsAppearance": "Aparência",
   "settingsThemeSystem": "Seguir sistema",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "สรุปการอธิษฐาน",
   "pageOverviewOdesSection": "สรุปภาวนา",
   "pageBannerRecordList": "รายการบันทึก",
+  "fiveStarOverviewTitle": "ภาพรวม 5 ดาว",
   "settingsTitle": "การตั้งค่า",
   "settingsAppearance": "ธีม",
   "settingsThemeSystem": "ตามระบบ",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -277,6 +277,7 @@
   "pageOverviewGachaSection": "Tổng quan Cầu Nguyện",
   "pageOverviewOdesSection": "Tổng quan Ca Tụng",
   "pageBannerRecordList": "Danh sách bản ghi",
+  "fiveStarOverviewTitle": "Tổng quan 5 sao",
   "settingsTitle": "Cài Đặt",
   "settingsAppearance": "Giao Diện",
   "settingsThemeSystem": "Theo hệ thống",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -206,6 +206,10 @@
   "pageOverviewGachaSection": "祈願綜合",
   "pageOverviewOdesSection": "頌願綜合",
   "pageBannerRecordList": "紀錄列表",
+  "fiveStarOverviewTitle": "五星一覽",
+  "@fiveStarOverviewTitle": {
+    "description": "Section title above the record list / timeline showing every unique five-star item the user pulled, each with a badge of how many copies were obtained."
+  },
 
   "settingsTitle": "設定",
   "settingsAppearance": "外觀",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -273,6 +273,7 @@
   "pageOverviewGachaSection": "祈愿综合",
   "pageOverviewOdesSection": "颂愿综合",
   "pageBannerRecordList": "记录列表",
+  "fiveStarOverviewTitle": "五星一览",
   "settingsTitle": "设置",
   "settingsAppearance": "外观",
   "settingsThemeSystem": "跟随系统",

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -10,12 +10,15 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_pity.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_row.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/state/record_filter.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_repository.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/record_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/utils/relative_time.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/chart_card.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/pity_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/stat_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/timeline_horizontal.dart';
@@ -115,6 +118,10 @@ class BannerPage extends ConsumerWidget {
             .toSet()
             .toList()
           ..sort();
+    final fiveStarItems = buildFiveStarCollection(
+      records,
+      index: ref.watch(hoyowikiIndexProvider),
+    );
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(AppSpacing.l),
@@ -293,6 +300,15 @@ class BannerPage extends ConsumerWidget {
           ),
 
           const SizedBox(height: AppSpacing.xl),
+          if (fiveStarItems.isNotEmpty) ...[
+            InlineSectionTitle(
+              icon: Icons.star_outline,
+              title: l.fiveStarOverviewTitle,
+            ),
+            const SizedBox(height: AppSpacing.s),
+            FiveStarOverview(items: fiveStarItems),
+            const SizedBox(height: AppSpacing.xl),
+          ],
           InlineSectionTitle(
             icon: Icons.table_chart_outlined,
             title: l.pageBannerRecordList,

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -363,6 +363,7 @@ class BannerPage extends ConsumerWidget {
         title: type.resolveName(l),
         records: records,
         targetRank: type.primaryPity.rank,
+        index: ref.read(hoyowikiIndexProvider),
       ),
     );
   }

--- a/lib/pages/overview_page.dart
+++ b/lib/pages/overview_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/app_info.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
@@ -16,6 +18,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/banner_top_rarity_bars.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/chart_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/stat_card.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/timeline_vertical.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/empty_state.dart';
@@ -143,6 +146,10 @@ class OverviewPage extends ConsumerWidget {
             timeline: gachaSec.timeline,
             timelineNowPulls: gachaSec.timelineNowPulls,
             timelineRank: gachaSec.timelineRank,
+            fiveStarItems: buildFiveStarCollectionAcrossBanners(
+              gachaSec.banners,
+              index: ref.watch(hoyowikiIndexProvider),
+            ),
           ),
           const SizedBox(height: AppSpacing.xxxl),
           Divider(
@@ -207,6 +214,7 @@ class _OverviewSection extends StatelessWidget {
     required this.timeline,
     required this.timelineNowPulls,
     required this.timelineRank,
+    this.fiveStarItems = const [],
   });
 
   /// 段落標題文字。
@@ -238,6 +246,9 @@ class _OverviewSection extends StatelessWidget {
 
   /// timeline 目標稀有度。
   final int timelineRank;
+
+  /// 此段的五星一覽清單；空清單時不顯示該區塊（頌願段一律空）。
+  final List<FiveStarCollectionItem> fiveStarItems;
 
   @override
   Widget build(BuildContext context) {
@@ -395,6 +406,15 @@ class _OverviewSection extends StatelessWidget {
         ),
 
         const SizedBox(height: AppSpacing.xl),
+        if (fiveStarItems.isNotEmpty) ...[
+          InlineSectionTitle(
+            icon: Icons.star_outline,
+            title: l.fiveStarOverviewTitle,
+          ),
+          const SizedBox(height: AppSpacing.s),
+          FiveStarOverview(items: fiveStarItems),
+          const SizedBox(height: AppSpacing.xl),
+        ],
         InlineSectionTitle(
           icon: Icons.timeline,
           title: l.timelineTopRarityTitle(

--- a/lib/pages/overview_page.dart
+++ b/lib/pages/overview_page.dart
@@ -196,6 +196,7 @@ class OverviewPage extends ConsumerWidget {
         uid: activeData.uid,
         updatedAt: activeData.lastUpdated.toLocal(),
         banners: activeData.banners,
+        index: ref.read(hoyowikiIndexProvider),
       ),
     );
   }

--- a/lib/services/five_star_collection.dart
+++ b/lib/services/five_star_collection.dart
@@ -1,11 +1,20 @@
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 
 /// 五星一覽聚合的 logger。
 final _log = Logger('gacha.fiveStar');
+
+/// 頌願（odes）卡池 gachaType 集合；五星一覽一律排除頌願——頌願物品沒有
+/// HoYoWiki icon（會渲染成空圈），且本功能範圍明確不含頌願。以 [gachaTypes]
+/// 靜態資料為單一來源，避免在多處硬編 `{'2000','1000'}`。
+final Set<String> _odesGachaTypes = {
+  for (final t in gachaTypes)
+    if (t.category == GachaCategory.odes) t.gachaType,
+};
 
 /// 五星一覽的單一條目：一個不重複的五星物品 + 其累計抽到次數。
 @immutable
@@ -39,7 +48,7 @@ class _Bucket {
 String _mergeKey(GachaRecord r, HoYoWikiIndex index) =>
     index.lookupId(name: r.name, lang: r.lang) ?? r.name;
 
-/// 由單一 records 來源建構五星一覽：取 5★，依合併鍵去重計數，
+/// 由單一 records 來源建構五星一覽：取 5★（排除頌願卡池），依合併鍵去重計數，
 /// 依「次數降冪 → 最近抽到時間降冪」排序。
 List<FiveStarCollectionItem> buildFiveStarCollection(
   List<GachaRecord> records, {
@@ -48,6 +57,7 @@ List<FiveStarCollectionItem> buildFiveStarCollection(
   final buckets = <String, _Bucket>{};
   for (final r in records) {
     if (r.rankType != 5) continue;
+    if (_odesGachaTypes.contains(r.gachaType)) continue;
     final b = buckets.putIfAbsent(_mergeKey(r, index), () => _Bucket(r));
     b.count++;
     if (r.time.isAfter(b.representative.time)) {

--- a/lib/services/five_star_collection.dart
+++ b/lib/services/five_star_collection.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+/// 五星一覽聚合的 logger。
+final _log = Logger('wish.fiveStar');
+
+/// 五星一覽的單一條目：一個不重複的五星物品 + 其累計抽到次數。
+@immutable
+class FiveStarCollectionItem {
+  /// 建立 [FiveStarCollectionItem]。
+  const FiveStarCollectionItem({
+    required this.representative,
+    required this.count,
+  });
+
+  /// 該物品最近一次被抽到的紀錄；決定 icon 查找與 tooltip 顯示名稱。
+  final GachaRecord representative;
+
+  /// 該物品（同合併鍵）在來源中被抽到的總次數。
+  final int count;
+}
+
+/// 內部累積桶：記住該合併鍵目前的代表 record（最近一次）與出現次數。
+class _Bucket {
+  /// 以首次遇到的 record 初始化，count 由呼叫端累加。
+  _Bucket(this.representative) : count = 0;
+
+  /// 目前該合併鍵最近一次的 record。
+  GachaRecord representative;
+
+  /// 出現次數。
+  int count;
+}
+
+/// 計算合併鍵：優先用 HoYoWiki id（可跨語系合併），lookup miss 時退化以名稱為鍵。
+String _mergeKey(GachaRecord r, HoYoWikiIndex index) =>
+    index.lookupId(name: r.name, lang: r.lang) ?? r.name;
+
+/// 由單一 records 來源建構五星一覽：取 5★，依合併鍵去重計數，
+/// 依「次數降冪 → 最近抽到時間降冪」排序。
+List<FiveStarCollectionItem> buildFiveStarCollection(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+}) {
+  final buckets = <String, _Bucket>{};
+  for (final r in records) {
+    if (r.rankType != 5) continue;
+    final b = buckets.putIfAbsent(_mergeKey(r, index), () => _Bucket(r));
+    b.count++;
+    if (r.time.isAfter(b.representative.time)) {
+      b.representative = r;
+    }
+  }
+  final items = buckets.values
+      .map(
+        (b) => FiveStarCollectionItem(
+          representative: b.representative,
+          count: b.count,
+        ),
+      )
+      .toList();
+  items.sort((a, b) {
+    final byCount = b.count.compareTo(a.count);
+    if (byCount != 0) return byCount;
+    return b.representative.time.compareTo(a.representative.time);
+  });
+  _log.info(
+    'buildFiveStarCollection: ${items.length} unique five-star item(s)',
+  );
+  return items;
+}
+
+/// 跨卡池版：攤平所有卡池 records 後委派給 [buildFiveStarCollection]，
+/// 同合併鍵跨卡池累加。
+List<FiveStarCollectionItem> buildFiveStarCollectionAcrossBanners(
+  Map<String, List<GachaRecord>> banners, {
+  required HoYoWikiIndex index,
+}) {
+  final all = banners.values.expand((r) => r).toList(growable: false);
+  return buildFiveStarCollection(all, index: index);
+}

--- a/lib/services/five_star_collection.dart
+++ b/lib/services/five_star_collection.dart
@@ -5,7 +5,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 
 /// 五星一覽聚合的 logger。
-final _log = Logger('wish.fiveStar');
+final _log = Logger('gacha.fiveStar');
 
 /// 五星一覽的單一條目：一個不重複的五星物品 + 其累計抽到次數。
 @immutable

--- a/lib/widgets/cards/five_star_overview.dart
+++ b/lib/widgets/cards/five_star_overview.dart
@@ -116,11 +116,18 @@ class _FiveStarChip extends StatelessWidget {
       ),
     );
 
-    if (!interactive) return stack;
+    // 徽章以 right/bottom: -2 微微外溢 SizedBox；靠右下 padding 把溢出量收進
+    // chip 自身的 box，避免放進會裁切的容器時邊角被切掉。
+    final chip = Padding(
+      padding: const EdgeInsets.only(right: 2, bottom: 2),
+      child: stack,
+    );
+
+    if (!interactive) return chip;
     return Tooltip(
       message: item.representative.name,
       waitDuration: const Duration(milliseconds: 100),
-      child: GachaItemTapTarget(record: item.representative, child: stack),
+      child: GachaItemTapTarget(record: item.representative, child: chip),
     );
   }
 }

--- a/lib/widgets/cards/five_star_overview.dart
+++ b/lib/widgets/cards/five_star_overview.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+
+/// 圓形 icon 邊長。
+const double _iconSize = 48;
+
+/// 金色外環寬度。
+const double _ringWidth = 2;
+
+/// 徽章高度（直徑）。
+const double _badgeSize = 19;
+
+/// 五星一覽：把不重複五星物品以橫向 [Wrap] 排列，每個 chip 為圓形 icon +
+/// 金色外環 + 右下角累計次數徽章。一行排滿自動換行、不限行數。空清單不顯示。
+class FiveStarOverview extends StatelessWidget {
+  /// 建立 [FiveStarOverview]。
+  const FiveStarOverview({
+    super.key,
+    required this.items,
+    this.interactive = true,
+  });
+
+  /// 聚合後的五星清單（已排序）。
+  final List<FiveStarCollectionItem> items;
+
+  /// true 時 chip 可點開詳情並顯示 tooltip；分享圖（靜態圖）傳 false。
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: AppSpacing.m,
+      runSpacing: AppSpacing.m,
+      children: [
+        for (final item in items)
+          _FiveStarChip(item: item, interactive: interactive),
+      ],
+    );
+  }
+}
+
+/// 單一五星 chip：圓形 icon + 金環 + 右下角次數徽章；[interactive] 時可點 / hover。
+class _FiveStarChip extends StatelessWidget {
+  /// 建立 [_FiveStarChip]。
+  const _FiveStarChip({required this.item, required this.interactive});
+
+  /// 對應的五星條目。
+  final FiveStarCollectionItem item;
+
+  /// 是否可互動。
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final gold = tokens.fiveStar;
+    // 金底徽章上的文字：dark 主題金色偏亮用深字、light 主題金色偏暗用白字，
+    // 兩個主題下都維持足夠對比。
+    final onGold = theme.brightness == Brightness.dark
+        ? tokens.surfaceBackground
+        : Colors.white;
+
+    final stack = SizedBox(
+      width: _iconSize + _ringWidth * 2,
+      height: _iconSize + _ringWidth * 2,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: gold, width: _ringWidth),
+              boxShadow: [
+                BoxShadow(color: gold.withValues(alpha: 0.35), blurRadius: 6),
+              ],
+            ),
+            child: GachaItemIcon(
+              record: item.representative,
+              size: _iconSize,
+              circular: true,
+            ),
+          ),
+          Positioned(
+            right: -2,
+            bottom: -2,
+            child: Container(
+              constraints: const BoxConstraints(minWidth: _badgeSize),
+              height: _badgeSize,
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: gold,
+                borderRadius: BorderRadius.circular(_badgeSize / 2),
+                border: Border.all(color: tokens.surfaceCard, width: 2),
+              ),
+              child: Text(
+                '${item.count}',
+                style: TextStyle(
+                  color: onGold,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (!interactive) return stack;
+    return Tooltip(
+      message: item.representative.name,
+      waitDuration: const Duration(milliseconds: 100),
+      child: GachaItemTapTarget(record: item.representative, child: stack),
+    );
+  }
+}

--- a/lib/widgets/gacha_item_icon.dart
+++ b/lib/widgets/gacha_item_icon.dart
@@ -13,13 +13,26 @@ const _odesGachaTypes = {'2000', '1000'};
 /// 顯示一筆卡池物品的 icon；cache 未到 / 缺資料時顯示 [_Placeholder]。
 class GachaItemIcon extends ConsumerWidget {
   /// 建立 [GachaItemIcon]。
-  const GachaItemIcon({super.key, required this.record, required this.size});
+  const GachaItemIcon({
+    super.key,
+    required this.record,
+    required this.size,
+    this.circular = false,
+  });
 
   /// 卡池記錄；用其 name / lang / rankType / gachaType。
   final GachaRecord record;
 
   /// icon 邊長（px，依使用情境調整：所有宿主一律 32）。
   final double size;
+
+  /// true 時以圓形裁切／圓形 placeholder 呈現（五星一覽用）。
+  final bool circular;
+
+  /// 依 [circular] 將 icon 圖片裁成圓形或 4px 圓角方塊。
+  Widget _clipIcon(Widget child) => circular
+      ? ClipOval(child: child)
+      : ClipRRect(borderRadius: BorderRadius.circular(4), child: child);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -42,10 +55,7 @@ class GachaItemIcon extends ConsumerWidget {
         return SizedBox(
           width: size,
           height: size,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: RawImage(image: preloadedImage, fit: BoxFit.cover),
-          ),
+          child: _clipIcon(RawImage(image: preloadedImage, fit: BoxFit.cover)),
         );
       }
 
@@ -58,15 +68,17 @@ class GachaItemIcon extends ConsumerWidget {
         return SizedBox(
           width: size,
           height: size,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.file(file, fit: BoxFit.cover),
-          ),
+          child: _clipIcon(Image.file(file, fit: BoxFit.cover)),
         );
       }
     }
 
-    return _Placeholder(rankType: record.rankType, size: size, tokens: tokens);
+    return _Placeholder(
+      rankType: record.rankType,
+      size: size,
+      tokens: tokens,
+      circular: circular,
+    );
   }
 }
 
@@ -77,6 +89,7 @@ class _Placeholder extends StatelessWidget {
     required this.rankType,
     required this.size,
     required this.tokens,
+    this.circular = false,
   });
 
   /// 星級（3 / 4 / 5）；決定強調色。
@@ -87,6 +100,9 @@ class _Placeholder extends StatelessWidget {
 
   /// 主題 token；提供稀有度顏色。
   final GachaTokens tokens;
+
+  /// true 時以圓形呈現。
+  final bool circular;
 
   @override
   Widget build(BuildContext context) {
@@ -101,7 +117,8 @@ class _Placeholder extends StatelessWidget {
       decoration: BoxDecoration(
         color: accent.withValues(alpha: 0.18),
         border: Border.all(color: accent.withValues(alpha: 0.40)),
-        borderRadius: BorderRadius.circular(4),
+        shape: circular ? BoxShape.circle : BoxShape.rectangle,
+        borderRadius: circular ? null : BorderRadius.circular(4),
       ),
       child: Center(
         child: Icon(Icons.question_mark, size: size * 0.55, color: accent),

--- a/lib/widgets/gacha_item_icon.dart
+++ b/lib/widgets/gacha_item_icon.dart
@@ -23,7 +23,7 @@ class GachaItemIcon extends ConsumerWidget {
   /// 卡池記錄；用其 name / lang / rankType / gachaType。
   final GachaRecord record;
 
-  /// icon 邊長（px，依使用情境調整：所有宿主一律 32）。
+  /// icon 邊長（px，依使用情境調整：時間軸等為 32、五星一覽為 48）。
   final double size;
 
   /// true 時以圓形裁切／圓形 placeholder 呈現（五星一覽用）。

--- a/lib/widgets/share/share_card.dart
+++ b/lib/widgets/share/share_card.dart
@@ -9,6 +9,8 @@ import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/share_image_options.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_pity.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/overview_sections.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/share_uid_mask.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/timeline_entries.dart';
@@ -20,6 +22,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.d
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/item_type_pie.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/rank_palette.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/rarity_pie.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/left_driven_equal_height.dart';
 
 /// 分享圖固定寬度（邏輯像素）。
@@ -86,7 +89,9 @@ class ShareCard extends StatelessWidget {
     required this.uid,
     required this.updatedAt,
     required List<_Section> sections,
-  }) : _sections = sections;
+    required List<FiveStarCollectionItem> fiveStar,
+  }) : _sections = sections,
+       _fiveStar = fiveStar;
 
   /// 單一卡池頁分享。
   factory ShareCard.banner({
@@ -99,6 +104,7 @@ class ShareCard extends StatelessWidget {
     required String title,
     required List<GachaRecord> records,
     required int targetRank,
+    required HoYoWikiIndex index,
   }) {
     final stats = computeGachaStats(records);
     // threshold: 0 — 此處只取 averageInterval，不需 pity progress/distance
@@ -137,6 +143,7 @@ class ShareCard extends StatelessWidget {
           ],
         ),
       ],
+      fiveStar: buildFiveStarCollection(records, index: index),
     );
   }
 
@@ -149,6 +156,7 @@ class ShareCard extends StatelessWidget {
     required String uid,
     required DateTime updatedAt,
     required Map<String, List<GachaRecord>> banners,
+    required HoYoWikiIndex index,
   }) {
     final s = buildOverviewSections(banners);
     final g = s.gacha;
@@ -212,6 +220,10 @@ class ShareCard extends StatelessWidget {
           ],
         ),
       ],
+      fiveStar: buildFiveStarCollectionAcrossBanners(
+        s.gacha.banners,
+        index: index,
+      ),
     );
   }
 
@@ -235,6 +247,9 @@ class ShareCard extends StatelessWidget {
 
   /// 各段內容（卡池模式 1 段；綜合模式 2 段）。
   final List<_Section> _sections;
+
+  /// 尾端五星一覽清單（banner = 該池；overview = 跨祈願卡池合併）。
+  final List<FiveStarCollectionItem> _fiveStar;
 
   /// 格式化「佔比 · 平均間隔」副標題字串；avg 為 null 時只回傳佔比。
   static String? _rateAvg(AppLocalizations l, double rate, double? avg) {
@@ -276,6 +291,17 @@ class ShareCard extends StatelessWidget {
             brightness: options.brightness,
             tokens: tokens,
           ),
+        ],
+        if (_fiveStar.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xl),
+          Divider(color: tokens.borderEmphasis, height: 1, thickness: 1),
+          const SizedBox(height: AppSpacing.xl),
+          Text(
+            l.fiveStarOverviewTitle,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: AppSpacing.m),
+          FiveStarOverview(items: _fiveStar, interactive: false),
         ],
       ],
     );

--- a/lib/widgets/share/share_card.dart
+++ b/lib/widgets/share/share_card.dart
@@ -51,6 +51,7 @@ class _Section {
     required this.timelineNowPulls,
     required this.isAcrossBanners,
     required this.statLines,
+    this.fiveStar = const [],
   });
 
   /// 段落標題文字（例如祈願段名稱或卡池名稱）。
@@ -74,6 +75,9 @@ class _Section {
   /// 左欄數字摘要列：label + value + subtitle（subtitle 可空）+ accent 語意。
   final List<(String label, String value, String? sub, _StatAccent accent)>
   statLines;
+
+  /// 此段尾端的五星一覽清單（祈願段才有；頌願段為空 → 不顯示）。
+  final List<FiveStarCollectionItem> fiveStar;
 }
 
 /// 分享圖固定寬版面（版面 B：左數字+雙圓餅，右垂直時間軸）。
@@ -89,9 +93,7 @@ class ShareCard extends StatelessWidget {
     required this.uid,
     required this.updatedAt,
     required List<_Section> sections,
-    required List<FiveStarCollectionItem> fiveStar,
-  }) : _sections = sections,
-       _fiveStar = fiveStar;
+  }) : _sections = sections;
 
   /// 單一卡池頁分享。
   factory ShareCard.banner({
@@ -141,9 +143,9 @@ class ShareCard extends StatelessWidget {
               _StatAccent.rank4,
             ),
           ],
+          fiveStar: buildFiveStarCollection(records, index: index),
         ),
       ],
-      fiveStar: buildFiveStarCollection(records, index: index),
     );
   }
 
@@ -195,6 +197,10 @@ class ShareCard extends StatelessWidget {
               _StatAccent.rank4,
             ),
           ],
+          fiveStar: buildFiveStarCollectionAcrossBanners(
+            s.gacha.banners,
+            index: index,
+          ),
         ),
         _Section(
           title: l.pageOverviewOdesSection,
@@ -220,10 +226,6 @@ class ShareCard extends StatelessWidget {
           ],
         ),
       ],
-      fiveStar: buildFiveStarCollectionAcrossBanners(
-        s.gacha.banners,
-        index: index,
-      ),
     );
   }
 
@@ -247,9 +249,6 @@ class ShareCard extends StatelessWidget {
 
   /// 各段內容（卡池模式 1 段；綜合模式 2 段）。
   final List<_Section> _sections;
-
-  /// 尾端五星一覽清單（banner = 該池；overview = 跨祈願卡池合併）。
-  final List<FiveStarCollectionItem> _fiveStar;
 
   /// 格式化「佔比 · 平均間隔」副標題字串；avg 為 null 時只回傳佔比。
   static String? _rateAvg(AppLocalizations l, double rate, double? avg) {
@@ -291,17 +290,6 @@ class ShareCard extends StatelessWidget {
             brightness: options.brightness,
             tokens: tokens,
           ),
-        ],
-        if (_fiveStar.isNotEmpty) ...[
-          const SizedBox(height: AppSpacing.xl),
-          Divider(color: tokens.borderEmphasis, height: 1, thickness: 1),
-          const SizedBox(height: AppSpacing.xl),
-          Text(
-            l.fiveStarOverviewTitle,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          const SizedBox(height: AppSpacing.m),
-          FiveStarOverview(items: _fiveStar, interactive: false),
         ],
       ],
     );
@@ -529,6 +517,14 @@ class _SectionView extends StatelessWidget {
             _timeline(),
           ],
         ),
+        // 五星一覽掛在該段尾端（祈願段才有；頌願段為空 → 不顯示），
+        // 確保綜合分享圖的五星落在祈願區底下、而非整張圖最末的頌願區後。
+        if (section.fiveStar.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.l),
+          Text(l.fiveStarOverviewTitle, style: theme.textTheme.titleLarge),
+          const SizedBox(height: AppSpacing.m),
+          FiveStarOverview(items: section.fiveStar, interactive: false),
+        ],
       ],
     );
   }

--- a/test/services/five_star_collection_test.dart
+++ b/test/services/five_star_collection_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+GachaRecord _r({
+  required String id,
+  required int rank,
+  required DateTime time,
+  String gachaType = '301',
+  String name = 'x',
+  String lang = 'zh-tw',
+}) => GachaRecord(
+  id: id,
+  uid: '1',
+  gachaType: gachaType,
+  name: name,
+  itemType: '角色',
+  rankType: rank,
+  time: time,
+  lang: lang,
+);
+
+void main() {
+  const emptyIndex = HoYoWikiIndex.empty();
+
+  group('buildFiveStarCollection', () {
+    test('empty records → empty list', () {
+      expect(buildFiveStarCollection(const [], index: emptyIndex), isEmpty);
+    });
+
+    test('只取 5★，排除 4★／3★', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 4, name: 'B', time: DateTime(2025, 1, 2)),
+        _r(id: '3', rank: 3, name: 'C', time: DateTime(2025, 1, 3)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(1));
+      expect(result.single.representative.name, 'A');
+      expect(result.single.count, 1);
+    });
+
+    test('同名去重計數，代表 record 取最近一次', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 5, name: 'A', time: DateTime(2025, 3, 1)),
+        _r(id: '3', rank: 5, name: 'A', time: DateTime(2025, 2, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(1));
+      expect(result.single.count, 3);
+      expect(result.single.representative.id, '2'); // 2025-03-01 最近
+    });
+
+    test('排序：次數降冪，同次數以最近時間降冪', () {
+      final records = [
+        _r(id: 'a1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: 'a2', rank: 5, name: 'A', time: DateTime(2025, 1, 2)),
+        _r(id: 'b1', rank: 5, name: 'B', time: DateTime(2025, 5, 1)),
+        _r(id: 'c1', rank: 5, name: 'C', time: DateTime(2025, 4, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      // A=2 → 最前；B/C 各 1，B(5/1) 比 C(4/1) 新 → B 在 C 前
+      expect(result.map((e) => e.representative.name).toList(), [
+        'A',
+        'B',
+        'C',
+      ]);
+    });
+
+    test('跨語系：同 id 不同語系名稱合併為一', () {
+      const index = HoYoWikiIndex(
+        searchMap: {'zh-tw::雷電將軍': '10000052', 'en::Raiden Shogun': '10000052'},
+        entries: {},
+        menuIds: {},
+      );
+      final records = [
+        _r(
+          id: '1',
+          rank: 5,
+          name: '雷電將軍',
+          lang: 'zh-tw',
+          time: DateTime(2025, 1, 1),
+        ),
+        _r(
+          id: '2',
+          rank: 5,
+          name: 'Raiden Shogun',
+          lang: 'en',
+          time: DateTime(2025, 2, 1),
+        ),
+      ];
+      final result = buildFiveStarCollection(records, index: index);
+      expect(result, hasLength(1));
+      expect(result.single.count, 2);
+      expect(result.single.representative.lang, 'en'); // 最近一筆
+    });
+
+    test('fallback：index lookup miss 時以名稱為鍵，不誤併不同物', () {
+      final records = [
+        _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),
+        _r(id: '2', rank: 5, name: 'B', time: DateTime(2025, 2, 1)),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(2));
+    });
+  });
+
+  group('buildFiveStarCollectionAcrossBanners', () {
+    test('同物品跨卡池合併、次數相加', () {
+      const index = HoYoWikiIndex(
+        searchMap: {'zh-tw::琴': '10000003'},
+        entries: {},
+        menuIds: {},
+      );
+      final banners = {
+        '301': [_r(id: 'c1', rank: 5, name: '琴', time: DateTime(2025, 1, 1))],
+        '200': [
+          _r(
+            id: 's1',
+            rank: 5,
+            name: '琴',
+            gachaType: '200',
+            time: DateTime(2025, 3, 1),
+          ),
+          _r(
+            id: 's2',
+            rank: 5,
+            name: '琴',
+            gachaType: '200',
+            time: DateTime(2025, 2, 1),
+          ),
+        ],
+      };
+      final result = buildFiveStarCollectionAcrossBanners(
+        banners,
+        index: index,
+      );
+      expect(result, hasLength(1));
+      expect(result.single.count, 3);
+      expect(result.single.representative.id, 's1'); // 2025-03-01 最近
+    });
+
+    test('empty banners → empty list', () {
+      expect(
+        buildFiveStarCollectionAcrossBanners(const {}, index: emptyIndex),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/services/five_star_collection_test.dart
+++ b/test/services/five_star_collection_test.dart
@@ -41,6 +41,49 @@ void main() {
       expect(result.single.count, 1);
     });
 
+    test('排除頌願卡池（2000／1000）的 5★', () {
+      final records = [
+        _r(id: '1', rank: 5, name: '一般角色', time: DateTime(2025, 1, 1)),
+        _r(
+          id: '2',
+          rank: 5,
+          name: '頌願活動',
+          gachaType: '2000',
+          time: DateTime(2025, 1, 2),
+        ),
+        _r(
+          id: '3',
+          rank: 5,
+          name: '頌願常駐',
+          gachaType: '1000',
+          time: DateTime(2025, 1, 3),
+        ),
+      ];
+      final result = buildFiveStarCollection(records, index: emptyIndex);
+      expect(result, hasLength(1));
+      expect(result.single.representative.name, '一般角色');
+    });
+
+    test('全為頌願卡池 → 空清單', () {
+      final records = [
+        _r(
+          id: '1',
+          rank: 5,
+          name: '頌願活動',
+          gachaType: '2000',
+          time: DateTime(2025, 1, 1),
+        ),
+        _r(
+          id: '2',
+          rank: 5,
+          name: '頌願常駐',
+          gachaType: '1000',
+          time: DateTime(2025, 1, 2),
+        ),
+      ];
+      expect(buildFiveStarCollection(records, index: emptyIndex), isEmpty);
+    });
+
     test('同名去重計數，代表 record 取最近一次', () {
       final records = [
         _r(id: '1', rank: 5, name: 'A', time: DateTime(2025, 1, 1)),

--- a/test/widgets/cards/five_star_overview_test.dart
+++ b/test/widgets/cards/five_star_overview_test.dart
@@ -11,6 +11,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
 
 GachaRecord _r(String id, String name, DateTime time) => GachaRecord(
   id: id,
@@ -64,7 +65,7 @@ void main() {
     await tester.pumpWidget(_wrap(c, const FiveStarOverview(items: [])));
     await tester.pump();
     expect(find.byType(GachaItemTapTarget), findsNothing);
-    expect(find.textContaining('×'), findsNothing);
+    expect(find.byType(GachaItemIcon), findsNothing); // 空清單不繪任何 chip
   });
 
   testWidgets('顯示每個物品的次數徽章', (tester) async {

--- a/test/widgets/cards/five_star_overview_test.dart
+++ b/test/widgets/cards/five_star_overview_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/five_star_collection.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
+
+GachaRecord _r(String id, String name, DateTime time) => GachaRecord(
+  id: id,
+  uid: '1',
+  gachaType: '301',
+  name: name,
+  itemType: '角色',
+  rankType: 5,
+  time: time,
+  lang: 'zh-tw',
+);
+
+Future<ProviderContainer> _container(WidgetTester tester) async {
+  late Directory tempDir;
+  await tester.runAsync(() async {
+    tempDir = await Directory.systemTemp.createTemp('five_star_overview_test_');
+  });
+  addTearDown(() async {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {}
+  });
+  final container = ProviderContainer(
+    overrides: [
+      hoyowikiIndexStorageProvider.overrideWithValue(
+        HoYoWikiIndexStorage(tempDir),
+      ),
+      hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.runAsync(
+    () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+  );
+  return container;
+}
+
+Widget _wrap(ProviderContainer c, Widget child) => UncontrolledProviderScope(
+  container: c,
+  child: MaterialApp(
+    theme: buildDarkTheme(),
+    home: Scaffold(body: SizedBox(width: 800, child: child)),
+  ),
+);
+
+void main() {
+  const emptyIndex = HoYoWikiIndex.empty();
+
+  testWidgets('空清單 → SizedBox.shrink，不顯示任何 chip', (tester) async {
+    final c = await _container(tester);
+    await tester.pumpWidget(_wrap(c, const FiveStarOverview(items: [])));
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsNothing);
+    expect(find.textContaining('×'), findsNothing);
+  });
+
+  testWidgets('顯示每個物品的次數徽章', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+      _r('2', 'A', DateTime(2025, 1, 2)),
+      _r('3', 'B', DateTime(2025, 1, 3)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(_wrap(c, FiveStarOverview(items: items)));
+    await tester.pump();
+    expect(find.text('2'), findsOneWidget); // A 抽到 2 次
+    expect(find.text('1'), findsOneWidget); // B 抽到 1 次
+  });
+
+  testWidgets('interactive=false → 不掛 GachaItemTapTarget', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(
+      _wrap(c, FiveStarOverview(items: items, interactive: false)),
+    );
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsNothing);
+  });
+
+  testWidgets('interactive=true → 掛 GachaItemTapTarget', (tester) async {
+    final c = await _container(tester);
+    final items = buildFiveStarCollection([
+      _r('1', 'A', DateTime(2025, 1, 1)),
+    ], index: emptyIndex);
+    await tester.pumpWidget(_wrap(c, FiveStarOverview(items: items)));
+    await tester.pump();
+    expect(find.byType(GachaItemTapTarget), findsOneWidget);
+  });
+}

--- a/test/widgets/cards/share_card_five_star_test.dart
+++ b/test/widgets/cards/share_card_five_star_test.dart
@@ -106,4 +106,106 @@ void main() {
     expect(find.byType(FiveStarOverview), findsOneWidget);
     expect(find.text(l.fiveStarOverviewTitle), findsOneWidget);
   });
+
+  testWidgets('overview 分享圖的五星一覽落在祈願段、頌願段之前', (tester) async {
+    late Directory tempDir;
+    await tester.runAsync(() async {
+      tempDir = await Directory.systemTemp.createTemp('share_five_star_ov_');
+    });
+    addTearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
+    final container = ProviderContainer(
+      overrides: [
+        hoyowikiIndexStorageProvider.overrideWithValue(
+          HoYoWikiIndexStorage(tempDir),
+        ),
+        hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.runAsync(
+      () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+    );
+
+    final icon = await tester.runAsync(_solidImage);
+    addTearDown(() => icon!.dispose());
+
+    // 祈願段有 5★（301），頌願段也有資料（2000）。
+    final banners = {
+      '301': [
+        GachaRecord(
+          id: '1',
+          uid: '100000001',
+          gachaType: '301',
+          name: '夜蘭',
+          itemType: '角色',
+          rankType: 5,
+          time: DateTime(2025, 4, 1),
+          lang: 'zh-tw',
+        ),
+      ],
+      '2000': [
+        GachaRecord(
+          id: '2',
+          uid: '100000001',
+          gachaType: '2000',
+          name: '頌願五星',
+          itemType: '角色',
+          rankType: 5,
+          time: DateTime(2025, 4, 2),
+          lang: 'zh-tw',
+        ),
+      ],
+    };
+
+    late AppLocalizations l;
+    final card = Builder(
+      builder: (ctx) {
+        l = AppLocalizations.of(ctx)!;
+        return ShareCard.overview(
+          l: l,
+          appVersion: '1.0.0',
+          appIcon: icon!,
+          options: const ShareImageOptions(
+            brightness: Brightness.dark,
+            showFullUid: true,
+          ),
+          uid: '100000001',
+          updatedAt: DateTime(2025, 4, 2),
+          banners: banners,
+          index: container.read(hoyowikiIndexProvider),
+        );
+      },
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildDarkTheme(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PreloadedHoYoWikiImages(images: const {}, child: card),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // 只在祈願段出現一次（頌願段的 5★ 被排除）。
+    expect(find.byType(FiveStarOverview), findsOneWidget);
+
+    // 五星一覽必須在頌願段標題「之上」（= 落在祈願段底下、頌願段之前）。
+    final overviewDy = tester.getTopLeft(find.byType(FiveStarOverview)).dy;
+    final odesTitleDy = tester
+        .getTopLeft(find.text(l.pageOverviewOdesSection))
+        .dy;
+    expect(overviewDy, lessThan(odesTitleDy));
+  });
 }

--- a/test/widgets/cards/share_card_five_star_test.dart
+++ b/test/widgets/cards/share_card_five_star_test.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/share_image_options.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/preloaded_hoyowiki_images.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/share_card.dart';
+
+Future<ui.Image> _solidImage() async {
+  final recorder = ui.PictureRecorder();
+  Canvas(recorder).drawRect(
+    const Rect.fromLTWH(0, 0, 4, 4),
+    Paint()..color = const Color(0xFFFFFFFF),
+  );
+  return recorder.endRecording().toImage(4, 4);
+}
+
+void main() {
+  testWidgets('banner 分享圖含 FiveStarOverview（含 5★ 時）', (tester) async {
+    late Directory tempDir;
+    await tester.runAsync(() async {
+      tempDir = await Directory.systemTemp.createTemp('share_five_star_test_');
+    });
+    addTearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
+    final container = ProviderContainer(
+      overrides: [
+        hoyowikiIndexStorageProvider.overrideWithValue(
+          HoYoWikiIndexStorage(tempDir),
+        ),
+        hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.runAsync(
+      () => container.read(hoyowikiIndexProvider.notifier).waitForLoad(),
+    );
+
+    final icon = await tester.runAsync(_solidImage);
+    addTearDown(() => icon!.dispose());
+
+    final records = [
+      GachaRecord(
+        id: '1',
+        uid: '100000001',
+        gachaType: '301',
+        name: '夜蘭',
+        itemType: '角色',
+        rankType: 5,
+        time: DateTime(2025, 4, 1),
+        lang: 'zh-tw',
+      ),
+    ];
+
+    late AppLocalizations l;
+    final card = Builder(
+      builder: (ctx) {
+        l = AppLocalizations.of(ctx)!;
+        return ShareCard.banner(
+          l: l,
+          appVersion: '1.0.0',
+          appIcon: icon!,
+          options: const ShareImageOptions(
+            brightness: Brightness.dark,
+            showFullUid: true,
+          ),
+          uid: '100000001',
+          updatedAt: DateTime(2025, 4, 1),
+          title: 'Test',
+          records: records,
+          targetRank: 5,
+          index: container.read(hoyowikiIndexProvider),
+        );
+      },
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildDarkTheme(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PreloadedHoYoWikiImages(images: const {}, child: card),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(FiveStarOverview), findsOneWidget);
+    expect(find.text(l.fiveStarOverviewTitle), findsOneWidget);
+  });
+}

--- a/test/widgets/gacha_item_icon_test.dart
+++ b/test/widgets/gacha_item_icon_test.dart
@@ -272,6 +272,61 @@ void main() {
       expect(icon.size, 32 * 0.55, reason: 'rank=$rank icon size');
     }
   });
+
+  testWidgets('circular=true → placeholder 用圓形 BoxShape.circle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        GachaItemIcon(
+          record: _rec(name: '夜蘭', gachaType: '301', rankType: 5),
+          size: 48,
+          circular: true,
+        ),
+        container,
+      ),
+    );
+    await tester.pump();
+
+    final deco =
+        tester
+                .widget<Container>(
+                  find.descendant(
+                    of: find.byType(GachaItemIcon),
+                    matching: find.byType(Container),
+                  ),
+                )
+                .decoration
+            as BoxDecoration;
+    expect(deco.shape, BoxShape.circle);
+  });
+
+  testWidgets('circular=false（預設）→ placeholder 用方形 BoxShape.rectangle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        GachaItemIcon(
+          record: _rec(name: '夜蘭', gachaType: '301', rankType: 5),
+          size: 48,
+        ),
+        container,
+      ),
+    );
+    await tester.pump();
+
+    final deco =
+        tester
+                .widget<Container>(
+                  find.descendant(
+                    of: find.byType(GachaItemIcon),
+                    matching: find.byType(Container),
+                  ),
+                )
+                .decoration
+            as BoxDecoration;
+    expect(deco.shape, BoxShape.rectangle);
+  });
 }
 
 /// 最小可解碼 1x1 透明 PNG。

--- a/test/widgets/share/share_card_test.dart
+++ b/test/widgets/share/share_card_test.dart
@@ -127,6 +127,7 @@ void main() {
       title: '角色活動祈願',
       records: [_r('301', 5, '那維萊特'), _r('301', 4, '菲謝爾'), _r('301', 3, '冷刃')],
       targetRank: 5,
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -146,6 +147,7 @@ void main() {
       title: '角色活動祈願',
       records: [_r('301', 5, '那維萊特'), _r('301', 4, '菲謝爾'), _r('301', 3, '冷刃')],
       targetRank: 5,
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -185,6 +187,7 @@ void main() {
       title: '角色活動祈願',
       records: [_r('301', 5, '那維萊特'), _r('301', 4, '菲謝爾'), _r('301', 3, '冷刃')],
       targetRank: 5,
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -218,6 +221,7 @@ void main() {
         '301': [_r('301', 5, '那維萊特'), _r('301', 3, '冷刃')],
         '2000': [_r('2000', 5, '某五星')],
       },
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -248,6 +252,7 @@ void main() {
       title: '角色活動祈願',
       records: _crossMonthFives(12),
       targetRank: 5,
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     // 直接裁切方案：不可有 RenderFlex overflow 或任何 error。
@@ -291,6 +296,7 @@ void main() {
       title: '角色活動祈願',
       records: [_r('301', 5, '那維萊特'), _r('301', 4, '菲謝爾'), _r('301', 3, '冷刃')],
       targetRank: 5,
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -325,6 +331,7 @@ void main() {
         '301': _crossMonthFives(16),
         '2000': [_r('2000', 5, '某五星')],
       },
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
@@ -346,6 +353,7 @@ void main() {
         '301': [_r('301', 5, '那維萊特'), _r('301', 3, '冷刃')],
         '2000': [_r('2000', 5, '某五星')],
       },
+      index: const HoYoWikiIndex.empty(),
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);

--- a/test/widgets/share/share_render_tree_test.dart
+++ b/test/widgets/share/share_render_tree_test.dart
@@ -92,6 +92,7 @@ void main() {
           _r('301', 3, '冷刃'),
         ],
         targetRank: 5,
+        index: const HoYoWikiIndex.empty(),
       );
       final png = await renderWidgetToPng(
         buildShareRenderTree(
@@ -146,6 +147,7 @@ void main() {
           '301': [_r('301', 5, '那維萊特'), _r('301', 3, '冷刃')],
           '2000': [_r('2000', 5, '某五星')],
         },
+        index: const HoYoWikiIndex.empty(),
       );
       final png = await renderWidgetToPng(
         buildShareRenderTree(


### PR DESCRIPTION
## 摘要

在祈願頁面與綜合數據頁新增「五星一覽」區塊：把該範圍內所有不重複的五星物品，以橫向排列的圓形 Icon 呈現，每個 Icon 右下角以金色徽章標示該物品累計被抽到的次數（含 1）。一行排滿自動換行、不限行數。

呈現位置：
- 所有非頌願卡池頁：祈願記錄列表上方。
- 綜合數據頁：祈願段時間軸上方。
- 分享圖：卡池分享圖放該段尾端；綜合分享圖放在「祈願綜合」段底下（頌願段之前）。

頌願（頌願個別頁、綜合頁頌願段、分享圖頌願段）一律不顯示。

## 設計重點

- **去重 + 計數**：每個不重複五星一個圓形 Icon，徽章為累計次數，恆顯示。
- **合併鍵採 HoYoWiki id**（lookup miss 時退化為物品名稱），跨語系匯入的同一物品能正確合併、次數相加。
- **排序**：次數降冪，次數相同時以「最近抽到時間」降冪。
- **頌願排除**：聚合層以 `GachaCategory.odes` 為單一來源排除頌願卡型，同時覆蓋頁面與分享圖。
- **重用既有元件**：擴充 `GachaItemIcon` 圓形模式、沿用 `GachaItemTapTarget`（點擊開詳情）；分享圖以 `interactive: false` 渲染靜態 chip，圖示沿用既有 `PreloadedHoYoWikiImages` 預載機制。
- 樣式：統一金色外環 + 圓形數字徽章（48px），徽章文字依亮暗主題切換以維持對比。

## 變更檔案

- 新增 `lib/services/five_star_collection.dart`（聚合純函式）
- 新增 `lib/widgets/cards/five_star_overview.dart`（呈現 widget）
- `lib/widgets/gacha_item_icon.dart` 擴充 `circular` 圓形模式
- `lib/pages/banner_page.dart`、`lib/pages/overview_page.dart`、`lib/widgets/share/share_card.dart` 接線
- i18n：`fiveStarOverviewTitle`（繁中起手，補上已有翻譯的 9 個語系）

設計與計畫：`docs/superpowers/specs/2026-05-29-five-star-overview-strip-design.md`、`docs/superpowers/plans/2026-05-29-five-star-overview-strip.md`

## 測試計畫

- [x] `flutter analyze` → No issues found!
- [x] `flutter test` → 819 passed（含聚合單元測試：去重／排序／跨卡池／跨語系／頌願排除；widget 測試：徽章／空狀態／interactive；分享圖：banner 含五星、overview 五星落在祈願段且在頌願段之前）
- [x] 手動於 App 產生卡池／綜合分享圖，確認五星一覽位置與徽章正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)