### PR TITLE
fix(share): show actual total count in timeline title

### DIFF
--- a/lib/widgets/share/share_card.dart
+++ b/lib/widgets/share/share_card.dart
@@ -419,10 +419,12 @@ class _SectionView extends StatelessWidget {
   };
 
   /// 右欄時間軸：重用 App TimelineVertical（自帶 container）。標題透過 title
-  /// 進到卡片 border 內。最多取 [_kShareTimelineMaxEntries] 筆（避免出現
-  /// 「載入更多」按鈕），以**自然高度**繪製；超出右欄區域（= 左欄兩 _PieBox
-  /// 疊高）的部分由外層 Stack(Clip.hardEdge) 直接裁掉，不報 overflow、不反拉
-  /// 左欄。不再傳 footerNote / fillHeight（已移除「還有 N 筆」與撐齊邏輯）。
+  /// 進到卡片 border 內，括號數量取 `section.timeline.length`（該星級實際出貨
+  /// 總數，與 App overview／banner 一致），不受下方視覺截斷影響。條目最多取
+  /// [_kShareTimelineMaxEntries] 筆（避免出現「載入更多」），以**自然高度**繪製；
+  /// 超出右欄區域（= 左欄兩 _PieBox 疊高）的部分由外層 Stack(Clip.hardEdge) 直接
+  /// 裁掉，不報 overflow、不反拉左欄。不再傳 footerNote / fillHeight（已移除「還有
+  /// N 筆」與撐齊邏輯）。
   Widget _timeline() {
     final rank = section.timelineRank;
     final n = section.timeline.length < _kShareTimelineMaxEntries
@@ -430,7 +432,10 @@ class _SectionView extends StatelessWidget {
         : _kShareTimelineMaxEntries;
     final shown = section.timeline.take(n).toList(growable: false);
     return TimelineVertical(
-      title: l.timelineTopRarityTitle(l.rarityStar(rank), shown.length),
+      title: l.timelineTopRarityTitle(
+        l.rarityStar(rank),
+        section.timeline.length,
+      ),
       entries: shown,
       colors: colors,
       targetRank: rank,

--- a/test/widgets/share/share_card_test.dart
+++ b/test/widgets/share/share_card_test.dart
@@ -274,11 +274,12 @@ void main() {
     final leftHeight = _leftColumnHeight(t, l);
     expect(rightHeight, closeTo(leftHeight, 0.5));
 
-    // 標題仍在 TimelineVertical 子樹內（title 保留，至多 10 筆）。
+    // 標題仍在 TimelineVertical 子樹內；括號數量顯示實際出貨總數（12），
+    // 不受條目至多 10 筆的視覺截斷影響。
     expect(
       find.descendant(
         of: find.byType(TimelineVertical),
-        matching: find.text(l.timelineTopRarityTitle(l.rarityStar(5), 10)),
+        matching: find.text(l.timelineTopRarityTitle(l.rarityStar(5), 12)),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## 摘要

分享圖右欄時間軸標題括號裡的數量，原本顯示的是「視覺截斷後的顯示筆數」（受 `_kShareTimelineMaxEntries = 10` 上限影響，最多只會顯示 `(10)`），而非該星級實際出貨總數。

本 PR 將標題的數量參數從 `shown.length` 改為 `section.timeline.length`，使括號數量反映完整總數，與 App 內 overview／banner 頁的行為一致。時間軸條目本體仍維持最多繪製 10 筆，避免破版與「載入更多」按鈕出現。

## 改動

- `lib/widgets/share/share_card.dart`：`_timeline()` 標題參數 `shown.length` → `section.timeline.length`，並更新 dartdoc 說明括號數量取完整總數、不受下方條目截斷影響。
- `test/widgets/share/share_card_test.dart`：12 筆 5★ 的測試斷言由預期標題 `(10)` 改為 `(12)`，並更新對應註解。

## 效果

例如實際有 35 個 5★ 時，分享圖標題顯示「5★ 時間軸 (35)」（原本只會顯示 `(10)`）；時間軸仍最多畫 10 筆。

## 品質檢查

- `fvm dart format lib/ test/` — 0 changed
- `fvm flutter analyze` — No issues found!
- `fvm flutter test` — All tests passed!（854 個）

🤖 Generated with [Claude Code](https://claude.com/claude-code)