### PR TITLE
feat(wish): classify item type via HoYoWiki menu_id

### DIFF
--- a/docs/superpowers/plans/2026-05-29-hoyowiki-item-type-classification.md
+++ b/docs/superpowers/plans/2026-05-29-hoyowiki-item-type-classification.md
@@ -1,0 +1,795 @@
+# HoYoWiki menu_id 物品類型判定 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 用 HoYoWiki `menu_id`（2＝角色、4＝武器）作為語言無關的物品類型判定，消除類型圓餅圖、記錄列表類型欄／排序、篩選下拉的跨語言統計分裂；查不到時 fallback 回原始 `itemType` 字串。
+
+**Architecture:** 新增共用 primitive `itemTypeKeyOf(record, index)`（沿用 `five_star_collection` 的「records + HoYoWikiIndex，`lookupId`→`lookupMenuId`，miss fallback」模式）回傳聚合鍵 `kind:character` / `kind:weapon` / 原始字串；`itemTypeKeyLabel(key, l)` 把鍵轉在地化標籤。`computeGachaStats` 與 `buildRecordRows` 改用此鍵，不動存檔、零狀態遷移、隨 HoYoWiki index live provider 反應式更新。
+
+**Tech Stack:** Flutter、Dart、Riverpod、Flutter gen-l10n（ARB）、flutter_test。
+
+**Branch:** `feat/item-type-hoyowiki-classification`（已從 master 開好，含 spec commit）。
+
+**Spec:** `docs/superpowers/specs/2026-05-29-hoyowiki-item-type-classification-design.md`
+
+---
+
+## File Structure
+
+- **新增** `lib/services/item_type_kind.dart` — 類型判定模組：kind 常數 + `itemTypeKeyOf`（純，依 `HoYoWikiIndex`）+ `itemTypeKeyLabel`（依 `AppLocalizations`）。單一職責。
+- **新增** `test/services/item_type_kind_test.dart`。
+- **改** `lib/l10n/app_zh.arb` 等 9 個有實體翻譯的 ARB — 新增 `kindCharacter` / `kindWeapon`。
+- **改** `lib/services/gacha_stats.dart` — `computeGachaStats` 加 `{required index}`，`byItemType` 改用鍵聚合 + summary log。
+- **改** `lib/widgets/item_type_pie.dart` — legend 顯示套 `itemTypeKeyLabel`。
+- **改** `lib/services/overview_sections.dart` — `buildOverviewSections` 加 `{required index}` 往下傳。
+- **改** `lib/services/gacha_row.dart` — `RecordRow` 加 `itemTypeKey`，`buildRecordRows` 加 `{required index}`。
+- **改** `lib/services/gacha_filter.dart` — `filterRecordRows` / `sortRecordRows` 改用 `row.itemTypeKey`。
+- **改** `lib/widgets/data/sortable_table.dart` — 類型欄顯示套 `itemTypeKeyLabel`。
+- **改** `lib/widgets/data/search_filter_bar.dart` — 下拉 label 套 `itemTypeKeyLabel`。
+- **改** 呼叫點：`lib/pages/banner_page.dart`、`lib/pages/overview_page.dart`、`lib/widgets/share/share_card.dart`。
+- **改** 既有測試：`gacha_stats_test`、`item_type_pie_test`、`overview_sections_test`、`gacha_row_test`、`gacha_filter_test`、`sortable_table_test`、`search_filter_bar_test`。
+
+---
+
+## Task 1: 新增 i18n 字串 kindCharacter / kindWeapon
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（template，近 `kindUnknown` 第 108 行）
+- Modify: `lib/l10n/app_zh_Hans.arb`、`app_en.arb`、`app_ja.arb`、`app_es.arb`、`app_fr.arb`、`app_pt_BR.arb`、`app_th.arb`、`app_vi.arb`（僅這 9 個已有實體翻譯的 ARB；空殼 ARB 不碰，留給 Crowdin pipeline）
+
+譯名取自 `docs/術語表.md`（權威來源，角色／武器名詞嵌在卡池全名列）；標準物品類型名詞，作為標籤首字母大寫。
+
+- [ ] **Step 1: 在 `app_zh.arb` 的 `kindUnknown` 那一行後加入兩個 key**
+
+`app_zh.arb` 現有：
+```json
+  "kindUnknown": "未知",
+```
+改為：
+```json
+  "kindUnknown": "未知",
+  "kindCharacter": "角色",
+  "kindWeapon": "武器",
+```
+
+- [ ] **Step 2: 在其餘 8 個 ARB 對應 `kindUnknown` 位置加入相同 key，值如下**
+
+逐檔在該檔既有 `"kindUnknown": ...,` 之後插入：
+
+`app_zh_Hans.arb`:
+```json
+  "kindCharacter": "角色",
+  "kindWeapon": "武器",
+```
+`app_en.arb`:
+```json
+  "kindCharacter": "Character",
+  "kindWeapon": "Weapon",
+```
+`app_ja.arb`:
+```json
+  "kindCharacter": "キャラクター",
+  "kindWeapon": "武器",
+```
+`app_es.arb`:
+```json
+  "kindCharacter": "Personaje",
+  "kindWeapon": "Arma",
+```
+`app_fr.arb`:
+```json
+  "kindCharacter": "Personnage",
+  "kindWeapon": "Arme",
+```
+`app_pt_BR.arb`:
+```json
+  "kindCharacter": "Personagem",
+  "kindWeapon": "Arma",
+```
+`app_th.arb`:
+```json
+  "kindCharacter": "ตัวละคร",
+  "kindWeapon": "อาวุธ",
+```
+`app_vi.arb`:
+```json
+  "kindCharacter": "Nhân Vật",
+  "kindWeapon": "Vũ Khí",
+```
+
+> 注意：JSON 不可有尾逗號問題——若 `kindUnknown` 是該物件最後一個 key，插入後確保最後一個 key 無尾逗號。各 ARB 內 `kindUnknown` 後通常還有其他 key，照原檔逗號規則維持。
+
+- [ ] **Step 3: 重新產生 localizations**
+
+Run: `flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 出現 `String get kindCharacter;` 與 `String get kindWeapon;`。
+
+- [ ] **Step 4: 驗證 analyze 通過**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add kindCharacter and kindWeapon strings"
+```
+
+---
+
+## Task 2: 新增 itemTypeKeyOf / itemTypeKeyLabel primitive
+
+**Files:**
+- Create: `lib/services/item_type_kind.dart`
+- Test: `test/services/item_type_kind_test.dart`
+
+- [ ] **Step 1: 寫失敗測試**
+
+Create `test/services/item_type_kind_test.dart`:
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+
+GachaRecord _r({required String name, required String lang, String itemType = '角色'}) =>
+    GachaRecord(
+      id: '1',
+      uid: '1',
+      gachaType: '301',
+      name: name,
+      itemType: itemType,
+      rankType: 5,
+      time: DateTime(2025),
+      lang: lang,
+    );
+
+void main() {
+  // 迪希雅(zh-tw) 與 Dehya(en) 對到同一 hoyowiki id c1（menu_id 2＝角色）；
+  // 天空之翼 對到 w1（menu_id 4＝武器）。
+  final index = HoYoWikiIndex(
+    searchMap: const {
+      'zh-tw::迪希雅': 'c1',
+      'en::Dehya': 'c1',
+      'zh-tw::天空之翼': 'w1',
+    },
+    entries: const {},
+    menuIds: const {'c1': 2, 'w1': 4},
+  );
+
+  group('itemTypeKeyOf', () {
+    test('menu_id 2 → kind:character', () {
+      expect(itemTypeKeyOf(_r(name: '迪希雅', lang: 'zh-tw'), index), 'kind:character');
+    });
+
+    test('menu_id 4 → kind:weapon', () {
+      expect(itemTypeKeyOf(_r(name: '天空之翼', lang: 'zh-tw', itemType: '武器'), index), 'kind:weapon');
+    });
+
+    test('跨語系同物品合併成同一 key', () {
+      final zh = itemTypeKeyOf(_r(name: '迪希雅', lang: 'zh-tw', itemType: '角色'), index);
+      final en = itemTypeKeyOf(_r(name: 'Dehya', lang: 'en', itemType: 'Character'), index);
+      expect(zh, en);
+      expect(zh, 'kind:character');
+    });
+
+    test('查無 menu_id → fallback 原始 itemType', () {
+      expect(itemTypeKeyOf(_r(name: '未知物', lang: 'zh-tw', itemType: 'Character'), index), 'Character');
+    });
+
+    test('查無且原始字串為空 → 回空字串', () {
+      expect(itemTypeKeyOf(_r(name: '未知物', lang: 'zh-tw', itemType: ''), index), '');
+    });
+  });
+
+  group('itemTypeKeyLabel', () {
+    test('canonical key 轉在地化標籤；fallback 原樣', () async {
+      final l = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(itemTypeKeyLabel('kind:character', l), 'Character');
+      expect(itemTypeKeyLabel('kind:weapon', l), 'Weapon');
+      expect(itemTypeKeyLabel('', l), l.kindUnknown);
+      expect(itemTypeKeyLabel('裝扮', l), '裝扮');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `flutter test test/services/item_type_kind_test.dart`
+Expected: 編譯失敗（`item_type_kind.dart` 不存在 / `itemTypeKeyOf` 未定義）。
+
+- [ ] **Step 3: 實作 primitive**
+
+Create `lib/services/item_type_kind.dart`:
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+/// 角色類型聚合鍵；以 `kind:` 前綴與遊戲原始 itemType 字串（角色／Character…）區隔，
+/// 永不碰撞。
+const kItemKindCharacter = 'kind:character';
+
+/// 武器類型聚合鍵。
+const kItemKindWeapon = 'kind:weapon';
+
+/// 解析單筆 [r] 的類型聚合鍵：以 HoYoWiki [index] 的 menu_id 判定（2＝角色、
+/// 4＝武器），跨語系自然合併；查不到時 fallback 回原始 `itemType` 字串（含空字串）。
+String itemTypeKeyOf(GachaRecord r, HoYoWikiIndex index) {
+  final id = index.lookupId(name: r.name, lang: r.lang);
+  final menuId = id == null ? null : index.lookupMenuId(id);
+  return switch (menuId) {
+    2 => kItemKindCharacter,
+    4 => kItemKindWeapon,
+    _ => r.itemType,
+  };
+}
+
+/// 將 [key]（[itemTypeKeyOf] 產物）轉成顯示用在地化標籤：canonical 鍵套
+/// [l] 譯名、空字串顯示「未知」、其餘原始字串 fallback 原樣顯示。
+String itemTypeKeyLabel(String key, AppLocalizations l) => switch (key) {
+  kItemKindCharacter => l.kindCharacter,
+  kItemKindWeapon => l.kindWeapon,
+  '' => l.kindUnknown,
+  _ => key,
+};
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `flutter test test/services/item_type_kind_test.dart`
+Expected: All tests passed!
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/item_type_kind.dart test/services/item_type_kind_test.dart
+git commit -m "feat(wish): add HoYoWiki menu_id item-type key resolver"
+```
+
+---
+
+## Task 3: 圓餅圖統計改用聚合鍵（消除分裂）
+
+**Files:**
+- Modify: `lib/services/gacha_stats.dart`
+- Modify: `lib/widgets/item_type_pie.dart:54-58`
+- Modify: `lib/services/overview_sections.dart:104-106,165,181`
+- Modify: `lib/pages/banner_page.dart:93`
+- Modify: `lib/pages/overview_page.dart:54`
+- Modify: `lib/widgets/share/share_card.dart:111,163`
+- Test: `test/services/gacha_stats_test.dart`、`test/services/overview_sections_test.dart`、`test/widgets/item_type_pie_test.dart`
+
+- [ ] **Step 1: 更新 `gacha_stats_test.dart` — 既有呼叫補 `index`（驗無回歸）+ 新增跨語系合併測試**
+
+`gacha_stats_test.dart` 頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+```
+把檔內所有 `computeGachaStats(records)` / `computeGachaStats(const [])` 改為帶 `index: const HoYoWikiIndex.empty()`（空 index → 全 fallback 原始字串 → 既有 assertion 不變，即無回歸）。例如：
+```dart
+final s = computeGachaStats(const [], index: const HoYoWikiIndex.empty());
+```
+```dart
+final s = computeGachaStats(records, index: const HoYoWikiIndex.empty());
+```
+（共 6 處：第 20、35、52、64、73、83 行附近。）
+
+在 `group('GachaStats', ...)` 內新增測試：
+```dart
+test('跨語系同物品以 menu_id 合併，不分裂', () {
+  final index = HoYoWikiIndex(
+    searchMap: const {'zh-tw::迪希雅': 'c1', 'en::Dehya': 'c1'},
+    entries: const {},
+    menuIds: const {'c1': 2},
+  );
+  final records = [
+    _r(id: '1', itemType: '角色'),
+    GachaRecord(
+      id: '2', uid: '1', gachaType: '301', name: 'Dehya',
+      itemType: 'Character', rankType: 5, time: DateTime(2025), lang: 'en',
+    ),
+  ];
+  // _r 的 name 預設為 'x'、lang 'zh-tw'；需讓第一筆 name 命中 index。
+  final stats = computeGachaStats([
+    GachaRecord(
+      id: '1', uid: '1', gachaType: '301', name: '迪希雅',
+      itemType: '角色', rankType: 5, time: DateTime(2025), lang: 'zh-tw',
+    ),
+    records[1],
+  ], index: index);
+  expect(stats.byItemType, {'kind:character': 2});
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `flutter test test/services/gacha_stats_test.dart`
+Expected: 編譯失敗（`computeGachaStats` 尚無 `index` 具名參數）。
+
+- [ ] **Step 3: 改 `computeGachaStats` 簽名與聚合 + summary log**
+
+`lib/services/gacha_stats.dart` 頂部 import 加：
+```dart
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+```
+在 `computeGachaStats` 前加 logger：
+```dart
+/// 祈願統計 logger。
+final _log = Logger('gacha.stats');
+```
+把函式：
+```dart
+GachaStats computeGachaStats(List<GachaRecord> records) {
+  var five = 0, four = 0, three = 0, two = 0;
+  final byItemType = <String, int>{};
+  for (final r in records) {
+    switch (r.rankType) {
+      case 5:
+        five++;
+      case 4:
+        four++;
+      case 3:
+        three++;
+      case 2:
+        two++;
+    }
+    byItemType[r.itemType] = (byItemType[r.itemType] ?? 0) + 1;
+  }
+```
+改為：
+```dart
+GachaStats computeGachaStats(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+}) {
+  var five = 0, four = 0, three = 0, two = 0;
+  var canonical = 0, fallback = 0;
+  final byItemType = <String, int>{};
+  for (final r in records) {
+    switch (r.rankType) {
+      case 5:
+        five++;
+      case 4:
+        four++;
+      case 3:
+        three++;
+      case 2:
+        two++;
+    }
+    final key = itemTypeKeyOf(r, index);
+    if (key == kItemKindCharacter || key == kItemKindWeapon) {
+      canonical++;
+    } else {
+      fallback++;
+    }
+    byItemType[key] = (byItemType[key] ?? 0) + 1;
+  }
+  if (records.isNotEmpty) {
+    _log.fine(
+      'computeGachaStats: total=${records.length} '
+      'canonicalKind=$canonical rawFallback=$fallback',
+    );
+  }
+```
+（`return GachaStats(...)` 區塊不變。）
+
+- [ ] **Step 4: 更新 stats 呼叫點補 `index`**
+
+`lib/pages/banner_page.dart:93`：
+```dart
+    final stats = computeGachaStats(records, index: ref.watch(hoyowikiIndexProvider));
+```
+（`banner_page.dart` 已 import `hoyowiki_index.dart` state；若無則加 `import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';`。第 123 行已用 `ref.watch(hoyowikiIndexProvider)`，故 import 已存在。）
+
+`lib/widgets/share/share_card.dart:111`：
+```dart
+    final stats = computeGachaStats(records, index: index);
+```
+
+`lib/services/overview_sections.dart`：把
+```dart
+OverviewSections buildOverviewSections(
+  Map<String, List<GachaRecord>> activeBanners,
+) {
+```
+改為（頂部 import 加 `import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';`）：
+```dart
+OverviewSections buildOverviewSections(
+  Map<String, List<GachaRecord>> activeBanners, {
+  required HoYoWikiIndex index,
+}) {
+```
+第 165、181 行：
+```dart
+      stats: computeGachaStats(gachaAll, index: index),
+```
+```dart
+      stats: computeGachaStats(odesAll, index: index),
+```
+
+`lib/pages/overview_page.dart:54`：
+```dart
+    final sections = buildOverviewSections(
+      activeData.banners,
+      index: ref.watch(hoyowikiIndexProvider),
+    );
+```
+（`overview_page.dart` 已 import state hoyowiki，見第 151、199 行。）
+
+`lib/widgets/share/share_card.dart:163`：
+```dart
+    final s = buildOverviewSections(banners, index: index);
+```
+
+- [ ] **Step 5: 圓餅圖 legend 顯示套 `itemTypeKeyLabel`**
+
+`lib/widgets/item_type_pie.dart` 頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+```
+把第 54-58 行 `DistributionEntry(... name: e.key.isEmpty ? l.kindUnknown : e.key, ...)` 的 `name` 改為：
+```dart
+        name: itemTypeKeyLabel(e.key, l),
+```
+
+- [ ] **Step 6: 更新 `overview_sections_test.dart` 補 `index`**
+
+找出檔內所有 `buildOverviewSections(...)` 呼叫，補 `index: const HoYoWikiIndex.empty()`（import `hoyowiki_index.dart`）。例如：
+```dart
+final sections = buildOverviewSections(banners, index: const HoYoWikiIndex.empty());
+```
+
+- [ ] **Step 7: 更新 `item_type_pie_test.dart`**
+
+檔內所有 `computeGachaStats(...)` 補 `index: const HoYoWikiIndex.empty()`（import `hoyowiki_index.dart`）。空 index 下原始字串 legend 行為不變，既有 assertion 應仍成立；若有測「未知」legend 的案例（空 itemType）維持以 `kindUnknown` 呈現，不需改。
+
+- [ ] **Step 8: 跑相關測試**
+
+Run: `flutter test test/services/gacha_stats_test.dart test/services/overview_sections_test.dart test/widgets/item_type_pie_test.dart`
+Expected: All tests passed!
+
+- [ ] **Step 9: analyze + commit**
+
+Run: `flutter analyze`（Expected: `No issues found!`）
+```bash
+git add lib/services/gacha_stats.dart lib/widgets/item_type_pie.dart lib/services/overview_sections.dart lib/pages/banner_page.dart lib/pages/overview_page.dart lib/widgets/share/share_card.dart test/
+git commit -m "feat(wish): aggregate item-type stats by HoYoWiki kind key"
+```
+
+---
+
+## Task 4: RecordRow 帶 itemTypeKey
+
+**Files:**
+- Modify: `lib/services/gacha_row.dart`
+- Modify: `lib/pages/banner_page.dart:111`
+- Test: `test/services/gacha_row_test.dart`
+
+- [ ] **Step 1: 更新 `gacha_row_test.dart`**
+
+頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+```
+把檔內所有 `buildRecordRows(records)` / `buildRecordRows(records, mainRank: X)` 補 `index: const HoYoWikiIndex.empty()`。例如：
+```dart
+final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
+```
+新增測試（驗 itemTypeKey 命中與 fallback）：
+```dart
+test('itemTypeKey: menu_id 命中用 canonical，miss fallback 原始字串', () {
+  final index = HoYoWikiIndex(
+    searchMap: const {'zh-tw::迪希雅': 'c1'},
+    entries: const {},
+    menuIds: const {'c1': 2},
+  );
+  final records = [
+    GachaRecord(
+      id: '1', uid: '1', gachaType: '301', name: '迪希雅',
+      itemType: '角色', rankType: 5, time: DateTime(2025, 1, 2), lang: 'zh-tw',
+    ),
+    GachaRecord(
+      id: '2', uid: '1', gachaType: '301', name: '某武器',
+      itemType: '武器', rankType: 4, time: DateTime(2025, 1, 1), lang: 'zh-tw',
+    ),
+  ];
+  final rows = buildRecordRows(records, index: index);
+  expect(rows[0].itemTypeKey, 'kind:character'); // 迪希雅命中
+  expect(rows[1].itemTypeKey, '武器');             // 未命中 → 原始字串
+});
+```
+（注意：`buildRecordRows` 輸出順序與輸入相同（desc by time），`records` 以 time desc 排，故 rows[0]＝迪希雅。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `flutter test test/services/gacha_row_test.dart`
+Expected: 編譯失敗（`buildRecordRows` 無 `index` 參數、`RecordRow.itemTypeKey` 不存在）。
+
+- [ ] **Step 3: `RecordRow` 加欄位、`buildRecordRows` 加 index**
+
+`lib/services/gacha_row.dart` 頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+```
+`RecordRow` 加欄位與建構參數：
+```dart
+  const RecordRow({
+    required this.record,
+    required this.totalIndex,
+    required this.mainPityIndex,
+    required this.itemTypeKey,
+  });
+```
+```dart
+  /// 跨語言無關的類型聚合鍵（[itemTypeKeyOf] 產物：kind:character / kind:weapon
+  /// / 原始字串）。供表格類型欄顯示、排序、篩選共用，避免各處重複解析 index。
+  final String itemTypeKey;
+```
+`buildRecordRows` 簽名與 row 建構：
+```dart
+List<RecordRow> buildRecordRows(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+  int mainRank = 5,
+}) {
+```
+迴圈內 `out.add(...)`：
+```dart
+    out.add(RecordRow(
+      record: r,
+      totalIndex: total,
+      mainPityIndex: pity,
+      itemTypeKey: itemTypeKeyOf(r, index),
+    ));
+```
+
+- [ ] **Step 4: 更新 banner_page 呼叫點**
+
+`lib/pages/banner_page.dart:111`：
+```dart
+    final allRows = buildRecordRows(
+      records,
+      index: ref.watch(hoyowikiIndexProvider),
+      mainRank: primary.rank,
+    );
+```
+
+- [ ] **Step 5: 跑測試確認通過 + analyze**
+
+Run: `flutter test test/services/gacha_row_test.dart`（Expected: All tests passed!）
+Run: `flutter analyze`（Expected: `No issues found!`）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/services/gacha_row.dart lib/pages/banner_page.dart test/services/gacha_row_test.dart
+git commit -m "feat(wish): stamp item-type key onto RecordRow"
+```
+
+---
+
+## Task 5: 表格類型欄顯示 + 排序改用 itemTypeKey
+
+**Files:**
+- Modify: `lib/services/gacha_filter.dart:135`（`sortRecordRows` 的 `SortColumn.kind`）
+- Modify: `lib/widgets/data/sortable_table.dart:413`
+- Test: `test/services/gacha_filter_test.dart`、`test/widgets/data/sortable_table_test.dart`
+
+- [ ] **Step 1: 更新 `gacha_filter_test.dart` 的排序測試**
+
+檔內凡建 `RecordRow`（直接 new 或經 `buildRecordRows`）的地方須提供 `itemTypeKey`。
+- 若用 `buildRecordRows(...)`：補 `index: const HoYoWikiIndex.empty()`（import `hoyowiki_index.dart`）。
+- 若直接 `RecordRow(...)`：補 `itemTypeKey: '<該列原始 itemType 或 kind:xxx>'`。
+
+新增／調整「依 kind 排序」測試，斷言改以 `itemTypeKey` 為排序鍵。範例：
+```dart
+test('SortColumn.kind 依 itemTypeKey 排序', () {
+  final rows = [
+    RecordRow(record: _rec('a'), totalIndex: 1, mainPityIndex: 1, itemTypeKey: 'kind:weapon'),
+    RecordRow(record: _rec('b'), totalIndex: 2, mainPityIndex: 2, itemTypeKey: 'kind:character'),
+  ];
+  final sorted = sortRecordRows(rows, const TableSort(column: SortColumn.kind, direction: SortDirection.asc));
+  expect(sorted.first.itemTypeKey, 'kind:character');
+});
+```
+（`_rec` 為該測試檔既有的 record helper；若名稱不同，沿用檔內現有 helper。）
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `flutter test test/services/gacha_filter_test.dart`
+Expected: FAIL（排序仍用 `record.itemType`，斷言不符）或編譯失敗（`RecordRow` 缺 `itemTypeKey`）。
+
+- [ ] **Step 3: `sortRecordRows` 的 kind 改比 itemTypeKey**
+
+`lib/services/gacha_filter.dart:135-136`：
+```dart
+    case SortColumn.kind:
+      cmp = (a, b) => a.record.itemType.compareTo(b.record.itemType);
+```
+改為：
+```dart
+    case SortColumn.kind:
+      cmp = (a, b) => a.itemTypeKey.compareTo(b.itemTypeKey);
+```
+
+- [ ] **Step 4: 表格類型欄顯示套 label**
+
+`lib/widgets/data/sortable_table.dart` 頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+```
+第 413 行：
+```dart
+          Expanded(flex: 2, child: Text(record.itemType)),
+```
+改為（`_Row` 內 `row` 與 `l` 均在 scope）：
+```dart
+          Expanded(flex: 2, child: Text(itemTypeKeyLabel(row.itemTypeKey, l))),
+```
+
+- [ ] **Step 5: 更新 `sortable_table_test.dart`**
+
+檔內建 `RecordRow` / `buildRecordRows` 處補 `itemTypeKey` / `index`（同 Step 1 規則）。若有斷言類型欄文字＝原始 itemType（如 `'角色'`），改為驗 `itemTypeKeyLabel` 結果——空 index fallback 下原始字串照舊顯示，故原斷言多半仍成立；canonical 命中的測試案例改驗在地化標籤。
+
+- [ ] **Step 6: 跑測試 + analyze**
+
+Run: `flutter test test/services/gacha_filter_test.dart test/widgets/data/sortable_table_test.dart`（Expected: All tests passed!）
+Run: `flutter analyze`（Expected: `No issues found!`）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/services/gacha_filter.dart lib/widgets/data/sortable_table.dart test/services/gacha_filter_test.dart test/widgets/data/sortable_table_test.dart
+git commit -m "feat(wish): display and sort item-type column by kind key"
+```
+
+---
+
+## Task 6: 篩選下拉與過濾改用 itemTypeKey
+
+**Files:**
+- Modify: `lib/services/gacha_filter.dart:117`（`filterRecordRows`）
+- Modify: `lib/pages/banner_page.dart:114-120`（`availableItemTypes`）+ 傳給 `SearchFilterBar` 的型別
+- Modify: `lib/widgets/data/search_filter_bar.dart:131-132`（下拉 label）
+- Test: `test/services/gacha_filter_test.dart`、`test/widgets/data/search_filter_bar_test.dart`
+
+- [ ] **Step 1: 更新 `gacha_filter_test.dart` 的過濾測試**
+
+新增／調整「依 itemType 過濾」測試，`RecordFilter.itemType` 存的是聚合鍵：
+```dart
+test('filterRecordRows 依 itemTypeKey 過濾', () {
+  final rows = [
+    RecordRow(record: _rec('a'), totalIndex: 1, mainPityIndex: 1, itemTypeKey: 'kind:character'),
+    RecordRow(record: _rec('b'), totalIndex: 2, mainPityIndex: 2, itemTypeKey: 'kind:weapon'),
+  ];
+  final out = filterRecordRows(rows, const RecordFilter(itemType: 'kind:character'));
+  expect(out.length, 1);
+  expect(out.first.itemTypeKey, 'kind:character');
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `flutter test test/services/gacha_filter_test.dart`
+Expected: FAIL（`filterRecordRows` 仍比 `r.itemType`）。
+
+- [ ] **Step 3: `filterRecordRows` 改比 itemTypeKey**
+
+`lib/services/gacha_filter.dart:117`：
+```dart
+        if (f.itemType != null && r.itemType != f.itemType) return false;
+```
+改為（注意此處 `r` 是 `row.record`，需改用 `row.itemTypeKey`；檢視該 `where` 區塊把 `final r = row.record;` 保留，新增比較用 `row.itemTypeKey`）：
+```dart
+        if (f.itemType != null && row.itemTypeKey != f.itemType) return false;
+```
+
+- [ ] **Step 4: 跑過濾測試確認通過**
+
+Run: `flutter test test/services/gacha_filter_test.dart`
+Expected: All tests passed!
+
+- [ ] **Step 5: banner_page 的 availableItemTypes 改用 rows 的 itemTypeKey**
+
+`lib/pages/banner_page.dart:114-120`：
+```dart
+    final availableItemTypes =
+        records
+            .map((r) => r.itemType)
+            .where((s) => s.isNotEmpty)
+            .toSet()
+            .toList()
+          ..sort();
+```
+改為（用已建好的 `allRows`，去重 distinct key、空字串排除）：
+```dart
+    final availableItemTypes =
+        allRows
+            .map((row) => row.itemTypeKey)
+            .where((k) => k.isNotEmpty)
+            .toSet()
+            .toList()
+          ..sort();
+```
+（`allRows` 於 Task 4 已含 itemTypeKey，且定義在第 111 行，位於此段之前。）
+
+- [ ] **Step 6: SearchFilterBar 下拉 label 套 itemTypeKeyLabel**
+
+`lib/widgets/data/search_filter_bar.dart` 頂部 import 加：
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+```
+第 131-132 行：
+```dart
+            for (final t in widget.availableItemTypes)
+              DropdownMenuItem<String?>(value: t, child: Text(t)),
+```
+改為：
+```dart
+            for (final t in widget.availableItemTypes)
+              DropdownMenuItem<String?>(value: t, child: Text(itemTypeKeyLabel(t, l))),
+```
+（`availableItemTypes` 的 dartdoc 文案順手更新為「當前 banner 出現過的類型聚合鍵集合」。）
+
+- [ ] **Step 7: 更新 `search_filter_bar_test.dart`**
+
+`availableItemTypes` 傳入值改為聚合鍵（如 `['kind:character', 'kind:weapon']` 或原始字串 fallback）。若有斷言下拉項顯示文字，改驗 `itemTypeKeyLabel` 對應的在地化標籤（widget test 內可用 `tester` 找到的 `AppLocalizations`，或直接斷言文字如 'Character'／視測試語系而定）。
+
+- [ ] **Step 8: 跑測試 + analyze**
+
+Run: `flutter test test/services/gacha_filter_test.dart test/widgets/data/search_filter_bar_test.dart`（Expected: All tests passed!）
+Run: `flutter analyze`（Expected: `No issues found!`）
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/services/gacha_filter.dart lib/pages/banner_page.dart lib/widgets/data/search_filter_bar.dart test/services/gacha_filter_test.dart test/widgets/data/search_filter_bar_test.dart
+git commit -m "feat(wish): filter records by kind key and localize dropdown"
+```
+
+---
+
+## Task 7: 全套品質檢查
+
+**Files:** 無（驗證）
+
+- [ ] **Step 1: 格式化**
+
+Run: `dart format lib/ test/`
+Expected: 顯示已格式化檔案數，無錯誤。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: 全套測試**
+
+Run: `flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 如格式化有變更則 commit**
+
+```bash
+git add -A
+git commit -m "style: format item-type classification changes"
+```
+（若 `git status` 乾淨則略過。）
+
+---
+
+## Self-Review 紀錄
+
+- **Spec coverage**：圓餅圖統計（Task 3）、表格類型欄＋排序（Task 5）、篩選下拉（Task 6）、primitive＋fallback（Task 2）、i18n（Task 1）、summary log（Task 3 Step 3）、測試（各 task 內含 + Task 7）。三畫面全覆蓋。
+- **無 placeholder**：所有 step 含實際程式碼／指令／預期輸出。
+- **型別一致**：`itemTypeKeyOf` / `itemTypeKeyLabel` / `kItemKindCharacter` / `kItemKindWeapon` / `RecordRow.itemTypeKey` / `computeGachaStats(..., {required index})` / `buildRecordRows(..., {required index, mainRank})` / `buildOverviewSections(..., {required index})` 跨 task 命名一致。
+- **編譯連續性**：每個 task 結尾 analyze + test 綠燈；簽名變更與其呼叫點在同一 task 內更新。

--- a/docs/superpowers/specs/2026-05-29-hoyowiki-item-type-classification-design.md
+++ b/docs/superpowers/specs/2026-05-29-hoyowiki-item-type-classification-design.md
@@ -1,0 +1,142 @@
+# 用 HoYoWiki menu_id 判定物品類型（消除跨語言統計分裂）
+
+## 背景與問題
+
+`GachaRecord.itemType` 是抓取當下遊戲語言的原始字串，依 `record.lang` 而定：
+zh-tw「角色／武器」、en「Character／Weapon」、ja「キャラクター／武器」……，並未對 UI
+語言翻譯。
+
+連帶 bug：`computeGachaStats` 以原始 `itemType` 字串聚合（`byItemType[r.itemType]`）。
+若使用者曾切換遊戲語言再同步，同一種類型會以多個語言字串存在，導致：
+
+- 類型圓餅圖分裂成多塊（同一個「角色」被算成「角色」「Character」兩塊）。
+- 篩選下拉出現重複的類型選項。
+- 表格「類型」欄顯示混雜語言。
+
+## 目標
+
+以 HoYoWiki 的 `menu_id`（語言無關的官方分類：**2＝角色、4＝武器**）作為類型判定依據，
+消除跨語言分裂。涵蓋三個受影響畫面：**類型圓餅圖統計**、**記錄列表「類型」欄（含排序）**、
+**篩選下拉**。
+
+## 非目標
+
+- 物品**名稱**的在地化（需整套遊戲辭典，YAGNI）。
+- 強制或主動觸發 HoYoWiki 拓圖；沿用既有 lazy／選用抓取流程。
+- 存檔 schema 變更或資料遷移。
+
+## 既有基礎（已存在，直接重用）
+
+- `HoYoWikiIndex`（`lib/services/hoyowiki_index.dart`）已帶：
+  - `searchMap`：`"<lang>::<name>"` → `hoyowiki_id`，方法 `lookupId({name, lang})`。
+  - `menuIds`：`hoyowiki_id` → `menu_id`（2／4），方法 `lookupMenuId(id)`。
+- `hoyowikiIndexProvider`（`lib/state/hoyowiki_index.dart`）是 live Riverpod provider，
+  拓圖完成會 emit 新 index → watch 的 widget 自動 rebuild。
+- 既有範例 `buildFiveStarCollection(records, {required HoYoWikiIndex index})`
+  （`lib/services/five_star_collection.dart`）已確立慣例：**service 吃 records + index，
+  以 `index.lookupId` 跨語系合併、miss 時 fallback**。本設計沿用此模式。
+
+## 設計
+
+### 核心 primitive
+
+新增共用方法（放 `lib/services/`，併入 `gacha_stats.dart` 或新檔 `item_type_kind.dart`）：
+
+```dart
+/// canonical key 前綴；與任何遊戲原始 itemType 字串（角色／Character…）不會碰撞。
+const _kindCharacter = 'kind:character';
+const _kindWeapon = 'kind:weapon';
+
+/// 解析單筆 record 的類型聚合鍵：menu_id 命中用 canonical，miss fallback 原始字串。
+String itemTypeKeyOf(GachaRecord r, HoYoWikiIndex index) {
+  final id = index.lookupId(name: r.name, lang: r.lang);
+  final menuId = id == null ? null : index.lookupMenuId(id);
+  return switch (menuId) {
+    2 => _kindCharacter,
+    4 => _kindWeapon,
+    _ => r.itemType,
+  };
+}
+
+/// key → 顯示用在地化標籤。
+String itemTypeKeyLabel(String key, AppLocalizations l) => switch (key) {
+  _kindCharacter => l.kindCharacter,
+  _kindWeapon => l.kindWeapon,
+  '' => l.kindUnknown,
+  _ => key, // 原始字串 fallback 原樣顯示
+};
+```
+
+**Fallback 行為（hybrid）**：menu_id 查得到用 canonical kind（跨語系合併成同一塊）；查不到
+（使用者沒跑過拓圖、該物品 wiki 沒收錄、或拓圖失敗）退回顯示原始 `itemType` 字串。已抓過的
+記錄不論語言都合併；只有未抓過且跨語言的記錄仍可能各自分開——這是 hybrid 取捨，且**單語言或
+沒跑過拓圖的使用者完全等同現狀，無回歸**。
+
+### 三個畫面的接法
+
+**A. 類型圓餅圖統計**
+
+- `computeGachaStats(records, {required HoYoWikiIndex index})`：`byItemType` 改用
+  `itemTypeKeyOf(r, index)` 聚合（取代 `r.itemType`）。
+- `itemTypeDistributionEntries`（`lib/widgets/item_type_pie.dart`）顯示時，entry 的
+  `name` 由 `itemTypeKeyLabel(key, l)` 求得（取代目前 `e.key.isEmpty ? l.kindUnknown : e.key`）。
+- 三個呼叫點補上 `index:`：
+  - `lib/pages/banner_page.dart:93` —— 已有 `ref.watch(hoyowikiIndexProvider)`。
+  - `lib/services/overview_sections.dart:165,181` —— `buildOverviewSections` 加
+    `{required HoYoWikiIndex index}` 參數往下傳；呼叫點 `overview_page.dart:54` 與 share
+    路徑補上（兩處皆已可取得 index）。
+  - `lib/widgets/share/share_card.dart:111` —— 離屏渲染已攜帶 HoYoWiki 資料（五星一覽用），
+    沿同一路徑取得 index。
+
+**B. 記錄列表「類型」欄 + 排序**
+
+- `RecordRow`（`lib/services/gacha_row.dart`）新增 `final String itemTypeKey`，於
+  `buildRecordRows(records, {required HoYoWikiIndex index})` 建構時用 `itemTypeKeyOf` 算好。
+  如此排序／篩選純函式簽名**不必吃 index**。
+- `sortable_table.dart:413` `Text(record.itemType)` → `Text(itemTypeKeyLabel(row.itemTypeKey, l))`。
+- `sortRecordRows` 的 `SortColumn.kind`（`gacha_filter.dart:135`）改比 `row.itemTypeKey`。
+  排序後標籤分組更直覺（character／weapon 各自聚集）。
+- `buildRecordRows` 呼叫點（`banner_page.dart:111` 等）補上 `index:`。
+
+**C. 篩選下拉**
+
+- `availableItemTypes`（`banner_page.dart:114–120`）改由 `allRows` 的 distinct
+  `itemTypeKey` 建（取代原始字串 set）。
+- `SearchFilterBar` 下拉 label 套 `itemTypeKeyLabel`（取代目前直接 `Text(t)`）。
+- `filterRecordRows`（`gacha_filter.dart:117`）`r.itemType != f.itemType` →
+  `row.itemTypeKey != f.itemType`。
+- `RecordFilter.itemType` **維持 `String?`**（存的是 key 字串）——零狀態遷移；
+  `recordFilterProvider` 持久化內容沿用既有 schema。
+
+### i18n
+
+- 新增 `kindCharacter` / `kindWeapon`（`kindUnknown` 已存在）。
+- 值依 `docs/術語表.md`（權威來源）填：zh-tw＝「角色」「武器」。
+- 從 `app_zh.arb` 起手，只加進**已有實體翻譯**的 ARB；空殼 ARB 留給 Crowdin pipeline。
+
+### Logging
+
+- `itemTypeKeyOf` 屬熱路徑（每筆 record 都跑），**不**逐筆埋 log。
+- 在聚合層加 summary：`computeGachaStats` 結尾 `Logger('gacha.stats').fine(...)`，記 canonical
+  命中數 vs fallback 筆數，方便日後判斷使用者拓圖覆蓋率。
+
+## 測試
+
+- **`itemTypeKeyOf`**：menu_id=2／4 命中回 canonical；miss 回原始字串；跨語系（zh-tw「角色」
+  與 en「Character」對到同一 hoyowiki_id）合併成同一 key。
+- **`computeGachaStats`**：跨語系記錄 + 命中的 index → `byItemType` 不分裂；命中項 fallback
+  路徑（空 index）→ 維持原始字串聚合（無回歸）。
+- **`filterRecordRows` / `sortRecordRows`**：以 `itemTypeKey` 過濾與排序。
+- **`buildRecordRows`**：`itemTypeKey` 正確標記。
+- 更新既有 `item_type_pie_test`、`sortable_table_test`、`search_filter_bar_test`、
+  `overview_sections_test`、`gacha_stats_test`、`gacha_filter_test`、`gacha_row_test`
+  以符合新簽名。
+
+## 風險與取捨
+
+- **碰撞**：canonical key 用 `kind:` 前綴，遊戲原始 itemType 字串（角色／Character／
+  キャラクター…）絕不會等於 `kind:character`，無碰撞風險。
+- **混雜顯示**：當同類型同時存在「已抓（canonical 在地化標籤）」與「未抓（原始字串）」記錄時，
+  圓餅圖／下拉會出現兩個項目。這是 hybrid fallback 的固有行為，使用者已接受；跑完整拓圖後消失。
+- **效能**：聚合改為顯示時即時計算，資料量小（單一帳號祈願記錄）可忽略，與
+  `five_star_collection` 同等級。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "Type Distribution",
   "statsNoData": "No data",
   "kindUnknown": "Unknown",
+  "kindCharacter": "Character",
+  "kindWeapon": "Weapon",
   "tableTime": "Time",
   "tableName": "Name",
   "tableKind": "Type",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "Distribución por tipo",
   "statsNoData": "Datos no encontrados",
   "kindUnknown": "Desconocido",
+  "kindCharacter": "Personaje",
+  "kindWeapon": "Arma",
   "tableTime": "Hora de recepcion",
   "tableName": "Nombre",
   "tableKind": "Tipo",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "Distribution par type",
   "statsNoData": "Données introuvables",
   "kindUnknown": "Inconnu",
+  "kindCharacter": "Personnage",
+  "kindWeapon": "Arme",
   "tableTime": "Heure de réception",
   "tableName": "Nom",
   "tableKind": "Type",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "タイプ分布",
   "statsNoData": "データがありません",
   "kindUnknown": "不明",
+  "kindCharacter": "キャラクター",
+  "kindWeapon": "武器",
   "tableTime": "日時",
   "tableName": "名称",
   "tableKind": "タイプ",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "Distribuição por tipo",
   "statsNoData": "Sem dados",
   "kindUnknown": "Desconhecido",
+  "kindCharacter": "Personagem",
+  "kindWeapon": "Arma",
   "tableTime": "Hora",
   "tableName": "O nome",
   "tableKind": "tipo",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "การกระจายประเภทไอเทม",
   "statsNoData": "ไม่มีข้อมูล",
   "kindUnknown": "ไม่ทราบ",
+  "kindCharacter": "ตัวละคร",
+  "kindWeapon": "อาวุธ",
   "tableTime": "เวลาที่ได้รับ",
   "tableName": "ชื่อ",
   "tableKind": "รูปแบบ",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -131,6 +131,8 @@
   "statsItemTypeDistribution": "Phân bổ loại vật phẩm",
   "statsNoData": "Không có dữ liệu",
   "kindUnknown": "Không rõ",
+  "kindCharacter": "Nhân Vật",
+  "kindWeapon": "Vũ Khí",
   "tableTime": "Thời Gian",
   "tableName": "Tên",
   "tableKind": "Loại",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -106,6 +106,8 @@
   "statsNoData": "無資料",
 
   "kindUnknown": "未知",
+  "kindCharacter": "角色",
+  "kindWeapon": "武器",
 
   "tableTime": "時間",
   "tableName": "名稱",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -127,6 +127,8 @@
   "statsItemTypeDistribution": "类型分布",
   "statsNoData": "无数据",
   "kindUnknown": "未知",
+  "kindCharacter": "角色",
+  "kindWeapon": "武器",
   "tableTime": "时间",
   "tableName": "名称",
   "tableKind": "类型",

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -111,7 +111,11 @@ class BannerPage extends ConsumerWidget {
     final isEndedPool = type.gachaType == '100';
 
     final filterState = ref.watch(recordFilterProvider(gachaType));
-    final allRows = buildRecordRows(records, mainRank: primary.rank);
+    final allRows = buildRecordRows(
+      records,
+      index: ref.watch(hoyowikiIndexProvider),
+      mainRank: primary.rank,
+    );
     final filtered = filterRecordRows(allRows, filterState.filter);
     final sorted = sortRecordRows(filtered, filterState.sort);
     final availableItemTypes =

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -90,7 +90,10 @@ class BannerPage extends ConsumerWidget {
       );
     }
 
-    final stats = computeGachaStats(records);
+    final stats = computeGachaStats(
+      records,
+      index: ref.watch(hoyowikiIndexProvider),
+    );
     final primary = type.primaryPity;
     final secondary = type.secondaryPity;
     final primaryPityData = computePity(

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -90,10 +90,8 @@ class BannerPage extends ConsumerWidget {
       );
     }
 
-    final stats = computeGachaStats(
-      records,
-      index: ref.watch(hoyowikiIndexProvider),
-    );
+    final hoyowikiIndex = ref.watch(hoyowikiIndexProvider);
+    final stats = computeGachaStats(records, index: hoyowikiIndex);
     final primary = type.primaryPity;
     final secondary = type.secondaryPity;
     final primaryPityData = computePity(
@@ -113,21 +111,21 @@ class BannerPage extends ConsumerWidget {
     final filterState = ref.watch(recordFilterProvider(gachaType));
     final allRows = buildRecordRows(
       records,
-      index: ref.watch(hoyowikiIndexProvider),
+      index: hoyowikiIndex,
       mainRank: primary.rank,
     );
     final filtered = filterRecordRows(allRows, filterState.filter);
     final sorted = sortRecordRows(filtered, filterState.sort);
     final availableItemTypes =
-        records
-            .map((r) => r.itemType)
-            .where((s) => s.isNotEmpty)
+        allRows
+            .map((row) => row.itemTypeKey)
+            .where((k) => k.isNotEmpty)
             .toSet()
             .toList()
           ..sort();
     final fiveStarItems = buildFiveStarCollection(
       records,
-      index: ref.watch(hoyowikiIndexProvider),
+      index: hoyowikiIndex,
     );
 
     return SingleChildScrollView(

--- a/lib/pages/overview_page.dart
+++ b/lib/pages/overview_page.dart
@@ -51,7 +51,10 @@ class OverviewPage extends ConsumerWidget {
       return EmptyState.noSync(context);
     }
 
-    final sections = buildOverviewSections(activeData.banners);
+    final sections = buildOverviewSections(
+      activeData.banners,
+      index: ref.watch(hoyowikiIndexProvider),
+    );
     final gachaSec = sections.gacha;
     final odesSec = sections.odes;
     final bannerColors = BannerColors.of(Theme.of(context).brightness);

--- a/lib/services/gacha_filter.dart
+++ b/lib/services/gacha_filter.dart
@@ -133,7 +133,7 @@ List<RecordRow> sortRecordRows(List<RecordRow> rows, TableSort? sort) {
     case SortColumn.name:
       cmp = (a, b) => a.record.name.compareTo(b.record.name);
     case SortColumn.kind:
-      cmp = (a, b) => a.record.itemType.compareTo(b.record.itemType);
+      cmp = (a, b) => a.itemTypeKey.compareTo(b.itemTypeKey);
     case SortColumn.rarity:
       cmp = (a, b) => a.record.rankType.compareTo(b.record.rankType);
     case SortColumn.totalIndex:

--- a/lib/services/gacha_filter.dart
+++ b/lib/services/gacha_filter.dart
@@ -27,7 +27,9 @@ class RecordFilter {
   /// 稀有度篩選。
   final RarityFilter rarity;
 
-  /// 物品類型篩選；null 表示不限。
+  /// 物品類型篩選；null 表示不限。儲存 [itemTypeKeyOf] 的產物（canonical 鍵如
+  /// `kind:character`，或查無 menu_id 時 fallback 的原始 itemType 字串），與
+  /// `RecordRow.itemTypeKey` 同一套詞彙比對。
   final String? itemType;
 
   /// 關鍵字搜尋字串。

--- a/lib/services/gacha_filter.dart
+++ b/lib/services/gacha_filter.dart
@@ -114,7 +114,7 @@ List<RecordRow> filterRecordRows(List<RecordRow> rows, RecordFilter f) {
         final r = row.record;
         if (f.rarity == RarityFilter.fiveStar && r.rankType != 5) return false;
         if (f.rarity == RarityFilter.fourStar && r.rankType != 4) return false;
-        if (f.itemType != null && r.itemType != f.itemType) return false;
+        if (f.itemType != null && row.itemTypeKey != f.itemType) return false;
         if (q.isNotEmpty && !r.name.toLowerCase().contains(q)) return false;
         return true;
       })

--- a/lib/services/gacha_filter.dart
+++ b/lib/services/gacha_filter.dart
@@ -135,6 +135,8 @@ List<RecordRow> sortRecordRows(List<RecordRow> rows, TableSort? sort) {
     case SortColumn.name:
       cmp = (a, b) => a.record.name.compareTo(b.record.name);
     case SortColumn.kind:
+      // 依聚合鍵（語言無關）字典序排，canonical 的角色／武器各自聚集；
+      // 刻意不依在地化標籤排序，避免排序結果隨 UI 語言變動。
       cmp = (a, b) => a.itemTypeKey.compareTo(b.itemTypeKey);
     case SortColumn.rarity:
       cmp = (a, b) => a.record.rankType.compareTo(b.record.rankType);

--- a/lib/services/gacha_row.dart
+++ b/lib/services/gacha_row.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 
 /// 附帶計算後序號的祈願紀錄行（表格顯示用）。
 @immutable
@@ -10,6 +12,7 @@ class RecordRow {
     required this.record,
     required this.totalIndex,
     required this.mainPityIndex,
+    required this.itemTypeKey,
   });
 
   /// 原始祈願紀錄。
@@ -23,12 +26,21 @@ class RecordRow {
   /// 該主稀有度那一抽 = 抵達該主稀有度的累積值；下一抽從 1 重新累計。
   /// 若該卡池從未出現符合主稀有度的紀錄，則持續累計，與 totalIndex 相同。
   final int mainPityIndex;
+
+  /// 跨語言無關的類型聚合鍵（[itemTypeKeyOf] 產物：kind:character / kind:weapon
+  /// ／原始字串）。供表格類型欄顯示、排序、篩選共用，避免各處重複解析 index。
+  final String itemTypeKey;
 }
 
 /// records 必須以時間 desc 排序（與 gacha_repository 一致）。
 /// 回傳順序與 records 相同（desc by time）。
 /// [mainRank] 預設 5（卡池主稀有度）。常駐頌願須傳 4。
-List<RecordRow> buildRecordRows(List<GachaRecord> records, {int mainRank = 5}) {
+/// [index] 用於解析每筆紀錄的跨語言類型聚合鍵（[RecordRow.itemTypeKey]）。
+List<RecordRow> buildRecordRows(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+  int mainRank = 5,
+}) {
   if (records.isEmpty) return const [];
   // 以 asc 順序累計再 reverse，保持輸出順序與輸入一致。
   final asc = records.reversed.toList(growable: false);
@@ -38,7 +50,14 @@ List<RecordRow> buildRecordRows(List<GachaRecord> records, {int mainRank = 5}) {
   for (final r in asc) {
     total++;
     pity++;
-    out.add(RecordRow(record: r, totalIndex: total, mainPityIndex: pity));
+    out.add(
+      RecordRow(
+        record: r,
+        totalIndex: total,
+        mainPityIndex: pity,
+        itemTypeKey: itemTypeKeyOf(r, index),
+      ),
+    );
     if (r.rankType == mainRank) {
       pity = 0;
     }

--- a/lib/services/gacha_stats.dart
+++ b/lib/services/gacha_stats.dart
@@ -31,7 +31,8 @@ class GachaStats {
   /// 2★ 數量。
   final int twoStarCount;
 
-  /// 各物品類型的抽數，key = itemType 字串。
+  /// 各物品類型的抽數，key = [itemTypeKeyOf] 產物（canonical 鍵如 `kind:character`，
+  /// 或查無 menu_id 時 fallback 的原始 itemType 字串）。
   final Map<String, int> byItemType;
 
   /// 計算 [n] 在總抽數中的占比；總抽數為 0 時回傳 0.0。

--- a/lib/services/gacha_stats.dart
+++ b/lib/services/gacha_stats.dart
@@ -1,4 +1,8 @@
+import 'package:logging/logging.dart';
+
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 
 /// 單一卡池的祈願統計摘要。
 class GachaStats {
@@ -53,9 +57,17 @@ class GachaStats {
   }
 }
 
-/// 從 [records] 計算統計摘要。
-GachaStats computeGachaStats(List<GachaRecord> records) {
+/// 祈願統計 logger。
+final _log = Logger('gacha.stats');
+
+/// 從 [records] 計算統計摘要；[index] 用於將 itemType 原始字串聚合為
+/// 語言無關的類型鍵（[itemTypeKeyOf]），消除跨語系分裂。
+GachaStats computeGachaStats(
+  List<GachaRecord> records, {
+  required HoYoWikiIndex index,
+}) {
   var five = 0, four = 0, three = 0, two = 0;
+  var canonical = 0, fallback = 0;
   final byItemType = <String, int>{};
   for (final r in records) {
     switch (r.rankType) {
@@ -68,7 +80,19 @@ GachaStats computeGachaStats(List<GachaRecord> records) {
       case 2:
         two++;
     }
-    byItemType[r.itemType] = (byItemType[r.itemType] ?? 0) + 1;
+    final key = itemTypeKeyOf(r, index);
+    if (key == kItemKindCharacter || key == kItemKindWeapon) {
+      canonical++;
+    } else {
+      fallback++;
+    }
+    byItemType[key] = (byItemType[key] ?? 0) + 1;
+  }
+  if (records.isNotEmpty) {
+    _log.fine(
+      'computeGachaStats: total=${records.length} '
+      'canonicalKind=$canonical rawFallback=$fallback',
+    );
   }
   return GachaStats(
     total: records.length,

--- a/lib/services/item_type_kind.dart
+++ b/lib/services/item_type_kind.dart
@@ -1,0 +1,31 @@
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+
+/// 角色類型聚合鍵；以 `kind:` 前綴與遊戲原始 itemType 字串（角色／Character…）區隔，
+/// 永不碰撞。
+const kItemKindCharacter = 'kind:character';
+
+/// 武器類型聚合鍵。
+const kItemKindWeapon = 'kind:weapon';
+
+/// 解析單筆 [r] 的類型聚合鍵：以 HoYoWiki [index] 的 menu_id 判定（2＝角色、
+/// 4＝武器），跨語系自然合併；查不到時 fallback 回原始 `itemType` 字串（含空字串）。
+String itemTypeKeyOf(GachaRecord r, HoYoWikiIndex index) {
+  final id = index.lookupId(name: r.name, lang: r.lang);
+  final menuId = id == null ? null : index.lookupMenuId(id);
+  return switch (menuId) {
+    2 => kItemKindCharacter,
+    4 => kItemKindWeapon,
+    _ => r.itemType,
+  };
+}
+
+/// 將 [key]（[itemTypeKeyOf] 產物）轉成顯示用在地化標籤：canonical 鍵套
+/// [l] 譯名、空字串顯示「未知」、其餘原始字串 fallback 原樣顯示。
+String itemTypeKeyLabel(String key, AppLocalizations l) => switch (key) {
+  kItemKindCharacter => l.kindCharacter,
+  kItemKindWeapon => l.kindWeapon,
+  '' => l.kindUnknown,
+  _ => key,
+};

--- a/lib/services/item_type_kind.dart
+++ b/lib/services/item_type_kind.dart
@@ -6,7 +6,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart'
 /// 永不碰撞。
 const kItemKindCharacter = 'kind:character';
 
-/// 武器類型聚合鍵。
+/// 武器類型聚合鍵；`kind:` 前綴用意見 [kItemKindCharacter]。
 const kItemKindWeapon = 'kind:weapon';
 
 /// 解析單筆 [r] 的類型聚合鍵：以 HoYoWiki [index] 的 menu_id 判定（2＝角色、

--- a/lib/services/item_type_kind.dart
+++ b/lib/services/item_type_kind.dart
@@ -6,7 +6,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart'
 /// 永不碰撞。
 const kItemKindCharacter = 'kind:character';
 
-/// 武器類型聚合鍵；`kind:` 前綴用意見 [kItemKindCharacter]。
+/// 武器類型聚合鍵；`kind:` 前綴的用意參見 [kItemKindCharacter]。
 const kItemKindWeapon = 'kind:weapon';
 
 /// 解析單筆 [r] 的類型聚合鍵：以 HoYoWiki [index] 的 menu_id 判定（2＝角色、

--- a/lib/services/overview_sections.dart
+++ b/lib/services/overview_sections.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_pity.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
@@ -100,10 +101,11 @@ class OverviewSections {
 }
 
 /// 從 [activeBanners] 建構 [OverviewSections]，供 OverviewPage 與 ShareCard 共用，
-/// 避免兩處複製分組邏輯。
+/// 避免兩處複製分組邏輯。[index] 傳入 [computeGachaStats] 以消除跨語系類型分裂。
 OverviewSections buildOverviewSections(
-  Map<String, List<GachaRecord>> activeBanners,
-) {
+  Map<String, List<GachaRecord>> activeBanners, {
+  required HoYoWikiIndex index,
+}) {
   final gachaList = gachaTypes
       .where((t) => t.category == GachaCategory.gacha)
       .toList(growable: false);
@@ -162,7 +164,7 @@ OverviewSections buildOverviewSections(
     gacha: GachaSectionData(
       types: gachaList,
       banners: gachaBanners,
-      stats: computeGachaStats(gachaAll),
+      stats: computeGachaStats(gachaAll, index: index),
       timeline: gachaTimeline,
       timelineRank: gachaTimelineRank,
       timelineNowPulls: gachaTimelineNowPulls,
@@ -178,7 +180,7 @@ OverviewSections buildOverviewSections(
     odes: OdesSectionData(
       types: odesList,
       banners: odesBanners,
-      stats: computeGachaStats(odesAll),
+      stats: computeGachaStats(odesAll, index: index),
       eventFiveCount: eventFive,
       standardFourCount: standardFour,
       timeline: odesTimeline,

--- a/lib/widgets/data/search_filter_bar.dart
+++ b/lib/widgets/data/search_filter_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/record_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 
@@ -21,7 +22,7 @@ class SearchFilterBar extends StatefulWidget {
   /// 當前篩選狀態。
   final RecordFilterState state;
 
-  /// 當前 banner 出現過的 itemType 字串集合（已排序、去重），用來建構動態 dropdown。
+  /// 當前 banner 出現過的類型聚合鍵集合（已排序、去重），用來建構動態 dropdown。
   final List<String> availableItemTypes;
 
   /// 篩選條件變更時的回呼。
@@ -129,7 +130,10 @@ class _SearchFilterBarState extends State<SearchFilterBar> {
               child: Text(l.filterKindAll),
             ),
             for (final t in widget.availableItemTypes)
-              DropdownMenuItem<String?>(value: t, child: Text(t)),
+              DropdownMenuItem<String?>(
+                value: t,
+                child: Text(itemTypeKeyLabel(t, l)),
+              ),
           ],
         ),
         if (widget.state.filter.hasAny)

--- a/lib/widgets/data/sortable_table.dart
+++ b/lib/widgets/data/sortable_table.dart
@@ -3,6 +3,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizati
 
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_row.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/utils/relative_time.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/data/pager.dart';
@@ -410,7 +411,7 @@ class _Row extends StatelessWidget {
               ),
             ),
           ),
-          Expanded(flex: 2, child: Text(record.itemType)),
+          Expanded(flex: 2, child: Text(itemTypeKeyLabel(row.itemTypeKey, l))),
           Expanded(
             flex: 2,
             child: accent != null

--- a/lib/widgets/item_type_pie.dart
+++ b/lib/widgets/item_type_pie.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.dart';
 
@@ -53,7 +54,7 @@ List<DistributionEntry> itemTypeDistributionEntries(
     for (final (i, e) in sorted.indexed)
       DistributionEntry(
         color: palette[i % palette.length],
-        name: e.key.isEmpty ? l.kindUnknown : e.key,
+        name: itemTypeKeyLabel(e.key, l),
         count: e.value,
         rate: stats.total == 0 ? 0.0 : e.value / stats.total,
       ),

--- a/lib/widgets/share/share_card.dart
+++ b/lib/widgets/share/share_card.dart
@@ -108,7 +108,7 @@ class ShareCard extends StatelessWidget {
     required int targetRank,
     required HoYoWikiIndex index,
   }) {
-    final stats = computeGachaStats(records);
+    final stats = computeGachaStats(records, index: index);
     // threshold: 0 — 此處只取 averageInterval，不需 pity progress/distance
     // （與 gacha_pity.dart 的 averageIntervalAcrossBanners 同一慣例）。
     final fiveAvg = computePity(records, threshold: 0, rank: 5).averageInterval;
@@ -160,7 +160,7 @@ class ShareCard extends StatelessWidget {
     required Map<String, List<GachaRecord>> banners,
     required HoYoWikiIndex index,
   }) {
-    final s = buildOverviewSections(banners);
+    final s = buildOverviewSections(banners, index: index);
     final g = s.gacha;
     final o = s.odes;
     // '2000'/'1000' 必定存在：o.types 來自 lib/data/gacha_types.dart 的靜態常數，

--- a/test/services/gacha_filter_test.dart
+++ b/test/services/gacha_filter_test.dart
@@ -116,6 +116,29 @@ void main() {
       expect(out.length, rows.length);
     });
 
+    test('filterRecordRows 依 itemTypeKey 過濾', () {
+      final kindRows = [
+        RecordRow(
+          record: _r(id: 'a', rank: 4, itemType: '角色', name: '煙緋'),
+          totalIndex: 1,
+          mainPityIndex: 1,
+          itemTypeKey: 'kind:character',
+        ),
+        RecordRow(
+          record: _r(id: 'b', rank: 4, itemType: '武器', name: '匣裡龍吟'),
+          totalIndex: 2,
+          mainPityIndex: 2,
+          itemTypeKey: 'kind:weapon',
+        ),
+      ];
+      final out = filterRecordRows(
+        kindRows,
+        const RecordFilter(itemType: 'kind:character'),
+      );
+      expect(out.length, 1);
+      expect(out.first.itemTypeKey, 'kind:character');
+    });
+
     test('搜尋 query 過濾 row 集', () {
       final out = filterRecordRows(rows, const RecordFilter(query: '夜'));
       expect(out.map((r) => r.record.id), ['5']);

--- a/test/services/gacha_filter_test.dart
+++ b/test/services/gacha_filter_test.dart
@@ -217,12 +217,28 @@ void main() {
       expect(out.length, rows.length);
     });
 
-    test('kind 排序（按 itemType）', () {
-      final out = sortRecordRows(
+    test('SortColumn.kind 依 itemTypeKey 排序', () {
+      final rows = [
+        RecordRow(
+          record: _r(id: 'a', rank: 4, itemType: '武器', name: '匣裡龍吟'),
+          totalIndex: 1,
+          mainPityIndex: 1,
+          itemTypeKey: 'kind:weapon',
+        ),
+        RecordRow(
+          record: _r(id: 'b', rank: 5, itemType: '角色', name: '夜蘭'),
+          totalIndex: 2,
+          mainPityIndex: 2,
+          itemTypeKey: 'kind:character',
+        ),
+      ];
+      final sorted = sortRecordRows(
         rows,
         const TableSort(column: SortColumn.kind, direction: SortDirection.asc),
       );
-      expect(out.length, rows.length);
+      // 'kind:character' < 'kind:weapon' 字典序，asc 時 character 在前
+      expect(sorted.first.itemTypeKey, 'kind:character');
+      expect(sorted.last.itemTypeKey, 'kind:weapon');
     });
   });
 }

--- a/test/services/gacha_filter_test.dart
+++ b/test/services/gacha_filter_test.dart
@@ -92,6 +92,8 @@ void main() {
   group('filterRecordRows', () {
     late List<RecordRow> rows;
     setUp(() {
+      // 空 index → itemTypeKey fallback 回原始 itemType 字串，故以下測試仍用
+      //「武器」「角色」這類原始字串當 filter 值比對（canonical 鍵的過濾另有測試）。
       rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     });
 

--- a/test/services/gacha_filter_test.dart
+++ b/test/services/gacha_filter_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_row.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 
 GachaRecord _r({
   required String id,
@@ -91,7 +92,7 @@ void main() {
   group('filterRecordRows', () {
     late List<RecordRow> rows;
     setUp(() {
-      rows = buildRecordRows(records);
+      rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     });
 
     test('5★ + 武器 → 只剩 1 row，且 totalIndex / pity 不變', () {
@@ -124,7 +125,7 @@ void main() {
   group('sortRecordRows', () {
     late List<RecordRow> rows;
     setUp(() {
-      rows = buildRecordRows(records);
+      rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     });
 
     test('null → 不排序，保持輸入順序', () {

--- a/test/services/gacha_row_test.dart
+++ b/test/services/gacha_row_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_row.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 
 GachaRecord _r({required String id, required int rank, DateTime? time}) =>
     GachaRecord(
@@ -17,7 +18,10 @@ GachaRecord _r({required String id, required int rank, DateTime? time}) =>
 void main() {
   group('buildRecordRows', () {
     test('空 list → const []', () {
-      expect(buildRecordRows(const []), isEmpty);
+      expect(
+        buildRecordRows(const [], index: const HoYoWikiIndex.empty()),
+        isEmpty,
+      );
     });
 
     test('totalIndex 從 1 開始累計，最舊=1、最新=N，且輸出順序與輸入一致 (desc by time)', () {
@@ -29,7 +33,7 @@ void main() {
         _r(id: '2', rank: 3),
         _r(id: '1', rank: 3),
       ];
-      final rows = buildRecordRows(records);
+      final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
       expect(rows.map((r) => r.record.id).toList(), ['5', '4', '3', '2', '1']);
       expect(rows.map((r) => r.totalIndex).toList(), [5, 4, 3, 2, 1]);
     });
@@ -40,7 +44,7 @@ void main() {
         _r(id: '2', rank: 3),
         _r(id: '1', rank: 4),
       ];
-      final rows = buildRecordRows(records);
+      final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
       expect(rows.map((r) => r.mainPityIndex).toList(), [3, 2, 1]);
     });
 
@@ -55,7 +59,7 @@ void main() {
         _r(id: '2', rank: 3), // pity = 2
         _r(id: '1', rank: 3), // pity = 1
       ];
-      final rows = buildRecordRows(records);
+      final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
       // 以 id 對應驗證 pity
       final byId = {for (final r in rows) r.record.id: r};
       expect(byId['1']!.mainPityIndex, 1);
@@ -67,9 +71,42 @@ void main() {
 
     test('首抽即 5★ → 該抽 pity = 1', () {
       final records = [_r(id: '1', rank: 5)];
-      final rows = buildRecordRows(records);
+      final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
       expect(rows.first.totalIndex, 1);
       expect(rows.first.mainPityIndex, 1);
+    });
+
+    test('itemTypeKey: menu_id 命中用 canonical，miss fallback 原始字串', () {
+      final index = HoYoWikiIndex(
+        searchMap: const {'zh-tw::迪希雅': 'c1'},
+        entries: const {},
+        menuIds: const {'c1': 2},
+      );
+      final records = [
+        GachaRecord(
+          id: '1',
+          uid: '1',
+          gachaType: '301',
+          name: '迪希雅',
+          itemType: '角色',
+          rankType: 5,
+          time: DateTime(2025, 1, 2),
+          lang: 'zh-tw',
+        ),
+        GachaRecord(
+          id: '2',
+          uid: '1',
+          gachaType: '301',
+          name: '某武器',
+          itemType: '武器',
+          rankType: 4,
+          time: DateTime(2025, 1, 1),
+          lang: 'zh-tw',
+        ),
+      ];
+      final rows = buildRecordRows(records, index: index);
+      expect(rows[0].itemTypeKey, 'kind:character'); // 迪希雅命中
+      expect(rows[1].itemTypeKey, '武器'); // 未命中 → 原始字串
     });
   });
 }

--- a/test/services/gacha_stats_test.dart
+++ b/test/services/gacha_stats_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_stats.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 
 GachaRecord _r({String id = '1', int rank = 5, String itemType = '角色'}) =>
     GachaRecord(
@@ -17,7 +18,7 @@ GachaRecord _r({String id = '1', int rank = 5, String itemType = '角色'}) =>
 void main() {
   group('GachaStats', () {
     test('空 list 全 0', () {
-      final s = computeGachaStats(const []);
+      final s = computeGachaStats(const [], index: const HoYoWikiIndex.empty());
       expect(s.total, 0);
       expect(s.fiveStarCount, 0);
       expect(s.byItemType, isEmpty);
@@ -32,7 +33,7 @@ void main() {
         _r(id: '4', rank: 3, itemType: '武器'),
         _r(id: '5', rank: 3, itemType: '武器'),
       ];
-      final s = computeGachaStats(records);
+      final s = computeGachaStats(records, index: const HoYoWikiIndex.empty());
       expect(s.total, 5);
       expect(s.fiveStarCount, 1);
       expect(s.fourStarCount, 2);
@@ -49,7 +50,10 @@ void main() {
         _r(id: '3', rank: 5, itemType: '武器'),
         _r(id: '4', rank: 4, itemType: '裝扮'),
       ];
-      final stats = computeGachaStats(records);
+      final stats = computeGachaStats(
+        records,
+        index: const HoYoWikiIndex.empty(),
+      );
       expect(stats.byItemType, {'角色': 2, '武器': 1, '裝扮': 1});
     });
 
@@ -61,7 +65,10 @@ void main() {
         _r(id: '4', rank: 3),
         _r(id: '5', rank: 2),
       ];
-      final stats = computeGachaStats(records);
+      final stats = computeGachaStats(
+        records,
+        index: const HoYoWikiIndex.empty(),
+      );
       expect(stats.fiveStarCount, 1);
       expect(stats.fourStarCount, 1);
       expect(stats.threeStarCount, 2);
@@ -70,7 +77,10 @@ void main() {
 
     test('空字串 itemType 累計到 ""', () {
       final records = [_r(id: '1', rank: 5, itemType: '')];
-      final stats = computeGachaStats(records);
+      final stats = computeGachaStats(
+        records,
+        index: const HoYoWikiIndex.empty(),
+      );
       expect(stats.byItemType, {'': 1});
     });
 
@@ -80,12 +90,46 @@ void main() {
         for (var i = 0; i < 3; i++) _r(id: 'c$i', itemType: '角色'),
         _r(id: 'd', itemType: '裝扮'),
       ];
-      final stats = computeGachaStats(records);
+      final stats = computeGachaStats(
+        records,
+        index: const HoYoWikiIndex.empty(),
+      );
       expect(stats.sortedItemTypes().map((e) => e.key).toList(), [
         '武器',
         '角色',
         '裝扮',
       ]);
+    });
+
+    test('跨語系同物品以 menu_id 合併，不分裂', () {
+      final index = HoYoWikiIndex(
+        searchMap: const {'zh-tw::迪希雅': 'c1', 'en::Dehya': 'c1'},
+        entries: const {},
+        menuIds: const {'c1': 2},
+      );
+      final stats = computeGachaStats([
+        GachaRecord(
+          id: '1',
+          uid: '1',
+          gachaType: '301',
+          name: '迪希雅',
+          itemType: '角色',
+          rankType: 5,
+          time: DateTime(2025),
+          lang: 'zh-tw',
+        ),
+        GachaRecord(
+          id: '2',
+          uid: '1',
+          gachaType: '301',
+          name: 'Dehya',
+          itemType: 'Character',
+          rankType: 5,
+          time: DateTime(2025),
+          lang: 'en',
+        ),
+      ], index: index);
+      expect(stats.byItemType, {'kind:character': 2});
     });
   });
 }

--- a/test/services/item_type_kind_test.dart
+++ b/test/services/item_type_kind_test.dart
@@ -5,6 +5,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 
+/// 建立測試用 [GachaRecord]；name／lang 必填，itemType 預設「角色」。
 GachaRecord _r({
   required String name,
   required String lang,

--- a/test/services/item_type_kind_test.dart
+++ b/test/services/item_type_kind_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
+
+GachaRecord _r({
+  required String name,
+  required String lang,
+  String itemType = '角色',
+}) => GachaRecord(
+  id: '1',
+  uid: '1',
+  gachaType: '301',
+  name: name,
+  itemType: itemType,
+  rankType: 5,
+  time: DateTime(2025),
+  lang: lang,
+);
+
+void main() {
+  // 迪希雅(zh-tw) 與 Dehya(en) 對到同一 hoyowiki id c1（menu_id 2＝角色）；
+  // 天空之翼 對到 w1（menu_id 4＝武器）。
+  final index = HoYoWikiIndex(
+    searchMap: const {
+      'zh-tw::迪希雅': 'c1',
+      'en::Dehya': 'c1',
+      'zh-tw::天空之翼': 'w1',
+    },
+    entries: const {},
+    menuIds: const {'c1': 2, 'w1': 4},
+  );
+
+  group('itemTypeKeyOf', () {
+    test('menu_id 2 → kind:character', () {
+      expect(
+        itemTypeKeyOf(_r(name: '迪希雅', lang: 'zh-tw'), index),
+        'kind:character',
+      );
+    });
+
+    test('menu_id 4 → kind:weapon', () {
+      expect(
+        itemTypeKeyOf(_r(name: '天空之翼', lang: 'zh-tw', itemType: '武器'), index),
+        'kind:weapon',
+      );
+    });
+
+    test('跨語系同物品合併成同一 key', () {
+      final zh = itemTypeKeyOf(
+        _r(name: '迪希雅', lang: 'zh-tw', itemType: '角色'),
+        index,
+      );
+      final en = itemTypeKeyOf(
+        _r(name: 'Dehya', lang: 'en', itemType: 'Character'),
+        index,
+      );
+      expect(zh, en);
+      expect(zh, 'kind:character');
+    });
+
+    test('查無 menu_id → fallback 原始 itemType', () {
+      expect(
+        itemTypeKeyOf(
+          _r(name: '未知物', lang: 'zh-tw', itemType: 'Character'),
+          index,
+        ),
+        'Character',
+      );
+    });
+
+    test('查無且原始字串為空 → 回空字串', () {
+      expect(
+        itemTypeKeyOf(_r(name: '未知物', lang: 'zh-tw', itemType: ''), index),
+        '',
+      );
+    });
+  });
+
+  group('itemTypeKeyLabel', () {
+    test('canonical key 轉在地化標籤；fallback 原樣', () async {
+      final l = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(itemTypeKeyLabel('kind:character', l), 'Character');
+      expect(itemTypeKeyLabel('kind:weapon', l), 'Weapon');
+      expect(itemTypeKeyLabel('', l), l.kindUnknown);
+      expect(itemTypeKeyLabel('裝扮', l), '裝扮');
+    });
+  });
+}

--- a/test/services/overview_sections_test.dart
+++ b/test/services/overview_sections_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/overview_sections.dart';
 
 GachaRecord _r(String gt, int rank, String name, DateTime t) => GachaRecord(
@@ -21,7 +22,10 @@ void main() {
       '2000': [_r('2000', 5, '某五星', t)],
     };
 
-    final sections = buildOverviewSections(activeBanners);
+    final sections = buildOverviewSections(
+      activeBanners,
+      index: const HoYoWikiIndex.empty(),
+    );
 
     expect(sections.gacha.stats.total, 2);
     expect(sections.gacha.stats.fiveStarCount, 1);
@@ -31,7 +35,10 @@ void main() {
   });
 
   test('buildOverviewSections 空輸入不拋例外、各欄位回傳零值', () {
-    final sections = buildOverviewSections(const <String, List<GachaRecord>>{});
+    final sections = buildOverviewSections(
+      const <String, List<GachaRecord>>{},
+      index: const HoYoWikiIndex.empty(),
+    );
 
     expect(sections.gacha.stats.total, 0);
     expect(sections.odes.stats.total, 0);
@@ -48,7 +55,10 @@ void main() {
       '2000': [_r('2000', 5, '某頌願五星', t)],
     };
 
-    final sections = buildOverviewSections(activeBanners);
+    final sections = buildOverviewSections(
+      activeBanners,
+      index: const HoYoWikiIndex.empty(),
+    );
 
     expect(sections.gacha.stats.total, 0);
     expect(sections.odes.eventFiveCount, 1);

--- a/test/widgets/data/search_filter_bar_test.dart
+++ b/test/widgets/data/search_filter_bar_test.dart
@@ -53,11 +53,7 @@ void main() {
       _wrap(
         SearchFilterBar(
           state: const RecordFilterState(filter: RecordFilter(), sort: null),
-          availableItemTypes: const [
-            kItemKindCharacter,
-            kItemKindWeapon,
-            '裝扮',
-          ],
+          availableItemTypes: const [kItemKindCharacter, kItemKindWeapon, '裝扮'],
           onFilterChanged: (_) {},
           onClear: () {},
         ),

--- a/test/widgets/data/search_filter_bar_test.dart
+++ b/test/widgets/data/search_filter_bar_test.dart
@@ -56,7 +56,7 @@ void main() {
           availableItemTypes: const [
             kItemKindCharacter,
             kItemKindWeapon,
-            'raw:costume',
+            '裝扮',
           ],
           onFilterChanged: (_) {},
           onClear: () {},

--- a/test/widgets/data/search_filter_bar_test.dart
+++ b/test/widgets/data/search_filter_bar_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/item_type_kind.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/record_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/data/search_filter_bar.dart';
@@ -19,7 +20,7 @@ void main() {
       _wrap(
         SearchFilterBar(
           state: const RecordFilterState(filter: RecordFilter(), sort: null),
-          availableItemTypes: const ['角色', '武器'],
+          availableItemTypes: const [kItemKindCharacter, kItemKindWeapon],
           onFilterChanged: (_) {},
           onClear: () {},
         ),
@@ -37,7 +38,7 @@ void main() {
             filter: RecordFilter(rarity: RarityFilter.fiveStar),
             sort: null,
           ),
-          availableItemTypes: const ['角色', '武器'],
+          availableItemTypes: const [kItemKindCharacter, kItemKindWeapon],
           onFilterChanged: (_) {},
           onClear: () {},
         ),
@@ -52,7 +53,11 @@ void main() {
       _wrap(
         SearchFilterBar(
           state: const RecordFilterState(filter: RecordFilter(), sort: null),
-          availableItemTypes: const ['角色', '武器', '裝扮'],
+          availableItemTypes: const [
+            kItemKindCharacter,
+            kItemKindWeapon,
+            'raw:costume',
+          ],
           onFilterChanged: (_) {},
           onClear: () {},
         ),
@@ -63,13 +68,35 @@ void main() {
     expect(find.byType(DropdownButton<String?>), findsOneWidget);
   });
 
-  testWidgets('選擇 itemType → onFilterChanged 收到新的 itemType', (tester) async {
+  testWidgets('下拉顯示 itemTypeKeyLabel 的在地化標籤', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        SearchFilterBar(
+          state: const RecordFilterState(filter: RecordFilter(), sort: null),
+          availableItemTypes: const [kItemKindCharacter, kItemKindWeapon],
+          onFilterChanged: (_) {},
+          onClear: () {},
+        ),
+      ),
+    );
+    // 開 dropdown，確認顯示在地化標籤而非原始 key
+    await tester.tap(find.byType(DropdownButton<String?>));
+    await tester.pumpAndSettle();
+    // 測試環境預設英文：kindCharacter → 'Character'、kindWeapon → 'Weapon'
+    expect(find.text('Character'), findsWidgets);
+    expect(find.text('Weapon'), findsWidgets);
+    // 確認原始 key 字串不直接顯示在 dropdown 選項中
+    expect(find.text(kItemKindCharacter), findsNothing);
+    expect(find.text(kItemKindWeapon), findsNothing);
+  });
+
+  testWidgets('選擇 itemType → onFilterChanged 收到對應聚合鍵', (tester) async {
     RecordFilter? captured;
     await tester.pumpWidget(
       _wrap(
         SearchFilterBar(
           state: const RecordFilterState(filter: RecordFilter(), sort: null),
-          availableItemTypes: const ['角色', '武器'],
+          availableItemTypes: const [kItemKindCharacter, kItemKindWeapon],
           onFilterChanged: (f) => captured = f,
           onClear: () {},
         ),
@@ -79,12 +106,30 @@ void main() {
     // 開 dropdown
     await tester.tap(find.byType(DropdownButton<String?>));
     await tester.pumpAndSettle();
-    // 點 '角色' 選項（dropdown 開啟後菜單會有兩個 '角色' Text：一個 closed item，一個 menu item）
-    final characterItems = find.text('角色');
+    // 測試環境英文下 kItemKindCharacter 顯示為「Character」；點最後一個（menu item）
+    final characterItems = find.text('Character');
     expect(characterItems, findsWidgets);
     await tester.tap(characterItems.last);
     await tester.pumpAndSettle();
 
-    expect(captured?.itemType, '角色');
+    // filter.itemType 儲存的是聚合鍵，非顯示標籤
+    expect(captured?.itemType, kItemKindCharacter);
+  });
+
+  testWidgets('fallback 原始字串直接顯示原字串', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        SearchFilterBar(
+          state: const RecordFilterState(filter: RecordFilter(), sort: null),
+          availableItemTypes: const ['服裝'],
+          onFilterChanged: (_) {},
+          onClear: () {},
+        ),
+      ),
+    );
+    // 開 dropdown，非 canonical key 的原始字串應原樣顯示
+    await tester.tap(find.byType(DropdownButton<String?>));
+    await tester.pumpAndSettle();
+    expect(find.text('服裝'), findsWidgets);
   });
 }

--- a/test/widgets/data/sortable_table_test.dart
+++ b/test/widgets/data/sortable_table_test.dart
@@ -77,7 +77,7 @@ void main() {
       _r(id: '4', rank: 4, name: 'B'), // accent != null → _Pill
       _r(id: '3', rank: 3, name: 'C'), // accent == null → 純 Text 分支
     ];
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     await tester.pumpWidget(
       _wrap(
         SortableTable(
@@ -106,7 +106,7 @@ void main() {
       _r(id: '4', rank: 4, name: 'B'),
       _r(id: '3', rank: 3, name: 'C'),
     ];
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     await tester.pumpWidget(
       _wrap(
         SortableTable(
@@ -133,7 +133,7 @@ void main() {
       45,
       (i) => _r(id: '${i + 1}', rank: 4, name: 'r$i'),
     );
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     await tester.pumpWidget(
       _wrap(
         SortableTable(
@@ -154,7 +154,7 @@ void main() {
 
   testWidgets('表頭點擊呼叫 onSortColumnTapped(對應欄)', (tester) async {
     final records = [_r(id: '1', rank: 5, name: 'A')];
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     SortColumn? tapped;
     await tester.pumpWidget(
       _wrap(
@@ -182,7 +182,7 @@ void main() {
 
   testWidgets('當前排序欄顯示 arrow_downward；其他欄維持 unfold_more', (tester) async {
     final records = [_r(id: '1', rank: 5, name: 'A')];
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     await tester.pumpWidget(
       _wrap(
         SortableTable(
@@ -208,7 +208,7 @@ void main() {
       _r(id: '4', rank: 4, name: 'B'),
       _r(id: '3', rank: 3, name: 'C'),
     ];
-    final rows = buildRecordRows(records);
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
     await tester.pumpWidget(
       _wrap(
         SortableTable(

--- a/test/widgets/data/sortable_table_test.dart
+++ b/test/widgets/data/sortable_table_test.dart
@@ -202,6 +202,26 @@ void main() {
     expect(find.byIcon(Icons.unfold_more), findsNWidgets(5));
   });
 
+  testWidgets('類型欄顯示 itemTypeKeyLabel 結果（fallback 原始字串）', (tester) async {
+    // _r 產的 record.itemType = '角色'；empty index → itemTypeKey = '角色'（fallback）
+    // itemTypeKeyLabel('角色', l) 原樣回傳 '角色'
+    final records = [_r(id: '1', rank: 5, name: 'A')];
+    final rows = buildRecordRows(records, index: const HoYoWikiIndex.empty());
+    await tester.pumpWidget(
+      _wrap(
+        SortableTable(
+          rows: rows,
+          sort: null,
+          mainRank: 5,
+          onSortColumnTapped: (_) {},
+        ),
+        container: container,
+      ),
+    );
+    // 類型欄應顯示 itemTypeKeyLabel(row.itemTypeKey='角色', l) = '角色'
+    expect(find.text('角色'), findsOneWidget);
+  });
+
   testWidgets('每列名稱欄前顯示 GachaItemIcon', (tester) async {
     final records = [
       _r(id: '5', rank: 5, name: 'A'),


### PR DESCRIPTION
## 摘要

- 改用 HoYoWiki `menu_id`（2＝角色、4＝武器）作為**語言無關**的物品類型判定，消除曾切換遊戲語言再同步而導致的跨語言統計分裂（圓餅圖裂成多塊、篩選下拉出現重複項）。
- 新增共用 primitive `lib/services/item_type_kind.dart`（`itemTypeKeyOf` / `itemTypeKeyLabel`），沿用 `five_star_collection` 既有的「records + HoYoWikiIndex」模式。
- 三處全改用聚合鍵：**類型圓餅圖統計**（`computeGachaStats`）、**記錄列表「類型」欄與排序**、**篩選下拉**。顯示一律經 `itemTypeKeyLabel` 套在地化標籤。
- 查不到 `menu_id` 時 fallback 回原始 `itemType` 字串（hybrid 設計）：**單語言或未拓圖的使用者行為等同現狀，零回歸**；跑完拓圖後自動合併。
- 反應式（隨 `hoyowikiIndexProvider` 更新）、**零存檔 schema 遷移**（`RecordFilter.itemType` 維持 `String?`，存的是聚合鍵）。
- 新增 i18n `kindCharacter` / `kindWeapon`（9 個有實體翻譯的 ARB，依術語表）。

設計與計畫文件：`docs/superpowers/specs/2026-05-29-hoyowiki-item-type-classification-design.md`、`docs/superpowers/plans/2026-05-29-hoyowiki-item-type-classification.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)