### PR TITLE
fix(installer): correct typos and localize zh-Hant Inno Setup messages

### DIFF
--- a/scripts/build_installer/ChineseTraditional.isl
+++ b/scripts/build_installer/ChineseTraditional.isl
@@ -55,17 +55,17 @@ LdrCannotExecTemp=無法執行暫存檔案。安裝程式將會結束。
 HelpTextNote=
 
 ; *** Startup error messages
-LastErrorMessage=%1%n%n錯誤 %2: %3
+LastErrorMessage=%1%n%n錯誤 %2：%3
 SetupFileMissing=安裝資料夾中遺失檔案 %1。請修正此問題或重新取得此軟體。
 SetupFileCorrupt=安裝檔案已經損毀。請重新取得此軟體。
 SetupFileCorruptOrWrongVer=安裝檔案已經損毀，或與安裝程式的版本不符。請重新取得此軟體。
-InvalidParameter=某個無效的變量已被傳遞到了命令列:%n%n%1
+InvalidParameter=某個無效的參數已傳遞至命令列：%n%n%1
 SetupAlreadyRunning=安裝程式已經在執行。
 WindowsVersionNotSupported=本安裝程式並不支援目前在電腦所運行的 Windows 版本。
 WindowsServicePackRequired=本安裝程式需要 %1 Service Pack %2 或更新。
 NotOnThisPlatform=這個程式無法在 %1 執行。
 OnlyOnThisPlatform=這個程式必須在 %1 執行。
-OnlyOnTheseArchitectures=這個程式只能在專門為以下處理器架構而設計的 Windows 上安裝:%n%n%1
+OnlyOnTheseArchitectures=這個程式只能在專門為以下處理器架構而設計的 Windows 上安裝：%n%n%1
 WinVersionTooLowError=這個程式必須在 %1 版本 %2 或以上的系統執行。
 WinVersionTooHighError=這個程式無法安裝在 %1 版本 %2 或以上的系統。
 AdminPrivilegesRequired=您必須登入成系統管理員以安裝這個程式。
@@ -84,15 +84,15 @@ PrivilegesRequiredOverrideCurrentUser=僅為我安裝 (&M)
 PrivilegesRequiredOverrideCurrentUserRecommended=僅為我安裝 (建議選項) (&M)
 
 ; *** Misc. errors
-ErrorCreatingDir=安裝程式無法建立資料夾“%1”。
-ErrorTooManyFilesInDir=無法在資料夾“%1”內建立檔案，因為資料夾內有太多的檔案。
+ErrorCreatingDir=安裝程式無法建立資料夾「%1」。
+ErrorTooManyFilesInDir=無法在資料夾「%1」內建立檔案，因為資料夾內有太多的檔案。
 
 ; *** Setup common messages
 ExitSetupTitle=結束安裝程式
-ExitSetupMessage=安裝尚未完成。如果您現在結束安裝程式，這個程式將不會被安裝。%n%n您可以稍後再執行安裝程式以完成安裝程式。您現在要結束安裝程式嗎?
+ExitSetupMessage=安裝尚未完成。如果您現在結束安裝程式，這個程式將不會被安裝。%n%n您可以稍後再執行安裝程式以完成安裝程式。您現在要結束安裝程式嗎？
 AboutSetupMenuItem=關於安裝程式 (&A)...
 AboutSetupTitle=關於安裝程式
-AboutSetupMessage=%1 版本 %2%n%3%n%n%1 網址:%n%4
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 網址：%n%4
 AboutSetupNote=
 TranslatorNote=
 
@@ -114,24 +114,24 @@ ButtonNewFolder=建立新資料夾 (&M)
 
 ; *** "Select Language" dialog messages
 SelectLanguageTitle=選擇安裝語言
-SelectLanguageLabel=選擇在安裝過程中使用的語言:
+SelectLanguageLabel=選擇在安裝過程中使用的語言：
 
 ; *** Common wizard text
 ClickNext=按 「下一步」 繼續安裝，或按 「取消」 結束安裝程式。
 BeveledLabel=
 BrowseDialogTitle=瀏覽資料夾
-BrowseDialogLabel=在下麵的資料夾清單中選擇一個資料夾，然後按 「確定」。
+BrowseDialogLabel=在下面的資料夾清單中選擇一個資料夾，然後按 「確定」。
 NewFolderName=新資料夾
 
 ; *** "Welcome" wizard page
 WelcomeLabel1=歡迎使用 [name] 安裝程式
-WelcomeLabel2=這個安裝程式將會安裝 [name/ver] 到您的電腦。%n%n我們強烈建議您在安裝過程中關閉其它的應用程式，以避免與安裝程式發生沖突。
+WelcomeLabel2=這個安裝程式將會安裝 [name/ver] 到您的電腦。%n%n我們強烈建議您在安裝過程中關閉其他的應用程式，以避免與安裝程式發生衝突。
 
 ; *** "Password" wizard page
 WizardPassword=密碼
 PasswordLabel1=這個安裝程式具有密碼保護。
 PasswordLabel3=請輸入密碼，然後按 「下一步」 繼續。密碼是區分大小寫的。
-PasswordEditLabel=密碼 (&P):
+PasswordEditLabel=密碼 (&P)：
 IncorrectPassword=您輸入的密碼不正確，請重新輸入。
 
 ; *** "License Agreement" wizard page
@@ -152,19 +152,19 @@ InfoAfterClickLabel=當您準備好繼續安裝，請按 「下一步」。
 ; *** "User Information" wizard page
 WizardUserInfo=使用者資訊
 UserInfoDesc=請輸入您的資料。
-UserInfoName=使用者名稱(&U):
-UserInfoOrg=組織(&O):
-UserInfoSerial=序號(&S):
+UserInfoName=使用者名稱(&U)：
+UserInfoOrg=組織(&O)：
+UserInfoSerial=序號(&S)：
 UserInfoNameRequired=您必須輸入您的名稱。
 
 ; *** "Select Destination Location" wizard page
 WizardSelectDir=選擇目的資料夾
 SelectDirDesc=選擇安裝程式安裝 [name] 的位置。
-SelectDirLabel3=安裝程式將會把 [name] 安裝到下麵的資料夾。
+SelectDirLabel3=安裝程式將會把 [name] 安裝到下面的資料夾。
 SelectDirBrowseLabel=按 「下一步」 繼續，如果您想選擇另一個資料夾，請按 「瀏覽」。
 DiskSpaceGBLabel=最少需要 [gb] GB 磁碟空間。
 DiskSpaceMBLabel=最少需要 [mb] MB 磁碟空間。
-CannotInstallToNetworkDrive=安裝程式無法安裝於網絡磁碟機。
+CannotInstallToNetworkDrive=安裝程式無法安裝於網路磁碟機。
 CannotInstallToUNCPath=安裝程式無法安裝於 UNC 路徑。
 InvalidPath=您必須輸入完整的路徑名稱及磁碟機代碼。%n%n例如 C:\App 或 UNC 路徑格式 \\伺服器\共用資料夾。
 InvalidDrive=您選取的磁碟機或 UNC 名稱不存在或無法存取，請選擇其他的目的地。
@@ -172,7 +172,7 @@ DiskSpaceWarningTitle=磁碟空間不足
 DiskSpaceWarning=安裝程式需要至少 %1 KB 的磁碟空間，您所選取的磁碟只有 %2 KB 可用空間。%n%n您要繼續安裝嗎？
 DirNameTooLong=資料夾名稱或路徑太長。
 InvalidDirName=資料夾名稱不正確。
-BadDirName32=資料夾名稱不得包含以下特殊字元:%n%n%1
+BadDirName32=資料夾名稱不得包含以下特殊字元：%n%n%1
 DirExistsTitle=資料夾已經存在
 DirExists=資料夾：%n%n%1%n%n 已經存在。仍要安裝到該資料夾嗎？
 DirDoesntExistTitle=資料夾不存在
@@ -187,7 +187,7 @@ FullInstallation=完整安裝
 CompactInstallation=最小安裝
 CustomInstallation=自訂安裝
 NoUninstallWarningTitle=元件已存在
-NoUninstallWarning=安裝程式偵測到以下元件已經安裝在您的電腦上:%n%n%1%n%n取消選擇這些元件將不會移除它們。%n%n您仍然要繼續嗎？
+NoUninstallWarning=安裝程式偵測到以下元件已經安裝在您的電腦上：%n%n%1%n%n取消選擇這些元件將不會移除它們。%n%n您仍然要繼續嗎？
 ComponentSize1=%1 KB
 ComponentSize2=%1 MB
 ComponentsDiskSpaceGBLabel=目前的選擇需要至少 [gb] GB 磁碟空間。
@@ -201,12 +201,12 @@ SelectTasksLabel2=選擇安裝程式在安裝 [name] 時要執行的附加工作
 ; *** "Select Start Menu Folder" wizard page
 WizardSelectProgramGroup=選擇「開始」功能表的資料夾
 SelectStartMenuFolderDesc=選擇安裝程式建立程式的捷徑的位置。
-SelectStartMenuFolderLabel3=安裝程式將會把程式的捷徑建立在下麵的「開始」功能表資料夾。
+SelectStartMenuFolderLabel3=安裝程式將會把程式的捷徑建立在下面的「開始」功能表資料夾。
 SelectStartMenuFolderBrowseLabel=按 「下一步」 繼續，如果您想選擇另一個資料夾，請按 「瀏覽」。
 MustEnterGroupName=您必須輸入一個資料夾的名稱。
 GroupNameTooLong=資料夾名稱或路徑太長。
 InvalidGroupName=資料夾名稱不正確。
-BadGroupName=資料夾名稱不得包含下列字元:%n%n%1
+BadGroupName=資料夾名稱不得包含下列字元：%n%n%1
 NoProgramGroupCheck2=不要在「開始」功能表中建立資料夾 (&D)
 
 ; *** "Ready to Install" wizard page
@@ -215,30 +215,30 @@ ReadyLabel1=安裝程式將開始安裝 [name] 到您的電腦中。
 ReadyLabel2a=按下 「安裝」 繼續安裝，或按 「上一步」 重新檢視或設定各選項的內容。
 ReadyLabel2b=按下 「安裝」 繼續安裝。
 ReadyMemoUserInfo=使用者資訊
-ReadyMemoDir=目的資料夾:
-ReadyMemoType=安裝型態:
-ReadyMemoComponents=選擇的元件:
-ReadyMemoGroup=「開始」功能表資料夾:
-ReadyMemoTasks=附加工作:
+ReadyMemoDir=目的資料夾：
+ReadyMemoType=安裝型態：
+ReadyMemoComponents=選擇的元件：
+ReadyMemoGroup=「開始」功能表資料夾：
+ReadyMemoTasks=附加工作：
 
 ; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
 DownloadingLabel2=正在下載額外檔案...
 ButtonStopDownload=停止下載 (&S)
 StopDownload=您確定要停止下載嗎？
 ErrorDownloadAborted=已停止下載
-ErrorDownloadFailed=下載失敗: %1 %2
-ErrorDownloadSizeFailed=取得檔案大小失敗: %1 %2
-ErrorProgress=進度無效: %1 之 %2
-ErrorFileSize=檔案大小無效: 必須為 %1，收到 %2
+ErrorDownloadFailed=下載失敗：%1 %2
+ErrorDownloadSizeFailed=取得檔案大小失敗：%1 %2
+ErrorProgress=進度無效：%1 之 %2
+ErrorFileSize=檔案大小無效：必須為 %1，收到 %2
 
-; *** TExtractionWizardPage 嚮導頁面與 ExtractArchive
-ExtractingLabel=正在解壓檔...
-ButtonStopExtraction=停止解壓(&S)
-StopExtraction=您確定要停止解壓嗎？
-ErrorExtractionAborted=解壓已中止
-ErrorExtractionFailed=解壓失敗：%1
+; *** TExtractionWizardPage 精靈頁面與 ExtractArchive
+ExtractingLabel=正在解壓縮檔...
+ButtonStopExtraction=停止解壓縮(&S)
+StopExtraction=您確定要停止解壓縮嗎？
+ErrorExtractionAborted=解壓縮已中止
+ErrorExtractionFailed=解壓縮失敗：%1
 
-; *** 壓縮檔解壓失敗詳情
+; *** 壓縮檔解壓縮失敗詳情
 ArchiveIncorrectPassword=壓縮檔密碼不正確
 ArchiveIsCorrupted=壓縮檔已損壞
 ArchiveUnsupportedFormat=不支援的壓縮檔格式
@@ -246,10 +246,10 @@ ArchiveUnsupportedFormat=不支援的壓縮檔格式
 ; *** "Preparing to Install" wizard page
 WizardPreparing=準備安裝程式
 PreparingDesc=安裝程式準備將 [name] 安裝到您的電腦上。
-PreviousInstallNotCompleted=先前的安裝/ 解除安裝尚未完成，您必須重新啟動電腦以完成該安裝。%n%n在重新啟動電腦之後，請再執行這個程式來安裝 [name]。
+PreviousInstallNotCompleted=先前的安裝／解除安裝尚未完成，您必須重新啟動電腦以完成該安裝。%n%n在重新啟動電腦之後，請再執行這個程式來安裝 [name]。
 CannotContinue=安裝程式無法繼續。請按 「取消」 離開。
-ApplicationsFound=下麵的應用程式正在使用安裝程式所需要更新的檔案。建議您允許安裝程式自動關閉這些應用程式。
-ApplicationsFound2=下麵的應用程式正在使用安裝程式所需要更新的檔案。建議您允許安裝程式自動關閉這些應用程式。當安裝過程結束後，本安裝程式將會嘗試重新開啟該應用程式。
+ApplicationsFound=下面的應用程式正在使用安裝程式所需要更新的檔案。建議您允許安裝程式自動關閉這些應用程式。
+ApplicationsFound2=下面的應用程式正在使用安裝程式所需要更新的檔案。建議您允許安裝程式自動關閉這些應用程式。當安裝過程結束後，本安裝程式將會嘗試重新開啟該應用程式。
 CloseApplications=關閉應用程式 (&A)
 DontCloseApplications=不要關閉應用程式 (&D)
 ErrorCloseApplications=安裝程式無法自動關閉所有應用程式。建議您在繼續前先關閉所有應用程式使用的檔案。
@@ -277,8 +277,8 @@ RunEntryShellExec=檢視 %1
 ; *** "Setup Needs the Next Disk" 
 ChangeDiskTitle=安裝程式需要下一張磁片
 SelectDiskLabel2=請插入磁片 %1，然後按 「確定」。%n%n如果檔案不在以下所顯示的資料夾之中，請輸入正確的資料夾名稱或按 [瀏覽] 選取。
-PathLabel=路徑(&P):
-FileNotInDir2=檔案“%1”無法在“%2”找到。請插入正確的磁片或選擇其它的資料夾。
+PathLabel=路徑(&P)：
+FileNotInDir2=檔案「%1」無法在「%2」找到。請插入正確的磁片或選擇其他的資料夾。
 SelectDirectoryLabel=請指定下一張磁片的位置。
 
 ; *** Installation phase messages
@@ -295,9 +295,9 @@ RetryCancelCancel=取消(&C)
 StatusClosingApplications=正在關閉應用程式...
 StatusCreateDirs=正在建立資料夾...
 StatusExtractFiles=正在解壓縮檔案...
-StatusDownloadFiles=正在下载文件...
+StatusDownloadFiles=正在下載檔案...
 StatusCreateIcons=正在建立程式集圖示...
-StatusCreateIniEntries=寫入 INI 檔案的項目...
+StatusCreateIniEntries=正在寫入 INI 檔案的項目...
 StatusCreateRegistryEntries=正在更新系統登錄...
 StatusRegisterFiles=正在登錄檔案...
 StatusSavingUninstall=儲存解除安裝資訊...
@@ -306,37 +306,37 @@ StatusRestartingApplications=正在重新開啟應用程式...
 StatusRollback=正在復原變更...
 
 ; *** Misc. errors
-ErrorInternal2=內部錯誤: %1
+ErrorInternal2=內部錯誤：%1
 ErrorFunctionFailedNoCode=%1 失敗
 ErrorFunctionFailed=%1 失敗；代碼 %2
-ErrorFunctionFailedWithMessage=%1 失敗；代碼 %2.%n%3
-ErrorExecutingProgram=無法執行檔案:%n%1
+ErrorFunctionFailedWithMessage=%1 失敗；代碼 %2。%n%3
+ErrorExecutingProgram=無法執行檔案：%n%1
 
 ; *** Registry errors
-ErrorRegOpenKey=無法開啟登錄鍵:%n%1\%2
-ErrorRegCreateKey=無法建立登錄項目:%n%1\%2
-ErrorRegWriteKey=無法變更登錄項目:%n%1\%2
+ErrorRegOpenKey=無法開啟登錄鍵：%n%1\%2
+ErrorRegCreateKey=無法建立登錄項目：%n%1\%2
+ErrorRegWriteKey=無法變更登錄項目：%n%1\%2
 
 ; *** INI errors
-ErrorIniEntry=在檔案“%1”建立 INI 項目錯誤。
+ErrorIniEntry=在檔案「%1」建立 INI 項目錯誤。
 
 ; *** File copying errors
 FileAbortRetryIgnoreSkipNotRecommended=略過這個檔案 (不建議) (&S)
 FileAbortRetryIgnoreIgnoreNotRecommended=略過錯誤並繼續 (不建議) (&I)
-SourceDoesntExist=來源檔案“%1”不存在。
+SourceDoesntExist=來源檔案「%1」不存在。
 SourceIsCorrupted=來源檔案已經損毀。
-SourceVerificationFailed=源文件验证失败: %1
-VerificationSignatureDoesntExist=簽名檔“%1”不存在
-VerificationSignatureInvalid=簽名檔“%1”無效
-VerificationKeyNotFound=簽名檔“%1”使用了未知金鑰
-VerificationFileNameIncorrect=檔案名不正確
-VerificationFileTagIncorrect=檔標籤不正確
-VerificationFileSizeIncorrect=檔大小不正確
-VerificationFileHashIncorrect=檔雜湊值不正確
+SourceVerificationFailed=來源檔案驗證失敗：%1
+VerificationSignatureDoesntExist=簽名檔「%1」不存在
+VerificationSignatureInvalid=簽名檔「%1」無效
+VerificationKeyNotFound=簽名檔「%1」使用了未知金鑰
+VerificationFileNameIncorrect=檔案名稱不正確
+VerificationFileTagIncorrect=檔案標籤不正確
+VerificationFileSizeIncorrect=檔案大小不正確
+VerificationFileHashIncorrect=檔案雜湊值不正確
 ExistingFileReadOnly2=無法取代現有檔案，因為檔案已標示為唯讀。
 ExistingFileReadOnlyRetry=移除唯讀屬性並重試 (&R)
 ExistingFileReadOnlyKeepExisting=保留現有檔案 (&K)
-ErrorReadingExistingDest=讀取一個已存在的檔案時發生錯誤:
+ErrorReadingExistingDest=讀取一個已存在的檔案時發生錯誤：
 FileExistsSelectAction=選擇操作
 FileExists2=檔案已存在。
 FileExistsOverwriteExisting=覆寫現有檔案
@@ -347,18 +347,18 @@ ExistingFileNewer2=現有檔案比安裝程式嘗試安裝的檔案還新。
 ExistingFileNewerOverwriteExisting=覆寫現有檔案 (&O)
 ExistingFileNewerKeepExisting=保留現有檔案 (&K) (建議選項)
 ExistingFileNewerOverwriteOrKeepAll=對下次衝突執行相同操作 (&D)
-ErrorChangingAttr=在變更檔案屬性時發生錯誤:
-ErrorCreatingTemp=在目的資料夾中建立檔案時發生錯誤:
-ErrorReadingSource=讀取原始檔案時發生錯誤:
-ErrorCopying=複製檔案時發生錯誤:
-ErrorDownloading=下載檔案時出錯：
-ErrorExtracting=解壓壓縮檔時出錯：	
-ErrorReplacingExistingFile=取代檔案時發生錯誤:
-ErrorRestartReplace=重新啟動電腦後取代檔案失敗:
-ErrorRenamingTemp=在目的資料夾變更檔案名稱時發生錯誤:
-ErrorRegisterServer=無法注冊 DLL/OCX 檔案: %1。
+ErrorChangingAttr=在變更檔案屬性時發生錯誤：
+ErrorCreatingTemp=在目的資料夾中建立檔案時發生錯誤：
+ErrorReadingSource=讀取原始檔案時發生錯誤：
+ErrorCopying=複製檔案時發生錯誤：
+ErrorDownloading=下載檔案時發生錯誤：
+ErrorExtracting=解壓縮壓縮檔時發生錯誤：
+ErrorReplacingExistingFile=取代檔案時發生錯誤：
+ErrorRestartReplace=重新啟動電腦後取代檔案失敗：
+ErrorRenamingTemp=在目的資料夾變更檔案名稱時發生錯誤：
+ErrorRegisterServer=無法註冊 DLL/OCX 檔案：%1。
 ErrorRegSvr32Failed=RegSvr32 失敗；退出代碼 %1
-ErrorRegisterTypeLib=無法注冊類型庫: %1。
+ErrorRegisterTypeLib=無法註冊類型庫：%1。
 
 ; *** Uninstall display name markings
 ; used for example as 'My Program (32-bit)'
@@ -375,9 +375,9 @@ ErrorOpeningReadme=開啟讀我檔案時發生錯誤。
 ErrorRestartingComputer=安裝程式無法重新啟動電腦，請自行重新啟動。
 
 ; *** Uninstaller messages
-UninstallNotFound=檔案“%1”不存在，無法解除安裝。
-UninstallOpenError=無法開啟檔案“%1”，無法解除安裝
-UninstallUnsupportedVer=這個版本的解除安裝程式無法辨識記錄檔 “%1” 之格式，無法解除安裝。
+UninstallNotFound=檔案「%1」不存在，無法解除安裝。
+UninstallOpenError=無法開啟檔案「%1」，無法解除安裝
+UninstallUnsupportedVer=這個版本的解除安裝程式無法辨識記錄檔 「%1」 之格式，無法解除安裝。
 UninstallUnknownEntry=解除安裝記錄檔中發現未知的記錄 (%1)。
 ConfirmUninstall=您確定要完全移除 %1 及其相關的檔案嗎？
 UninstallOnlyOnWin64=這個程式只能在 64 位元的 Windows 上解除安裝。
@@ -386,13 +386,13 @@ UninstallStatusLabel=正在從您的電腦移除 %1 中，請稍候...
 UninstalledAll=%1 已經成功從您的電腦中移除。
 UninstalledMost=%1 解除安裝完成。%n%n某些檔案及元件無法移除，您可以自行刪除這些檔案。
 UninstalledAndNeedsRestart=要完成 %1 的解除安裝程式，您必須重新啟動電腦。%n%n您想要現在重新啟動電腦嗎？
-UninstallDataCorrupted=檔案“%1”已經損毀，無法解除安裝
+UninstallDataCorrupted=檔案「%1」已經損毀，無法解除安裝
 
 ; *** Uninstallation phase messages
 ConfirmDeleteSharedFileTitle=移除共用檔案
-ConfirmDeleteSharedFile2=系統顯示下列共用檔案已不再被任何程式所使用，您要移除這些檔案嗎?%n%n%1%n%n倘若您移除了以上檔案但仍有程式需要使用它們，將造成這些程式無法正常執行，因此您若無法確定請選擇 [否]。保留這些檔案在您的系統中不會造成任何損害。
-SharedFileNameLabel=檔案名稱:
-SharedFileLocationLabel=位置:
+ConfirmDeleteSharedFile2=系統顯示下列共用檔案已不再被任何程式所使用，您要移除這些檔案嗎？%n%n%1%n%n倘若您移除了以上檔案但仍有程式需要使用它們，將造成這些程式無法正常執行，因此您若無法確定請選擇 [否]。保留這些檔案在您的系統中不會造成任何損害。
+SharedFileNameLabel=檔案名稱：
+SharedFileLocationLabel=位置：
 WizardUninstalling=解除安裝狀態
 StatusUninstalling=正在解除安裝 %1...
 
@@ -406,7 +406,7 @@ ShutdownBlockReasonUninstallingApp=正在解除安裝 %1。
 [CustomMessages]
 
 NameAndVersion=%1 版本 %2
-AdditionalIcons=附加圖示:
+AdditionalIcons=附加圖示：
 CreateDesktopIcon=建立桌面圖示(&D)
 CreateQuickLaunchIcon=建立快速啟動圖示(&Q)
 ProgramOnTheWeb=%1 的網站
@@ -414,6 +414,6 @@ UninstallProgram=解除安裝 %1
 LaunchProgram=啟動 %1
 AssocFileExtension=將 %1 與檔案副檔名 %2 產生關聯(&A)
 AssocingFileExtension=正在將 %1 與檔案副檔名 %2 產生關聯...
-AutoStartProgramGroupDescription=開啟:
+AutoStartProgramGroupDescription=開啟：
 AutoStartProgram=自動開啟 %1
 AddonHostProgramNotFound=%1 無法在您所選的資料夾中找到。%n%n您是否還要繼續？


### PR DESCRIPTION
## 摘要

校正 Inno Setup 繁體中文翻譯檔 `scripts/build_installer/ChineseTraditional.isl`。這份檔案是從 jrsoftware 官方 vendored 進專案、未經人工校過的版本，混雜了簡轉繁過度轉換的錯字、整句漏翻的簡體，以及中國大陸用語。本次將整份徹底正規化為台灣慣用語與全形標點。

檔案維持 **UTF-8 無 BOM、CRLF、檔尾無多餘換行**（Inno Setup 6 以 UTF-8 讀取 `.isl`，與 `LanguageCodepage=950` 無衝突）。

## 修正內容

### 明確錯字
- `下麵`→`下面`（5 處，簡轉繁誤轉成「麵條」）
- `發生沖突`→`發生衝突`
- `無法注冊`→`無法註冊`（2 處）
- `檔標籤／檔大小／檔雜湊值`→`檔案標籤／檔案大小／檔案雜湊值`、`檔案名不正確`→`檔案名稱不正確`

### 整句簡體漏翻
- `正在下载文件...`→`正在下載檔案...`
- `源文件验证失败`→`來源檔案驗證失敗`

### 大陸用語→台灣慣用語
- `變量`→`參數`、`已被傳遞到了`→`已傳遞至`
- `網絡磁碟機`→`網路磁碟機`
- `嚮導頁面`→`精靈頁面`
- `其它`→`其他`
- `解壓`→`解壓縮`（與既有 `StatusExtractFiles` 的「解壓縮」一致）
- `…時出錯`→`…時發生錯誤`（與前後錯誤訊息一致），並清除 `ErrorExtracting` 行尾多餘的 tab

### 標點一致化（依 CLAUDE.md：CJK 一律全形）
- 彎引號 `“%1”`→角括號 `「%1」`（13 處）
- CJK 訊息中的半形冒號 `:`→全形 `：`（並收斂冒號後多餘空格）
- 半形問號 `嗎?`→`嗎？`（2 處）、半形句點 `%2.`→`%2。`（1 處）
- 磁碟機代號 `C:\` 與註解中的 URL／Email 等英文脈絡刻意保留半形

## 範圍外（刻意未動）
`(&X)` 快捷鍵前後空格、`...` 半形省略號、`[LangOptions]` 字型與 LanguageID、`ChineseSimplified.isl`、上游註解既有的行尾空白。

## 驗證
- 殘留掃描全綠：無錯字／簡體殘留、無裸「解壓」、無彎引號；訊息 entry 行半形冒號僅剩 `C:\App`。
- Codepoint 逐字確認：`：`(U+FF1A)、`「」`(U+300C／U+300D)、`？`(U+FF1F)、`。`(U+3002)。
- 編碼完整性：UTF-8 無 BOM、CR/LF 各 418 對齊、檔尾無多餘換行。

> 註：本變更僅動 `.isl` 翻譯檔，不涉及任何 Dart 程式碼，`flutter analyze`／`flutter test`／`dart format` 對其為 N/A。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
