### PR TITLE
feat(gacha): write lang when fetching odes records

### DIFF
--- a/docs/superpowers/plans/2026-05-31-odes-fetch-write-lang.md
+++ b/docs/superpowers/plans/2026-05-31-odes-fetch-write-lang.md
@@ -1,0 +1,491 @@
+# 頌願抓取時補寫 `lang` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 抓取頌願並寫入 json 時，把 record 的 `lang` 補成擷取 URL 的 `lang`（而非空字串），並回填既有空 `lang` 的頌願記錄。
+
+**Architecture:** 取向 A，三檔改動。`GachaUrl` 暴露 `lang` getter；`GachaRecord.fromApiJson` 新增 `fallbackLang` 參數讓頌願新記錄出生即帶 lang，並加 `copyWith` 供回填；`GachaFetcher` 的 `fetchPage` 傳入 URL 的 lang 作 fallback，`fetchBannerWithMerge` 回傳前回填 `existing` 中空 lang 者。下游（HoYoWiki 批次與 on-demand）已用 gachaType 在兩層擋掉頌願，故無副作用、不需守衛。
+
+**Tech Stack:** Dart / Flutter、`http` + `http/testing` MockClient、`logging`、`flutter_test`。
+
+**Spec:** `docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md`
+
+---
+
+## File Structure
+
+- `lib/services/gacha_url.dart` — 新增 `lang` getter（讀 query 參數）。
+- `lib/models/gacha_record.dart` — `fromApiJson` 加 `fallbackLang`；新增 `copyWith({String? lang})`。
+- `lib/services/gacha_fetcher.dart` — `fetchPage` 傳 `fallbackLang`；`fetchBannerWithMerge` 回填 existing。
+- `test/services/gacha_url_test.dart` — `lang` getter 測試。
+- `test/models/gacha_record_test.dart` — fallback 行為、API lang 優先、copyWith 測試。
+- `test/services/gacha_fetcher_test.dart` — fresh 頌願帶 lang、existing 回填、URL 無 lang 不動。
+
+---
+
+### Task 1: `GachaUrl.lang` getter
+
+**Files:**
+- Modify: `lib/services/gacha_url.dart`
+- Test: `test/services/gacha_url_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `test/services/gacha_url_test.dart` 的 `group('GachaUrl', () {` 內、最後一個 `test(...)` 之後加入：
+
+```dart
+    test('lang getter 讀 query 的 lang', () {
+      expect(GachaUrl.parse(_capturedUrl).lang, 'zh-tw');
+    });
+
+    test('lang getter 缺 lang 參數時回空字串', () {
+      final url = GachaUrl.parse(
+        'https://example.com/gacha_info/api/getGachaLog?authkey=AAA&gacha_type=301&end_id=0',
+      );
+      expect(url.lang, '');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/services/gacha_url_test.dart`
+Expected: FAIL — `The getter 'lang' isn't defined for the type 'GachaUrl'`（編譯錯誤）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `lib/services/gacha_url.dart` 的 `GachaUrl` class 內、`final Uri _uri;` 之後加入：
+
+```dart
+  /// 擷取 URL 的 `lang` query 參數；缺漏時為空字串。
+  String get lang => _uri.queryParameters['lang'] ?? '';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/services/gacha_url_test.dart`
+Expected: PASS（All tests passed!）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/gacha_url.dart test/services/gacha_url_test.dart
+git commit -m "feat(gacha): expose lang getter on GachaUrl"
+```
+
+---
+
+### Task 2: `GachaRecord` fallbackLang 與 copyWith
+
+**Files:**
+- Modify: `lib/models/gacha_record.dart:48-62`（`fromApiJson`），並新增 `copyWith`
+- Test: `test/models/gacha_record_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `test/models/gacha_record_test.dart` 的 `group('GachaRecord.fromApiJson', () {` 內加入兩個 test（接在既有兩個 test 之後）：
+
+```dart
+    test('頌願無 lang 時，以 fallbackLang 補上', () {
+      final json = {
+        'id': '1761240000000038925',
+        'uid': '801057625',
+        'item_type': '裝扮套裝',
+        'item_name': '女性裝扮·「燭影狂歡夜」',
+        'rank_type': '5',
+        'time': '2025-10-24 01:51:25',
+        'op_gacha_type': '20021',
+      };
+      final record = GachaRecord.fromApiJson(
+        json,
+        gachaType: '2000',
+        fallbackLang: 'ja',
+      );
+      expect(record.lang, 'ja');
+    });
+
+    test('API 已帶 lang 時，fallbackLang 被忽略', () {
+      final json = {
+        'uid': '801057625',
+        'gacha_type': '200',
+        'time': '2025-09-23 21:27:37',
+        'name': '討龍英傑譚',
+        'lang': 'zh-tw',
+        'item_type': '武器',
+        'rank_type': '3',
+        'id': '1758632760000221425',
+      };
+      final record = GachaRecord.fromApiJson(
+        json,
+        gachaType: '200',
+        fallbackLang: 'ja',
+      );
+      expect(record.lang, 'zh-tw');
+    });
+```
+
+再於 `group('GachaRecord JSON 持久化序列化', () {` 之後新增一個 group：
+
+```dart
+  group('GachaRecord.copyWith', () {
+    test('只改 lang，其餘欄位不變', () {
+      final original = GachaRecord(
+        id: '1',
+        uid: '801057625',
+        gachaType: '2000',
+        name: 'x',
+        itemType: '裝扮套裝',
+        rankType: 5,
+        time: DateTime(2025, 10, 24, 1, 51, 25),
+        lang: '',
+      );
+      final updated = original.copyWith(lang: 'zh-tw');
+      expect(updated.lang, 'zh-tw');
+      expect(updated.id, original.id);
+      expect(updated.uid, original.uid);
+      expect(updated.gachaType, original.gachaType);
+      expect(updated.name, original.name);
+      expect(updated.itemType, original.itemType);
+      expect(updated.rankType, original.rankType);
+      expect(updated.time, original.time);
+    });
+
+    test('不傳 lang 則沿用原值', () {
+      final original = GachaRecord(
+        id: '1',
+        uid: '801057625',
+        gachaType: '2000',
+        name: 'x',
+        itemType: '裝扮套裝',
+        rankType: 5,
+        time: DateTime(2025, 10, 24, 1, 51, 25),
+        lang: 'en',
+      );
+      expect(original.copyWith().lang, 'en');
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/models/gacha_record_test.dart`
+Expected: FAIL — `fromApiJson` 沒有 `fallbackLang` 具名參數、`copyWith` 未定義（編譯錯誤）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `lib/models/gacha_record.dart` 把 `fromApiJson`（行 48-62）整段替換為：
+
+```dart
+  factory GachaRecord.fromApiJson(
+    Map<String, dynamic> json, {
+    required String gachaType,
+    String fallbackLang = '',
+  }) {
+    final apiLang = json['lang'] as String?;
+    return GachaRecord(
+      id: json['id'] as String,
+      uid: json['uid'] as String,
+      gachaType: gachaType,
+      name: (json['name'] ?? json['item_name']) as String,
+      itemType: json['item_type'] as String,
+      rankType: int.parse(json['rank_type'] as String),
+      time: DateTime.parse((json['time'] as String).replaceFirst(' ', 'T')),
+      lang: (apiLang == null || apiLang.isEmpty) ? fallbackLang : apiLang,
+    );
+  }
+```
+
+並把 `fromApiJson` 上方的 dartdoc 末段（描述 `頌願 (getBeyondGachaLog): ... 無 lang`）補一句說明 fallback。在原 dartdoc 行 44 的「無 `lang`」之後、`///` 區塊內加入一行：
+
+```dart
+  ///   無 `lang`，故由呼叫端傳入的 [fallbackLang]（擷取 URL 的 lang）補上。
+```
+
+接著在 `toStorageJson()`（行 78-94）之後、class 結尾 `}` 之前新增 `copyWith`：
+
+```dart
+
+  /// 複製本 record，可覆寫 [lang]（其餘欄位沿用原值）。
+  GachaRecord copyWith({String? lang}) => GachaRecord(
+    id: id,
+    uid: uid,
+    gachaType: gachaType,
+    name: name,
+    itemType: itemType,
+    rankType: rankType,
+    time: time,
+    lang: lang ?? this.lang,
+  );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/models/gacha_record_test.dart`
+Expected: PASS（All tests passed!）。既有「解析頌願 API 回傳」測試未傳 `fallbackLang`，預設 `''`，`record.lang` 仍為 `''`，不受影響。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/models/gacha_record.dart test/models/gacha_record_test.dart
+git commit -m "feat(gacha): add fallbackLang and copyWith to GachaRecord"
+```
+
+---
+
+### Task 3: `fetchPage` 以 URL lang 補頌願新記錄
+
+**Files:**
+- Modify: `lib/services/gacha_fetcher.dart:105-127`（`fetchPage`）
+- Test: `test/services/gacha_fetcher_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `test/services/gacha_fetcher_test.dart` 的 `group('GachaFetcher.fetchPage', () {` 內加入（接在既有 test 之後）：
+
+```dart
+    test('頌願回傳無 lang 時，以 URL 的 lang 補上', () async {
+      final mock = MockClient(
+        (req) async => _ok([
+          {
+            'uid': '801057625',
+            'op_gacha_type': '20021',
+            'item_id': '265044',
+            'count': '1',
+            'time': '2025-10-24 01:51:25',
+            'item_name': 'x',
+            'item_type': '裝扮套裝',
+            'rank_type': '5',
+            'id': '99',
+          },
+        ]),
+      );
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final page = await fetcher.fetchPage(
+        GachaUrl.parse(
+          _baseUrl,
+        ).build(gachaType: '2000', endId: '0', endpoint: GachaEndpoint.odes),
+        mock,
+      );
+      expect(page.records.first.lang, 'zh-tw');
+    });
+```
+
+> `_baseUrl` 的 query 帶 `lang=zh-tw`，`build` 會保留，故 fetchPage 取得的 URL lang 為 `zh-tw`。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/services/gacha_fetcher_test.dart --plain-name "頌願回傳無 lang"`
+Expected: FAIL — `Expected: 'zh-tw' Actual: ''`（fetchPage 尚未傳 fallbackLang）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `lib/services/gacha_fetcher.dart` 的 `fetchPage`：
+
+在行 106 `final queryGachaType = url.queryParameters['gacha_type'] ?? '';` 之後新增一行：
+
+```dart
+    final queryLang = url.queryParameters['lang'] ?? '';
+```
+
+並把 `GachaRecord.fromApiJson(...)`（行 120-123）改為傳入 `fallbackLang`：
+
+```dart
+                (e) => GachaRecord.fromApiJson(
+                  e as Map<String, dynamic>,
+                  gachaType: queryGachaType,
+                  fallbackLang: queryLang,
+                ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/services/gacha_fetcher_test.dart`
+Expected: PASS（All tests passed!）。既有測試不受影響（一般祈願 mock 帶 lang，fallback 不啟用）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/gacha_fetcher.dart test/services/gacha_fetcher_test.dart
+git commit -m "feat(gacha): backfill odes record lang from URL on fetch"
+```
+
+---
+
+### Task 4: `fetchBannerWithMerge` 回填既有空 lang 記錄
+
+**Files:**
+- Modify: `lib/services/gacha_fetcher.dart:206-208`（`fetchBannerWithMerge` 回傳段）
+- Test: `test/services/gacha_fetcher_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+先在 `test/services/gacha_fetcher_test.dart` 頂部 import 區（行 8 之後）加入 `GachaRecord` import：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+```
+
+在 `group('GachaFetcher.fetchBannerWithMerge', () {` 內加入兩個 test（接在既有兩個 test 之後）：
+
+```dart
+    test('既有空 lang 記錄回填為 URL 的 lang', () async {
+      final client = MockClient((req) async => _ok(const []));
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final existing = [
+        GachaRecord(
+          id: '50',
+          uid: '801057625',
+          gachaType: '2000',
+          name: 'x',
+          itemType: '裝扮套裝',
+          rankType: 5,
+          time: DateTime(2025, 10, 24, 1, 51, 25),
+          lang: '',
+        ),
+      ];
+      final merged = await fetcher.fetchBannerWithMerge(
+        url: GachaUrl.parse(_baseUrl),
+        gachaType: '2000',
+        endpoint: GachaEndpoint.odes,
+        existing: existing,
+        primer: null,
+        onProgress: (_) {},
+        client: client,
+      );
+      expect(merged, hasLength(1));
+      expect(merged.first.lang, 'zh-tw');
+    });
+
+    test('URL 無 lang 時不動既有記錄', () async {
+      final client = MockClient((req) async => _ok(const []));
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final existing = [
+        GachaRecord(
+          id: '50',
+          uid: '801057625',
+          gachaType: '2000',
+          name: 'x',
+          itemType: '裝扮套裝',
+          rankType: 5,
+          time: DateTime(2025, 10, 24, 1, 51, 25),
+          lang: '',
+        ),
+      ];
+      final merged = await fetcher.fetchBannerWithMerge(
+        url: GachaUrl.parse(
+          'https://example.com/gacha_info/api/getBeyondGachaLog'
+          '?authkey=AAA&gacha_type=2000&end_id=0',
+        ),
+        gachaType: '2000',
+        endpoint: GachaEndpoint.odes,
+        existing: existing,
+        primer: null,
+        onProgress: (_) {},
+        client: client,
+      );
+      expect(merged.first.lang, '');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/services/gacha_fetcher_test.dart --plain-name "既有空 lang 記錄回填"`
+Expected: FAIL — `Expected: 'zh-tw' Actual: ''`（尚未回填）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `lib/services/gacha_fetcher.dart` 的 `fetchBannerWithMerge`，把行 206-208：
+
+```dart
+    // fresh + existing 都是 desc
+    _log.info('banner=$gachaType done, fresh=${fresh.length} pages=$pageIndex');
+    return [...fresh, ...existing];
+```
+
+替換為：
+
+```dart
+    // fresh + existing 都是 desc
+    _log.info('banner=$gachaType done, fresh=${fresh.length} pages=$pageIndex');
+
+    // 頌願 API 不回傳 lang；既有空 lang 記錄以擷取 URL 的 lang 回填（一般祈願
+    // existing 必有非空 lang，不受影響）。URL 缺 lang 則不動，避免以空蓋空。
+    final urlLang = url.lang;
+    final List<GachaRecord> normalizedExisting;
+    if (urlLang.isEmpty) {
+      normalizedExisting = existing;
+    } else {
+      var backfilled = 0;
+      normalizedExisting = existing.map((r) {
+        if (r.lang.isEmpty) {
+          backfilled++;
+          return r.copyWith(lang: urlLang);
+        }
+        return r;
+      }).toList(growable: false);
+      if (backfilled > 0) {
+        _log.info(
+          'banner=$gachaType backfilled lang for $backfilled records '
+          'to "$urlLang"',
+        );
+      }
+    }
+    return [...fresh, ...normalizedExisting];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/services/gacha_fetcher_test.dart`
+Expected: PASS（All tests passed!）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/gacha_fetcher.dart test/services/gacha_fetcher_test.dart
+git commit -m "feat(gacha): backfill empty lang on existing odes records during merge"
+```
+
+---
+
+### Task 5: 全量驗收
+
+**Files:** 無（僅執行檢查）。
+
+- [ ] **Step 1: 格式化**
+
+Run: `dart format lib/ test/`
+Expected: 顯示已格式化檔案數，無錯誤。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: 全量測試**
+
+Run: `flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 若格式化動到檔案則補一個 commit**
+
+```bash
+git add -A
+git commit -m "style: dart format"
+```
+
+（若 `git status` 乾淨則略過此步。）
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 「新抓頌願帶 URL lang」→ Task 2（fromApiJson fallback）＋ Task 3（fetchPage 傳入）。✔
+- 「回填既有空 lang」→ Task 2（copyWith）＋ Task 4（merge 回填）。✔
+- 「URL 缺 lang 不以空蓋空」→ Task 4 第二個 test 與 `urlLang.isEmpty` 分支。✔
+- 「一般祈願不受影響」→ Task 2「API 已帶 lang 時 fallbackLang 被忽略」test、Task 4 通用 `isEmpty` 判斷。✔
+- 「下游零副作用、無守衛」→ 設計層結論，無程式碼改動，無對應 task（正確）。✔
+- 驗收（format / analyze / test 全綠）→ Task 5。✔
+
+**Placeholder scan：** 無 TBD/TODO，所有步驟含實際程式碼與指令。✔
+
+**Type consistency：** `fallbackLang`（具名、預設 `''`）、`copyWith({String? lang})`、`GachaUrl.lang`、`urlLang`／`normalizedExisting`／`backfilled` 在各 task 命名一致。Task 4 依賴 Task 1 的 `url.lang` 與 Task 2 的 `copyWith`，順序正確。✔

--- a/docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md
+++ b/docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md
@@ -1,0 +1,135 @@
+# 頌願抓取時補寫 `lang` 設計
+
+## 背景與問題
+
+頌願走的 API 是 `getBeyondGachaLog`，回應的 list 元素**不含 `lang` 欄位**（與一般祈願的 `getGachaLog` schema 不一致）。因此 `GachaRecord.fromApiJson`（`lib/models/gacha_record.dart:60`）目前把頌願 record 的 `lang` 填成空字串 `''`，並一路寫進本地存檔 json。
+
+但擷取到的祈願 URL **本身帶 `lang` query 參數**（如 `lang=zh-tw`／`en`／`ja`），且每次組請求都帶著它。也就是說「這筆是用哪個語言抓的」這個資訊其實拿得到，只是沒被寫進 record。URL 的 `lang` 值與一般祈願 API 回傳的 `lang` 同格式同語意。
+
+目標：**抓取頌願並寫入 json 時，把 `lang` 補成 URL 的 `lang`，而非空值。** 既有已存檔、`lang` 為空的頌願記錄也一併回填。
+
+## 範圍與非目標
+
+- **單純補 `lang`**：不新增任何抓取 HoYoWiki 的邏輯，不改動 HoYoWiki 管線。
+- 不處理「匯入外部 json」路徑（那是另一條資料來源，與 API 再抓取無關）。
+
+### 下游零副作用（無需額外守衛）
+
+補 `lang` 後，頌願物品**不會**因此被 HoYoWiki 抓取，既有程式已在兩層擋掉：
+
+1. **批次抓取**：更新後與 force-refetch 都走 `_fetchHoYoWiki`。它在 `gacha_repository.dart:782/788` 用 `hoyoWikiTargetGachaTypes = {'301','302','500','200','100'}` 過濾，頌願的 gachaType（`'2000'`／`'1000'`）在 `lang.isEmpty` 判斷之前就先被 `continue` 掉。
+2. **on-demand 詳情**：`gacha_item_detail_dialog.dart:22/28` 的 `_odesGachaTypes = {'2000','1000'}` 讓頌願物品「永遠不可點」，dialog 不開、不觸發抓取。
+
+其他用到 `record.lang` 的地方（`five_star_collection.dart:49`、`item_type_kind.dart:15`）對頌願都是 `lookupId → null → fallback 到 name`。補 `lang` 後因為頌願從未進過 HoYoWiki index，結果仍是 `null → fallback`，**行為零變化**。
+
+故本設計**不需要任何「擋 HoYoWiki」守衛**。
+
+## 資料來源與流向
+
+頌願 record 的 `lang` 唯一可靠來源 ＝ 擷取 URL 的 `lang` query 參數。流向分兩條：
+
+- **新抓的記錄**：在解析 API 回應時，以 URL 的 `lang` 作為 fallback 寫入 → record 一出生即帶正確 `lang`。
+- **既有存檔記錄**：在合併（merge）回傳前，把 `lang` 為空者回填成 URL 的 `lang`。
+
+兩條都只在 `lang` 為空時才套用 fallback／回填，因此一般祈願（API 已帶非空 `lang`）完全不受影響。
+
+## 改動點
+
+### 1. `lib/services/gacha_url.dart`
+
+新增 getter，讓 fetcher 不必自己摸內部 `_uri`：
+
+```dart
+/// 擷取 URL 的 `lang` query 參數；缺漏時為空字串。
+String get lang => _uri.queryParameters['lang'] ?? '';
+```
+
+### 2. `lib/models/gacha_record.dart`
+
+- `fromApiJson` 新增具名參數 `String fallbackLang = ''`。`lang` 邏輯改為：API 有非空 `lang` 時用 API 的（一般祈願不受影響）；否則用 `fallbackLang`（頌願）。
+
+  ```dart
+  factory GachaRecord.fromApiJson(
+    Map<String, dynamic> json, {
+    required String gachaType,
+    String fallbackLang = '',
+  }) {
+    final apiLang = json['lang'] as String?;
+    return GachaRecord(
+      // ……其餘欄位不變……
+      lang: (apiLang == null || apiLang.isEmpty) ? fallbackLang : apiLang,
+    );
+  }
+  ```
+
+- 新增 `copyWith`，供回填產生新 record（YAGNI：當前只需改 `lang`）：
+
+  ```dart
+  /// 複製本 record，可覆寫 [lang]（其餘欄位沿用原值）。
+  GachaRecord copyWith({String? lang}) => GachaRecord(
+    id: id,
+    uid: uid,
+    gachaType: gachaType,
+    name: name,
+    itemType: itemType,
+    rankType: rankType,
+    time: time,
+    lang: lang ?? this.lang,
+  );
+  ```
+
+### 3. `lib/services/gacha_fetcher.dart`
+
+- `fetchPage`：對稱既有的 `queryGachaType`，加抽 `queryLang`，並傳入 `fromApiJson` 作 fallback：
+
+  ```dart
+  final queryLang = url.queryParameters['lang'] ?? '';
+  // ……
+  GachaRecord.fromApiJson(
+    e as Map<String, dynamic>,
+    gachaType: queryGachaType,
+    fallbackLang: queryLang,
+  )
+  ```
+
+- `fetchBannerWithMerge`：回傳前回填 `existing` 中 `lang` 為空者。`url.lang` 為空（URL 缺 `lang` 參數）時整段跳過，避免把空值蓋空值。回填數 `> 0` 時記一行 log：
+
+  ```dart
+  final urlLang = url.lang;
+  final List<GachaRecord> normalizedExisting;
+  if (urlLang.isEmpty) {
+    normalizedExisting = existing;
+  } else {
+    var backfilled = 0;
+    normalizedExisting = existing.map((r) {
+      if (r.lang.isEmpty) {
+        backfilled++;
+        return r.copyWith(lang: urlLang);
+      }
+      return r;
+    }).toList(growable: false);
+    if (backfilled > 0) {
+      _log.info(
+        'banner=$gachaType backfilled lang for $backfilled records to "$urlLang"',
+      );
+    }
+  }
+  return [...fresh, ...normalizedExisting];
+  ```
+
+> 一般祈願的 existing record 必有非空 `lang`，`r.lang.isEmpty` 為 false → 不變動；故此回填在實務上只作用於頌願。採通用的 `isEmpty` 判斷而非按 endpoint 特判，較精準也較簡潔。
+
+## 測試
+
+- **`test/models/gacha_record_test.dart`**
+  - `fromApiJson` 頌願形態（`item_name`、無 `lang`）＋ `fallbackLang` → `lang` 為 fallback 值。
+  - `fromApiJson` 一般祈願形態（API 帶 `lang`）＋ `fallbackLang` → API 的 `lang` 優先，fallback 被忽略。
+  - `copyWith(lang: ...)` 只改 `lang`，其餘欄位不變。
+- **`test/services/gacha_fetcher_test.dart`**
+  - 新抓的頌願 fresh record 帶 URL 的 `lang`。
+  - `fetchBannerWithMerge` 把 existing 中空 `lang` 的記錄回填成 URL 的 `lang`。
+  - URL 無 `lang` 參數時不丟例外，existing 原樣保留。
+
+## 驗收
+
+- `dart format lib/ test/`、`flutter analyze`（`No issues found!`）、`flutter test`（`All tests passed!`）全綠。

--- a/docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md
+++ b/docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md
@@ -20,9 +20,12 @@
 1. **批次抓取**：更新後與 force-refetch 都走 `_fetchHoYoWiki`。它在 `gacha_repository.dart:782/788` 用 `hoyoWikiTargetGachaTypes = {'301','302','500','200','100'}` 過濾，頌願的 gachaType（`'2000'`／`'1000'`）在 `lang.isEmpty` 判斷之前就先被 `continue` 掉。
 2. **on-demand 詳情**：`gacha_item_detail_dialog.dart:22/28` 的 `_odesGachaTypes = {'2000','1000'}` 讓頌願物品「永遠不可點」，dialog 不開、不觸發抓取。
 
-其他用到 `record.lang` 的地方（`five_star_collection.dart:49`、`item_type_kind.dart:15`）對頌願都是 `lookupId → null → fallback 到 name`。補 `lang` 後因為頌願從未進過 HoYoWiki index，結果仍是 `null → fallback`，**行為零變化**。
+其他用到 `record.lang` 的地方：
 
-故本設計**不需要任何「擋 HoYoWiki」守衛**。
+- `five_star_collection.dart:60`、`gacha_item_detail_dialog.dart:28`：兩者都在 lookup 之前以 gachaType 硬排除頌願，補 `lang` **行為零變化**。
+- `item_type_kind.dart:15` 的 `itemTypeKeyOf`：**未**排除頌願，會經 `gacha_row`／`gacha_stats` 對頌願 record 呼叫。補 `lang` 前查 `'::name'`（空 lang）結構上保證 `null → fallback`；補 `lang` 後查 `'<lang>::name'`，**不再結構保證 null**，僅當某一般祈願物品同名同語言已被 HoYoWiki 索引時才命中，此時頌願 `itemTypeKey` 會從原始字串翻成 `kind:character`／`kind:weapon`。頌願裝扮名不與角色／武器撞名，實務影響趨近於零；且此為純本地 lookup，**不觸發任何抓取**。
+
+故本設計**不需要任何「擋 HoYoWiki」守衛**（`itemTypeKeyOf` 的 nuance 僅為衍生標籤，且不涉及任何 I/O）。
 
 ## 資料來源與流向
 

--- a/lib/models/gacha_record.dart
+++ b/lib/models/gacha_record.dart
@@ -33,7 +33,7 @@ class GachaRecord {
   /// 抽到的時間（本地時間）。
   final DateTime time;
 
-  /// 紀錄的語言 tag（頌願 API 無此欄位時為空字串）。
+  /// 紀錄的語言 tag（頌願 API 無此欄位時由 fallbackLang 補上，未知時為空字串）。
   final String lang;
 
   /// 從 hoyoverse getGachaLog / getBeyondGachaLog API 回傳的 list 元素解析。

--- a/lib/models/gacha_record.dart
+++ b/lib/models/gacha_record.dart
@@ -41,14 +41,17 @@ class GachaRecord {
   /// 兩個 endpoint 的 schema 不一致：
   /// - 卡池 (getGachaLog): `name` / `gacha_type` / `lang`
   /// - 頌願 (getBeyondGachaLog): `item_name` / `op_gacha_type`（值為 schedule 級
-  ///   ID 如 20021，跟我們查詢的 banner 級 gacha_type 2000/1000 不同）；無 `lang`
+  ///   ID 如 20021，跟我們查詢的 banner 級 gacha_type 2000/1000 不同）；
+  ///   無 `lang`，故由呼叫端傳入的 [fallbackLang]（擷取 URL 的 lang）補上。
   ///
   /// 為了讓存檔 schema 對齊查詢的 banner（mergedBanners key 是 query 用的
   /// gacha_type），這裡用呼叫端傳入的 [gachaType] 覆寫，不取回傳的 op_gacha_type。
   factory GachaRecord.fromApiJson(
     Map<String, dynamic> json, {
     required String gachaType,
+    String fallbackLang = '',
   }) {
+    final apiLang = json['lang'] as String?;
     return GachaRecord(
       id: json['id'] as String,
       uid: json['uid'] as String,
@@ -57,7 +60,7 @@ class GachaRecord {
       itemType: json['item_type'] as String,
       rankType: int.parse(json['rank_type'] as String),
       time: DateTime.parse((json['time'] as String).replaceFirst(' ', 'T')),
-      lang: (json['lang'] as String?) ?? '',
+      lang: (apiLang == null || apiLang.isEmpty) ? fallbackLang : apiLang,
     );
   }
 
@@ -92,4 +95,16 @@ class GachaRecord {
       'lang': lang,
     };
   }
+
+  /// 複製本 record，可覆寫 [lang]（其餘欄位沿用原值）。
+  GachaRecord copyWith({String? lang}) => GachaRecord(
+    id: id,
+    uid: uid,
+    gachaType: gachaType,
+    name: name,
+    itemType: itemType,
+    rankType: rankType,
+    time: time,
+    lang: lang ?? this.lang,
+  );
 }

--- a/lib/services/gacha_fetcher.dart
+++ b/lib/services/gacha_fetcher.dart
@@ -104,6 +104,7 @@ class GachaFetcher {
   /// 抓單頁，retcode 處理：0=ok / -101,-100=AuthExpired / -110=自動退避 / 其他=ApiError
   Future<FetchedPage> fetchPage(Uri url, http.Client client) async {
     final queryGachaType = url.queryParameters['gacha_type'] ?? '';
+    final queryLang = url.queryParameters['lang'] ?? '';
     var attempt = 0;
     _log.fine(
       'fetchPage gachaType=$queryGachaType url=${sanitizeUrl(url.toString())}',
@@ -120,6 +121,7 @@ class GachaFetcher {
                 (e) => GachaRecord.fromApiJson(
                   e as Map<String, dynamic>,
                   gachaType: queryGachaType,
+                  fallbackLang: queryLang,
                 ),
               )
               .toList(growable: false),

--- a/lib/services/gacha_fetcher.dart
+++ b/lib/services/gacha_fetcher.dart
@@ -207,7 +207,32 @@ class GachaFetcher {
 
     // fresh + existing 都是 desc
     _log.info('banner=$gachaType done, fresh=${fresh.length} pages=$pageIndex');
-    return [...fresh, ...existing];
+
+    // 頌願 API 不回傳 lang；既有空 lang 記錄以擷取 URL 的 lang 回填（一般祈願
+    // existing 必有非空 lang，不受影響）。URL 缺 lang 則不動，避免以空蓋空。
+    final urlLang = url.lang;
+    final List<GachaRecord> normalizedExisting;
+    if (urlLang.isEmpty) {
+      normalizedExisting = existing;
+    } else {
+      var backfilled = 0;
+      normalizedExisting = existing
+          .map((r) {
+            if (r.lang.isEmpty) {
+              backfilled++;
+              return r.copyWith(lang: urlLang);
+            }
+            return r;
+          })
+          .toList(growable: false);
+      if (backfilled > 0) {
+        _log.info(
+          'banner=$gachaType backfilled lang for $backfilled records '
+          'to "$urlLang"',
+        );
+      }
+    }
+    return [...fresh, ...normalizedExisting];
   }
 
   /// 字串字典序比對；id 等長 19 字元 → 字典序 = 數值序

--- a/lib/services/gacha_url.dart
+++ b/lib/services/gacha_url.dart
@@ -20,6 +20,9 @@ class GachaUrl {
   /// 內部包裝的原始 URI。
   final Uri _uri;
 
+  /// 擷取 URL 的 `lang` query 參數；缺漏時為空字串。
+  String get lang => _uri.queryParameters['lang'] ?? '';
+
   /// 解析使用者擷取的 URL 字串。
   static GachaUrl parse(String capturedUrl) =>
       GachaUrl._(Uri.parse(capturedUrl));

--- a/test/models/gacha_record_test.dart
+++ b/test/models/gacha_record_test.dart
@@ -55,6 +55,43 @@ void main() {
       expect(record.lang, '');
       expect(record.time, DateTime(2025, 10, 24, 1, 51, 25));
     });
+
+    test('頌願無 lang 時，以 fallbackLang 補上', () {
+      final json = {
+        'id': '1761240000000038925',
+        'uid': '801057625',
+        'item_type': '裝扮套裝',
+        'item_name': '女性裝扮·「燭影狂歡夜」',
+        'rank_type': '5',
+        'time': '2025-10-24 01:51:25',
+        'op_gacha_type': '20021',
+      };
+      final record = GachaRecord.fromApiJson(
+        json,
+        gachaType: '2000',
+        fallbackLang: 'ja',
+      );
+      expect(record.lang, 'ja');
+    });
+
+    test('API 已帶 lang 時，fallbackLang 被忽略', () {
+      final json = {
+        'uid': '801057625',
+        'gacha_type': '200',
+        'time': '2025-09-23 21:27:37',
+        'name': '討龍英傑譚',
+        'lang': 'zh-tw',
+        'item_type': '武器',
+        'rank_type': '3',
+        'id': '1758632760000221425',
+      };
+      final record = GachaRecord.fromApiJson(
+        json,
+        gachaType: '200',
+        fallbackLang: 'ja',
+      );
+      expect(record.lang, 'zh-tw');
+    });
   });
 
   group('GachaRecord JSON 持久化序列化', () {
@@ -80,6 +117,44 @@ void main() {
       expect(restored.id, original.id);
       expect(restored.itemType, original.itemType);
       expect(restored.time, original.time);
+    });
+  });
+
+  group('GachaRecord.copyWith', () {
+    test('只改 lang，其餘欄位不變', () {
+      final original = GachaRecord(
+        id: '1',
+        uid: '801057625',
+        gachaType: '2000',
+        name: 'x',
+        itemType: '裝扮套裝',
+        rankType: 5,
+        time: DateTime(2025, 10, 24, 1, 51, 25),
+        lang: '',
+      );
+      final updated = original.copyWith(lang: 'zh-tw');
+      expect(updated.lang, 'zh-tw');
+      expect(updated.id, original.id);
+      expect(updated.uid, original.uid);
+      expect(updated.gachaType, original.gachaType);
+      expect(updated.name, original.name);
+      expect(updated.itemType, original.itemType);
+      expect(updated.rankType, original.rankType);
+      expect(updated.time, original.time);
+    });
+
+    test('不傳 lang 則沿用原值', () {
+      final original = GachaRecord(
+        id: '1',
+        uid: '801057625',
+        gachaType: '2000',
+        name: 'x',
+        itemType: '裝扮套裝',
+        rankType: 5,
+        time: DateTime(2025, 10, 24, 1, 51, 25),
+        lang: 'en',
+      );
+      expect(original.copyWith().lang, 'en');
     });
   });
 

--- a/test/models/gacha_record_test.dart
+++ b/test/models/gacha_record_test.dart
@@ -92,6 +92,25 @@ void main() {
       );
       expect(record.lang, 'zh-tw');
     });
+
+    test('API 回傳空字串 lang 時，以 fallbackLang 補上', () {
+      final json = {
+        'uid': '801057625',
+        'gacha_type': '200',
+        'time': '2025-09-23 21:27:37',
+        'name': '討龍英傑譚',
+        'lang': '',
+        'item_type': '武器',
+        'rank_type': '3',
+        'id': '1758632760000221425',
+      };
+      final record = GachaRecord.fromApiJson(
+        json,
+        gachaType: '200',
+        fallbackLang: 'en',
+      );
+      expect(record.lang, 'en');
+    });
   });
 
   group('GachaRecord JSON 持久化序列化', () {

--- a/test/services/gacha_fetcher_test.dart
+++ b/test/services/gacha_fetcher_test.dart
@@ -71,6 +71,32 @@ void main() {
       );
     });
 
+    test('頌願回傳無 lang 時，以 URL 的 lang 補上', () async {
+      final mock = MockClient(
+        (req) async => _ok([
+          {
+            'uid': '801057625',
+            'op_gacha_type': '20021',
+            'item_id': '265044',
+            'count': '1',
+            'time': '2025-10-24 01:51:25',
+            'item_name': 'x',
+            'item_type': '裝扮套裝',
+            'rank_type': '5',
+            'id': '99',
+          },
+        ]),
+      );
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final page = await fetcher.fetchPage(
+        GachaUrl.parse(
+          _baseUrl,
+        ).build(gachaType: '2000', endId: '0', endpoint: GachaEndpoint.odes),
+        mock,
+      );
+      expect(page.records.first.lang, 'zh-tw');
+    });
+
     test('retcode=-110 退避後 throw RateLimitedException', () async {
       var hits = 0;
       final mock = MockClient((req) async {

--- a/test/services/gacha_fetcher_test.dart
+++ b/test/services/gacha_fetcher_test.dart
@@ -6,6 +6,7 @@ import 'package:http/testing.dart';
 import 'package:logging/logging.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_url.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_fetcher.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 
 const _baseUrl =
     'https://public-operation-hk4e-sg.hoyoverse.com/gacha_info/api/getGachaLog'
@@ -159,6 +160,64 @@ void main() {
       );
       expect(paths, isNotEmpty);
       expect(paths.every((p) => p.endsWith('/getBeyondGachaLog')), isTrue);
+    });
+
+    test('既有空 lang 記錄回填為 URL 的 lang', () async {
+      final client = MockClient((req) async => _ok(const []));
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final existing = [
+        GachaRecord(
+          id: '50',
+          uid: '801057625',
+          gachaType: '2000',
+          name: 'x',
+          itemType: '裝扮套裝',
+          rankType: 5,
+          time: DateTime(2025, 10, 24, 1, 51, 25),
+          lang: '',
+        ),
+      ];
+      final merged = await fetcher.fetchBannerWithMerge(
+        url: GachaUrl.parse(_baseUrl),
+        gachaType: '2000',
+        endpoint: GachaEndpoint.odes,
+        existing: existing,
+        primer: null,
+        onProgress: (_) {},
+        client: client,
+      );
+      expect(merged, hasLength(1));
+      expect(merged.first.lang, 'zh-tw');
+    });
+
+    test('URL 無 lang 時不動既有記錄', () async {
+      final client = MockClient((req) async => _ok(const []));
+      final fetcher = GachaFetcher(rateLimit: Duration.zero);
+      final existing = [
+        GachaRecord(
+          id: '50',
+          uid: '801057625',
+          gachaType: '2000',
+          name: 'x',
+          itemType: '裝扮套裝',
+          rankType: 5,
+          time: DateTime(2025, 10, 24, 1, 51, 25),
+          lang: '',
+        ),
+      ];
+      final merged = await fetcher.fetchBannerWithMerge(
+        url: GachaUrl.parse(
+          'https://example.com/gacha_info/api/getBeyondGachaLog'
+          '?authkey=AAA&gacha_type=2000&end_id=0',
+        ),
+        gachaType: '2000',
+        endpoint: GachaEndpoint.odes,
+        existing: existing,
+        primer: null,
+        onProgress: (_) {},
+        client: client,
+      );
+      expect(merged.first.lang, '');
     });
   });
 

--- a/test/services/gacha_url_test.dart
+++ b/test/services/gacha_url_test.dart
@@ -94,5 +94,16 @@ void main() {
       expect(built.queryParameters['page'], '3');
       expect(built.queryParameters['size'], '5');
     });
+
+    test('lang getter 讀 query 的 lang', () {
+      expect(GachaUrl.parse(_capturedUrl).lang, 'zh-tw');
+    });
+
+    test('lang getter 缺 lang 參數時回空字串', () {
+      final url = GachaUrl.parse(
+        'https://example.com/gacha_info/api/getGachaLog?authkey=AAA&gacha_type=301&end_id=0',
+      );
+      expect(url.lang, '');
+    });
   });
 }


### PR DESCRIPTION
## 摘要

頌願（odes）走的 API 是 `getBeyondGachaLog`，回應不含 `lang` 欄位，原本 `GachaRecord.fromApiJson` 會把頌願記錄的 `lang` 填成空字串並寫進本地存檔。本 PR 改為以擷取 URL 的 `lang` query 參數補上：

- **`GachaUrl`**：新增 `lang` getter，暴露 URL 的 `lang` query 參數。
- **`GachaRecord`**：`fromApiJson` 新增 `fallbackLang` 參數（API 有非空 `lang` 時優先，否則用 fallback）；新增 `copyWith({String? lang})`。
- **`GachaFetcher`**：`fetchPage` 把 URL 的 `lang` 當 fallback 傳入，新抓的頌願記錄一出生即帶 `lang`；`fetchBannerWithMerge` 在回傳前把既有空 `lang` 記錄回填成 URL 的 `lang`（URL 缺 `lang` 則跳過，避免以空蓋空），並記 log。

一般祈願記錄本就帶 API 回傳的 `lang`，採通用的 `lang.isEmpty` 判斷，不受影響。

## 下游影響

補 `lang` **不會**觸發 HoYoWiki 抓取頌願：批次管線 `_fetchHoYoWiki` 與詳情 dialog 都已在 gachaType 層級排除頌願（`2000`／`1000`）。唯一 nuance 是 `itemTypeKeyOf` 對頌願記錄的 lookup 由「結構保證 null」變為「依同名同語言是否已索引」，但純本地 lookup、不涉 I/O，實務影響趨近於零（詳見 spec）。

## 測試計畫

- [x] `flutter analyze` → No issues found!
- [x] `flutter test` → All tests passed!（841 個）
- [x] 新增測試：`GachaUrl.lang` getter、`fromApiJson` fallback／API lang 優先／API 空字串、`copyWith`、`fetchPage` 頌願補 lang、`fetchBannerWithMerge` 回填既有空 lang 與 URL 無 lang 不動。

設計與實作計畫：`docs/superpowers/specs/2026-05-31-odes-fetch-write-lang-design.md`、`docs/superpowers/plans/2026-05-31-odes-fetch-write-lang.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
