### PR TITLE
fix(settings): use dedicated message when clearing detail-image cache fails

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "Failed to clear detail images",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "Clear detail images",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "No se pudieron borrar las imágenes detalladas",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "Borrar imágenes detalladas",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "Échec de la suppression des images détaillées",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "Effacer les images détaillées",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "詳細画像の削除に失敗しました",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "詳細画像をクリア",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "Falha ao limpar as imagens detalhadas",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "Limpar imagens detalhadas",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "ล้างรูปรายละเอียดไม่สำเร็จ",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "ล้างรูปรายละเอียด",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -499,6 +499,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "Không thể xoá ảnh chi tiết",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "Xoá ảnh chi tiết",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -374,6 +374,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "清除詳情圖快取失敗",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "清除詳情圖快取",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -495,6 +495,10 @@
   "@settingsImageCacheFailed": {
     "description": "Shown when scanning cache size fails (e.g. permission denied)."
   },
+  "settingsImageCacheClearFailed": "清除详情图缓存失败",
+  "@settingsImageCacheClearFailed": {
+    "description": "Shown as a snackbar when clearing the detail-image (gallery) cache fails (e.g. file in use or permission denied)."
+  },
   "settingsImageCacheClearGallery": "清除详情图",
   "@settingsImageCacheClearGallery": {
     "description": "Button label: clear gallery cache (keeps icons)."

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -813,7 +813,7 @@ class _ImageCacheSectionState extends ConsumerState<_ImageCacheSection> {
       ref.invalidate(hoyowikiCacheUsageProvider);
       ScaffoldMessenger.of(
         ctx,
-      ).showSnackBar(SnackBar(content: Text(l.settingsImageCacheFailed)));
+      ).showSnackBar(SnackBar(content: Text(l.settingsImageCacheClearFailed)));
     }
   }
 


### PR DESCRIPTION
## 變更內容

設定頁「清除詳情圖快取」按鈕失敗時，原本複用了 `settingsImageCacheFailed`（「無法讀取快取大小」）。該文案的設計用途是「掃描快取大小失敗」，套在清除失敗的情境並不貼切——失敗的是「刪除」而非「讀取」。

本 PR 新增專屬 key `settingsImageCacheClearFailed`，並讓 `_clearGallery()` 的 catch 分支改用它。

### 程式碼

- `lib/pages/settings_page.dart`：`_clearGallery()` catch 區塊的 SnackBar 改用 `l.settingsImageCacheClearFailed`。讀取快取大小失敗處（`error: (e, st) => Text(...)`）維持 `settingsImageCacheFailed` 不動。

### i18n

於 9 個已有實體翻譯的語系檔新增 key，用語對齊既有按鈕 `settingsImageCacheClearGallery` 的「詳情圖／detail images」；其餘空殼語系檔留給 Crowdin pipeline 處理。

| 語系 | 文案 |
| --- | --- |
| 繁中（zh） | 清除詳情圖快取失敗 |
| 簡中（zh_Hans） | 清除详情图缓存失败 |
| en | Failed to clear detail images |
| ja | 詳細画像の削除に失敗しました |
| fr | Échec de la suppression des images détaillées |
| es | No se pudieron borrar las imágenes detalladas |
| pt_BR | Falha ao limpar as imagens detalhadas |
| th | ล้างรูปรายละเอียดไม่สำเร็จ |
| vi | Không thể xoá ảnh chi tiết |

## 品質檢查

- `dart format lib/`：已格式化
- `flutter analyze`：`No issues found!`
- `flutter test`：`All tests passed!`（841 項）

🤖 Generated with [Claude Code](https://claude.com/claude-code)