### PR TITLE
fix(dialogs): wrap long item-detail description and keep name-to-desc spacing consistent

### DIFF
--- a/lib/widgets/dialogs/app_dialog.dart
+++ b/lib/widgets/dialogs/app_dialog.dart
@@ -83,7 +83,9 @@ class AppDialog extends StatelessWidget {
 
     return AlertDialog(
       constraints: BoxConstraints(maxHeight: dialogMaxHeight),
-      title: title,
+      // title 與 content 同寬：title 內容（如長描述 Html）的 intrinsic 寬度
+      // 不再能把整個 AlertDialog 撐寬，過長文字會在 dialogWidth 內換行。
+      title: SizedBox(width: dialogWidth, child: title),
       content: body,
       actions: actions.isEmpty ? null : actions,
     );

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -403,26 +403,38 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (desc.trim().isNotEmpty)
+                if (desc.trim().isNotEmpty) ...[
+                  // 名稱與說明之間的固定間距，讓單行/多行說明都有一致的呼吸空間。
+                  // 用 2px 微距（小於最小 token AppSpacing.xs=4），名稱與說明貼得更近。
+                  const SizedBox(height: 2),
                   ConstrainedBox(
                     constraints: const BoxConstraints(maxHeight: 120),
                     child: SingleChildScrollView(
-                      child: Html(
-                        data: desc,
-                        style: {
-                          'body': Style(
-                            fontSize: FontSize(
-                              theme.textTheme.bodyMedium?.fontSize ?? 14,
+                      // 壓低環境 DefaultTextStyle 的行高：flutter_html 以繼承的環境
+                      // 行高當作區塊最小高度，dialog title 的環境行高偏高（約 31px），
+                      // 使「單行說明」被在偏高行框內垂直置中、首行比「多行說明」下移
+                      // 約 6px。壓成 1.0 後區塊最小高度＝文字行高，單行/多行首行對齊。
+                      child: DefaultTextStyle.merge(
+                        style: const TextStyle(height: 1.0),
+                        child: Html(
+                          data: desc,
+                          style: {
+                            'body': Style(
+                              fontSize: FontSize(
+                                theme.textTheme.bodyMedium?.fontSize ?? 14,
+                              ),
+                              lineHeight: LineHeight.number(1.4),
+                              color: tokens.textSecondary,
+                              margin: Margins.zero,
+                              padding: HtmlPaddings.zero,
                             ),
-                            color: tokens.textSecondary,
-                            margin: Margins.zero,
-                            padding: HtmlPaddings.zero,
-                          ),
-                          'p': Style(margin: Margins.zero),
-                        },
+                            'p': Style(margin: Margins.zero),
+                          },
+                        ),
                       ),
                     ),
                   ),
+                ],
                 if (tags.isNotEmpty) ...[
                   const SizedBox(height: 8),
                   Wrap(

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -423,7 +423,7 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
                               fontSize: FontSize(
                                 theme.textTheme.bodyMedium?.fontSize ?? 14,
                               ),
-                              lineHeight: LineHeight.number(1.4),
+                              lineHeight: LineHeight.number(1.2),
                               color: tokens.textSecondary,
                               margin: Margins.zero,
                               padding: HtmlPaddings.zero,

--- a/test/widgets/dialogs/app_dialog_test.dart
+++ b/test/widgets/dialogs/app_dialog_test.dart
@@ -104,6 +104,50 @@ void main() {
     expect(_innerWidth(tester), 320);
   });
 
+  testWidgets('wide title content is clamped to dialog width, not widening', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () => showDialog<void>(
+                  context: ctx,
+                  builder: (_) => const AppDialog(
+                    size: AppDialogSize.md,
+                    // 內在寬度遠大於 md(640)：未約束時會把整個 dialog 撐寬。
+                    title: SizedBox(
+                      key: Key('wide-title'),
+                      width: 1400,
+                      height: 24,
+                    ),
+                    content: Text('Body'),
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // title 應被約束到 md 的 640，而非渲染成內在的 1400。
+    expect(tester.getSize(find.byKey(const Key('wide-title'))).width, 640);
+  });
+
   testWidgets('maxHeight = min(720, mq.height - 120) — tall window', (
     tester,
   ) async {

--- a/test/widgets/dialogs/gacha_item_detail_dialog_test.dart
+++ b/test/widgets/dialogs/gacha_item_detail_dialog_test.dart
@@ -934,4 +934,116 @@ void main() {
       );
     });
   });
+
+  group('title 區 desc 間距', () {
+    /// 開 dialog 並回傳「名稱底 → 說明文字首行頂」的垂直間距。
+    /// [contains] 用來在 title 區 Html 內定位實際 desc 文字那條 RichText。
+    Future<double> openAndMeasureGap(
+      WidgetTester tester,
+      String name,
+      String contains,
+    ) async {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            // 唯一 key：避免兩次量測重用同一 Navigator、上一個 dialog 殘留擋住按鈕。
+            key: ValueKey(name),
+            theme: buildDarkTheme(),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (ctx) => ElevatedButton(
+                onPressed: () => showGachaItemDetailDialog(
+                  ctx,
+                  _rec(name: name, gachaType: '301'),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final nameBottom = tester.getRect(find.text(name)).bottom;
+      final descLine = find.descendant(
+        of: find.byType(Html),
+        matching: find.byWidgetPredicate(
+          (w) => w is RichText && w.text.toPlainText().contains(contains),
+        ),
+      );
+      return tester.getRect(descLine.first).top - nameBottom;
+    }
+
+    testWidgets('單行說明與多行（換行）說明的首行間距一致', (tester) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final notifier = container.read(hoyowikiIndexProvider.notifier);
+      await tester.runAsync(() async {
+        await _touchFile(tempDir, 'short1_icon.png');
+        await _touchFile(tempDir, 'long1_icon.png');
+        await notifier.setSearch(
+          name: 'ShortName',
+          lang: 'en-us',
+          id: 'short1',
+          menuId: 2,
+        );
+        await notifier.mergeEntry(
+          id: 'short1',
+          lang: 'en-us',
+          fetched: const HoYoWikiEntryFetched(
+            iconUrl: 'https://cdn.hoyolab.com/short_icon.png',
+            page: HoYoWikiPageData(
+              gallery: null,
+              desc: '<p>Short.</p>',
+              tags: [],
+            ),
+          ),
+        );
+        await notifier.setSearch(
+          name: 'LongName',
+          lang: 'en-us',
+          id: 'long1',
+          menuId: 2,
+        );
+        await notifier.mergeEntry(
+          id: 'long1',
+          lang: 'en-us',
+          fetched: const HoYoWikiEntryFetched(
+            iconUrl: 'https://cdn.hoyolab.com/long_icon.png',
+            page: HoYoWikiPageData(
+              gallery: null,
+              desc:
+                  '<p>This is a very long description that should definitely '
+                  'wrap across multiple lines inside the constrained dialog '
+                  'width so the leading above the first line can be '
+                  'compared with the single-line case.</p>',
+              tags: [],
+            ),
+          ),
+        );
+      });
+
+      final shortGap = await openAndMeasureGap(tester, 'ShortName', 'Short.');
+      final longGap = await openAndMeasureGap(
+        tester,
+        'LongName',
+        'This is a very long',
+      );
+
+      expect(
+        (shortGap - longGap).abs(),
+        lessThan(1.0),
+        reason: 'single-line gap=$shortGap multi-line gap=$longGap',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 背景

物品詳情 dialog（`GachaItemDetailDialog`）的 HoYoWiki 說明文字過長時會把整個 dialog 拉寬；且說明文字「換行 vs 沒換行」時，名稱與說明之間的間距不一致。

## 改了什麼

**1. 長說明不再撐寬 dialog**（`AppDialog`）

`AppDialog` 原本只把 `content` 包進 `SizedBox(width: dialogWidth)`，`title` 沒約束。title 內 `Html` 的 intrinsic 寬度會把整個 `AlertDialog` 撐過尺寸上限，而非換行。把 `title` 也包進同樣的 `SizedBox(width: dialogWidth)`，過長文字即在 dialog 寬度內換行。屬根因修法，其他 dialog 之後有寬 title 也免疫。

**2. 名稱 ↔ 說明間距一致**（`GachaItemDetailDialog`）

根因：`flutter_html` 把單行文字在偏高的行框（最小高度繼承自 dialog title 的環境行高 ~31px）內垂直置中，使單行說明首行比多行掉了約 6px。

- Html 外包 `DefaultTextStyle.merge(height: 1.0)` → 行框＝文字行高，消除單行置中位移。
- body `lineHeight: LineHeight.number(1.2)` → 維持多行可讀行距，同時讓換行文字行距緊湊（須 > 1.0，否則單行會重新被置中）。
- 名稱與說明間放固定 2px 微距 → 間距刻意且一致。

## 驗證

- 新增測試：`app_dialog_test.dart`（寬 title 不撐寬、clamp 到 640）、`gacha_item_detail_dialog_test.dart`（單行／多行說明首行間距差 < 1px；修前差 6.0px）。
- `dart format lib/ test/`：0 changed。
- `flutter analyze`：No issues found!
- `flutter test`：All 850 tests passed!（含新增 2 條，共用元件 AppDialog 無回歸）

## 備註

- 名稱與說明間的 2px 是刻意的微距（小於最小 token `AppSpacing.xs` = 4）。
- 換行說明行距用 `lineHeight: 1.2`。以上兩者皆可再調；一致性由測試把關。

🤖 Generated with [Claude Code](https://claude.com/claude-code)