### PR TITLE
fix(uid-mask): use bullet (•) instead of x for masked UID digits

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "Account management",
   "settingsPrivacySectionTitle": "Privacy",
   "settingsMaskUidInUi": "Mask UID in interface",
-  "settingsMaskUidInUiHint": "When on, UIDs in the interface and account list show the first 3 digits with the rest masked (e.g. 123xxxxx). Useful for streaming or screen sharing. Share images, exported files, and the delete confirmation dialog are not affected.",
+  "settingsMaskUidInUiHint": "When on, UIDs in the interface and account list show the first 3 digits with the rest masked (e.g. 123•••••). Useful for streaming or screen sharing. Share images, exported files, and the delete confirmation dialog are not affected.",
   "settingsAbout": "About",
   "settingsAboutVersion": "Version {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "Dark",
   "shareImageThemeLight": "Light",
   "shareImageShowFullUid": "Show full UID on image",
-  "shareImageShowFullUidHint": "When off, only the first 3 digits are shown, the rest masked with x",
+  "shareImageShowFullUidHint": "When off, only the first 3 digits are shown, the rest masked with •",
   "shareImageGenerate": "Generate",
   "shareImageUpdatedAt": "Updated {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "Gestión de cuentas",
   "settingsPrivacySectionTitle": "Privacidad",
   "settingsMaskUidInUi": "Ocultar UID en la interfaz",
-  "settingsMaskUidInUiHint": "Cuando está activado, los UID en la interfaz y la lista de cuentas muestran los primeros 3 dígitos y el resto enmascarado (por ejemplo, 123xxxxx). Útil para transmisiones en vivo o al compartir pantalla. Las imágenes para compartir, los archivos exportados y el diálogo de confirmación de eliminación no se ven afectados.",
+  "settingsMaskUidInUiHint": "Cuando está activado, los UID en la interfaz y la lista de cuentas muestran los primeros 3 dígitos y el resto enmascarado (por ejemplo, 123•••••). Útil para transmisiones en vivo o al compartir pantalla. Las imágenes para compartir, los archivos exportados y el diálogo de confirmación de eliminación no se ven afectados.",
   "settingsAbout": "Sobre",
   "settingsAboutVersion": "Versión {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "Oscuro",
   "shareImageThemeLight": "Claro",
   "shareImageShowFullUid": "Mostrar UID completo en la imagen",
-  "shareImageShowFullUidHint": "Al desactivar, solo se muestran los primeros 3 dígitos; el resto se oculta con x",
+  "shareImageShowFullUidHint": "Al desactivar, solo se muestran los primeros 3 dígitos; el resto se oculta con •",
   "shareImageGenerate": "Generar",
   "shareImageUpdatedAt": "Datos actualizados {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "Gestion des comptes",
   "settingsPrivacySectionTitle": "Confidentialité",
   "settingsMaskUidInUi": "Masquer l'UID dans l'interface",
-  "settingsMaskUidInUiHint": "Lorsqu'activé, les UID dans l'interface et la liste des comptes affichent les 3 premiers chiffres et le reste est masqué (par exemple 123xxxxx). Utile pour le streaming ou le partage d'écran. Les images de partage, les fichiers exportés et la boîte de dialogue de confirmation de suppression ne sont pas affectés.",
+  "settingsMaskUidInUiHint": "Lorsqu'activé, les UID dans l'interface et la liste des comptes affichent les 3 premiers chiffres et le reste est masqué (par exemple 123•••••). Utile pour le streaming ou le partage d'écran. Les images de partage, les fichiers exportés et la boîte de dialogue de confirmation de suppression ne sont pas affectés.",
   "settingsAbout": "Sur",
   "settingsAboutVersion": "Version {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "Sombre",
   "shareImageThemeLight": "Clair",
   "shareImageShowFullUid": "Afficher l'UID complet sur l'image",
-  "shareImageShowFullUidHint": "Désactivé : seuls les 3 premiers chiffres sont affichés, le reste est masqué par des x",
+  "shareImageShowFullUidHint": "Désactivé : seuls les 3 premiers chiffres sont affichés, le reste est masqué par des •",
   "shareImageGenerate": "Générer",
   "shareImageUpdatedAt": "Données mises à jour le {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "アカウント管理",
   "settingsPrivacySectionTitle": "プライバシー",
   "settingsMaskUidInUi": "画面上の UID をマスク",
-  "settingsMaskUidInUiHint": "オンにすると、画面とアカウント一覧の UID が先頭 3 桁と残りを x でマスクして表示されます（例：123xxxxx）。配信や画面共有時に便利です。共有画像、エクスポートファイル、削除確認ダイアログは影響を受けません。",
+  "settingsMaskUidInUiHint": "オンにすると、画面とアカウント一覧の UID が先頭 3 桁と残りを • でマスクして表示されます（例：123•••••）。配信や画面共有時に便利です。共有画像、エクスポートファイル、削除確認ダイアログは影響を受けません。",
   "settingsAbout": "このツールについて",
   "settingsAboutVersion": "バージョン {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "ダーク",
   "shareImageThemeLight": "ライト",
   "shareImageShowFullUid": "画像に UID をすべて表示",
-  "shareImageShowFullUidHint": "オフにすると先頭 3 桁のみ表示し、残りは x でマスクします",
+  "shareImageShowFullUidHint": "オフにすると先頭 3 桁のみ表示し、残りは • でマスクします",
   "shareImageGenerate": "生成",
   "shareImageUpdatedAt": "データ更新 {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "Gerenciamento de contas",
   "settingsPrivacySectionTitle": "Privacidade",
   "settingsMaskUidInUi": "Mascarar UID na interface",
-  "settingsMaskUidInUiHint": "Quando ativado, os UIDs na interface e na lista de contas mostram os 3 primeiros dígitos com o restante mascarado (por exemplo, 123xxxxx). Útil para transmissões ou compartilhamento de tela. Imagens compartilháveis, arquivos exportados e a caixa de diálogo de confirmação de exclusão não são afetados.",
+  "settingsMaskUidInUiHint": "Quando ativado, os UIDs na interface e na lista de contas mostram os 3 primeiros dígitos com o restante mascarado (por exemplo, 123•••••). Útil para transmissões ou compartilhamento de tela. Imagens compartilháveis, arquivos exportados e a caixa de diálogo de confirmação de exclusão não são afetados.",
   "settingsAbout": "Cerca de",
   "settingsAboutVersion": "Versão {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "Escuro",
   "shareImageThemeLight": "Claro",
   "shareImageShowFullUid": "Mostrar UID completo na imagem",
-  "shareImageShowFullUidHint": "Quando desativado, exibe apenas os 3 primeiros dígitos; o restante é ocultado com x",
+  "shareImageShowFullUidHint": "Quando desativado, exibe apenas os 3 primeiros dígitos; o restante é ocultado com •",
   "shareImageGenerate": "Gerar",
   "shareImageUpdatedAt": "Dados atualizados em {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "จัดการบัญชี",
   "settingsPrivacySectionTitle": "ความเป็นส่วนตัว",
   "settingsMaskUidInUi": "ปิดบัง UID ในอินเทอร์เฟซ",
-  "settingsMaskUidInUiHint": "เมื่อเปิดใช้งาน UID ในอินเทอร์เฟซและรายการบัญชีจะแสดง 3 หลักแรกและส่วนที่เหลือจะถูกปิดบัง (เช่น 123xxxxx) เหมาะสำหรับการสตรีมหรือการแชร์หน้าจอ ภาพแชร์ ไฟล์ส่งออก และกล่องโต้ตอบยืนยันการลบจะไม่ได้รับผลกระทบ",
+  "settingsMaskUidInUiHint": "เมื่อเปิดใช้งาน UID ในอินเทอร์เฟซและรายการบัญชีจะแสดง 3 หลักแรกและส่วนที่เหลือจะถูกปิดบัง (เช่น 123•••••) เหมาะสำหรับการสตรีมหรือการแชร์หน้าจอ ภาพแชร์ ไฟล์ส่งออก และกล่องโต้ตอบยืนยันการลบจะไม่ได้รับผลกระทบ",
   "settingsAbout": "เกี่ยวกับ",
   "settingsAboutVersion": "เวอร์ชัน {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "มืด",
   "shareImageThemeLight": "สว่าง",
   "shareImageShowFullUid": "แสดง UID เต็มในภาพ",
-  "shareImageShowFullUidHint": "เมื่อปิด จะแสดงเพียง 3 ตัวแรก ส่วนที่เหลือจะถูกปิดบังด้วย x",
+  "shareImageShowFullUidHint": "เมื่อปิด จะแสดงเพียง 3 ตัวแรก ส่วนที่เหลือจะถูกปิดบังด้วย •",
   "shareImageGenerate": "สร้าง",
   "shareImageUpdatedAt": "ข้อมูลอัพเดทเมื่อ {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -299,7 +299,7 @@
   "settingsAccountManagement": "Quản Lý Tài Khoản",
   "settingsPrivacySectionTitle": "Quyền riêng tư",
   "settingsMaskUidInUi": "Che giấu UID trong giao diện",
-  "settingsMaskUidInUiHint": "Khi bật, UID trong giao diện và danh sách tài khoản sẽ hiển thị 3 chữ số đầu tiên và phần còn lại được che giấu (ví dụ: 123xxxxx). Hữu ích khi phát trực tiếp hoặc chia sẻ màn hình. Hình ảnh chia sẻ, tệp xuất và hộp thoại xác nhận xóa không bị ảnh hưởng.",
+  "settingsMaskUidInUiHint": "Khi bật, UID trong giao diện và danh sách tài khoản sẽ hiển thị 3 chữ số đầu tiên và phần còn lại được che giấu (ví dụ: 123•••••). Hữu ích khi phát trực tiếp hoặc chia sẻ màn hình. Hình ảnh chia sẻ, tệp xuất và hộp thoại xác nhận xóa không bị ảnh hưởng.",
   "settingsAbout": "Giới Thiệu",
   "settingsAboutVersion": "Phiên bản {version}",
   "@settingsAboutVersion": {
@@ -535,7 +535,7 @@
   "shareImageThemeDark": "Tối",
   "shareImageThemeLight": "Sáng",
   "shareImageShowFullUid": "Hiển thị UID đầy đủ trên ảnh",
-  "shareImageShowFullUidHint": "Khi tắt, chỉ hiển thị 3 ký tự đầu, phần còn lại sẽ bị che bằng x",
+  "shareImageShowFullUidHint": "Khi tắt, chỉ hiển thị 3 ký tự đầu, phần còn lại sẽ bị che bằng •",
   "shareImageGenerate": "Tạo",
   "shareImageUpdatedAt": "Dữ liệu cập nhật {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -225,7 +225,7 @@
   "settingsAccountManagement": "帳號管理",
   "settingsPrivacySectionTitle": "隱私",
   "settingsMaskUidInUi": "遮蔽介面中的 UID",
-  "settingsMaskUidInUiHint": "開啟後，畫面與帳號清單中的 UID 會以前 3 碼搭配 x 顯示（例如 123xxxxx），適合實況或螢幕分享時使用。分享圖、匯出檔案、刪除確認框不受影響。",
+  "settingsMaskUidInUiHint": "開啟後，畫面與帳號清單中的 UID 會以前 3 碼搭配 • 顯示（例如 123•••••），適合實況或螢幕分享時使用。分享圖、匯出檔案、刪除確認框不受影響。",
   "settingsAbout": "關於",
   "settingsAboutVersion": "版本 {version}",
   "@settingsAboutVersion": {
@@ -409,7 +409,7 @@
   "shareImageThemeDark": "深色",
   "shareImageThemeLight": "淺色",
   "shareImageShowFullUid": "在圖上顯示完整 UID",
-  "shareImageShowFullUidHint": "關閉時只顯示前 3 碼，其餘以 x 遮罩",
+  "shareImageShowFullUidHint": "關閉時只顯示前 3 碼，其餘以 • 遮罩",
   "shareImageGenerate": "生成",
   "shareImageUpdatedAt": "資料更新 {time}",
   "@shareImageUpdatedAt": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -295,7 +295,7 @@
   "settingsAccountManagement": "账号管理",
   "settingsPrivacySectionTitle": "隐私",
   "settingsMaskUidInUi": "遮蔽界面中的 UID",
-  "settingsMaskUidInUiHint": "开启后，画面与账号清单中的 UID 会以前 3 码搭配 x 显示（例如 123xxxxx），适合直播或屏幕分享时使用。分享图、导出文件、删除确认框不受影响。",
+  "settingsMaskUidInUiHint": "开启后，画面与账号清单中的 UID 会以前 3 码搭配 • 显示（例如 123•••••），适合直播或屏幕分享时使用。分享图、导出文件、删除确认框不受影响。",
   "settingsAbout": "关于",
   "settingsAboutVersion": "版本 {version}",
   "@settingsAboutVersion": {
@@ -531,7 +531,7 @@
   "shareImageThemeDark": "深色",
   "shareImageThemeLight": "浅色",
   "shareImageShowFullUid": "在图上显示完整 UID",
-  "shareImageShowFullUidHint": "关闭时只显示前 3 位，其余以 x 遮盖",
+  "shareImageShowFullUidHint": "关闭时只显示前 3 位，其余以 • 遮盖",
   "shareImageGenerate": "生成",
   "shareImageUpdatedAt": "数据更新 {time}",
   "@shareImageUpdatedAt": {

--- a/lib/services/settings_storage.dart
+++ b/lib/services/settings_storage.dart
@@ -101,7 +101,7 @@ class AppSettings {
   /// 使用者選擇跳過的 release tag（已讀過不再提示）。
   final String? skippedReleaseTag;
 
-  /// 是否在介面中遮蔽 UID（前 3 碼搭配 `x`）；資料檔與刪除確認框不受影響。
+  /// 是否在介面中遮蔽 UID（前 3 碼搭配 `•`）；資料檔與刪除確認框不受影響。
   final bool maskUidInUi;
 
   /// 預設設定值（跟隨系統主題與語言）。

--- a/lib/services/share_uid_mask.dart
+++ b/lib/services/share_uid_mask.dart
@@ -1,9 +1,12 @@
-/// 分享圖專用 UID 遮罩：顯示前 3 碼，其餘逐字以 `x` 取代（長度保留）。
+/// 分享圖專用 UID 遮罩：顯示前 3 碼，其餘逐字以 `•` 取代（長度保留）。
+///
+/// 用 `•`（U+2022）而非 `*`：星號在多數字體裡靠上緣繪製，與數字並排時會偏高；
+/// 圓點垂直置中，與前 3 碼對齊較自然。
 ///
 /// 刻意不重用 [sanitizeUid]（前 3 + 後 3）：公開分享情境不應洩漏末碼，
-/// 故政策比 log 脫敏更嚴。長度 < 3 全遮 `xxx`。
+/// 故政策比 log 脫敏更嚴。長度 < 3 全遮 `•••`。
 String maskUidForShare(String uid) {
-  if (uid.length < 3) return 'xxx';
+  if (uid.length < 3) return '•••';
   if (uid.length == 3) return uid;
-  return '${uid.substring(0, 3)}${'x' * (uid.length - 3)}';
+  return '${uid.substring(0, 3)}${'•' * (uid.length - 3)}';
 }

--- a/lib/utils/uid_display.dart
+++ b/lib/utils/uid_display.dart
@@ -3,7 +3,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/share_uid_mask.dart'
 /// UID 介面顯示工具：依介面隱私設定回傳遮蔽後或原樣 UID。
 ///
 /// [mask] 來自 `AppSettings.maskUidInUi`。`true` 時呼叫 [maskUidForShare]
-/// （前 3 碼搭配 `x` 遮蔽其餘），與分享圖政策一致；`false` 時原樣回傳。
+/// （前 3 碼搭配 `•` 遮蔽其餘），與分享圖政策一致；`false` 時原樣回傳。
 ///
 /// 與 log 用的 `sanitizeUid` 刻意分開：log 場景需要末碼幫助稽核交叉比對，
 /// UI 場景則是公開曝光情境，不應洩漏末碼。

--- a/lib/widgets/cards/account_management.dart
+++ b/lib/widgets/cards/account_management.dart
@@ -142,7 +142,7 @@ class _Row extends StatefulWidget {
   /// 使用者自訂別名；空字串表示未設定。
   final String alias;
 
-  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  /// 是否套用介面隱私模式（前 3 碼搭配 `•` 遮蔽）。
   final bool maskUid;
 
   /// 點擊「切換」後呼叫。

--- a/lib/widgets/uid_indicator.dart
+++ b/lib/widgets/uid_indicator.dart
@@ -136,7 +136,7 @@ class AccountTriggerLabel extends StatelessWidget {
   /// 使用者自訂的帳號別名。
   final String? alias;
 
-  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  /// 是否套用介面隱私模式（前 3 碼搭配 `•` 遮蔽）。
   final bool maskUid;
 
   @override
@@ -234,7 +234,7 @@ class AccountMenuLabel extends StatelessWidget {
   /// 是否為當前使用中的帳號。
   final bool isActive;
 
-  /// 是否套用介面隱私模式（前 3 碼搭配 `x` 遮蔽）。
+  /// 是否套用介面隱私模式（前 3 碼搭配 `•` 遮蔽）。
   final bool maskUid;
 
   @override

--- a/test/services/share_uid_mask_test.dart
+++ b/test/services/share_uid_mask_test.dart
@@ -3,23 +3,23 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/share_uid_mask.dart'
 
 void main() {
   group('maskUidForShare', () {
-    test('顯示前 3 碼，其餘以 x 遮罩、長度保留', () {
-      expect(maskUidForShare('123456789'), '123xxxxxx');
+    test('顯示前 3 碼，其餘以 • 遮罩、長度保留', () {
+      expect(maskUidForShare('123456789'), '123••••••');
     });
 
     test('長度恰為 3 全可見', () {
       expect(maskUidForShare('123'), '123');
     });
 
-    test('長度小於 3 全遮罩為固定 xxx', () {
-      expect(maskUidForShare('12'), 'xxx');
-      expect(maskUidForShare(''), 'xxx');
+    test('長度小於 3 全遮罩為固定 •••', () {
+      expect(maskUidForShare('12'), '•••');
+      expect(maskUidForShare(''), '•••');
     });
 
     test('比 sanitizeUid 嚴格：不洩漏末碼', () {
       final masked = maskUidForShare('800123456');
       expect(masked.endsWith('456'), isFalse);
-      expect(masked, '800xxxxxx');
+      expect(masked, '800••••••');
     });
   });
 }

--- a/test/utils/uid_display_test.dart
+++ b/test/utils/uid_display_test.dart
@@ -9,7 +9,7 @@ void main() {
     });
 
     test('returns masked uid when mask=true', () {
-      expect(displayUid('123456789', mask: true), '123xxxxxx');
+      expect(displayUid('123456789', mask: true), '123••••••');
     });
 
     test('mask=true delegates to maskUidForShare', () {
@@ -18,12 +18,12 @@ void main() {
     });
 
     test('handles empty string', () {
-      expect(displayUid('', mask: true), 'xxx');
+      expect(displayUid('', mask: true), '•••');
       expect(displayUid('', mask: false), '');
     });
 
     test('handles short uid (< 3 chars)', () {
-      expect(displayUid('12', mask: true), 'xxx');
+      expect(displayUid('12', mask: true), '•••');
       expect(displayUid('12', mask: false), '12');
     });
 

--- a/test/widgets/cards/account_management_test.dart
+++ b/test/widgets/cards/account_management_test.dart
@@ -299,12 +299,12 @@ void main() {
     testWidgets('maskUidInUi=false 顯示完整 UID', (tester) async {
       await pumpWithUid(tester, uid: '123456789', maskUidInUi: false);
       expect(find.text('123456789'), findsOneWidget);
-      expect(find.text('123xxxxxx'), findsNothing);
+      expect(find.text('123••••••'), findsNothing);
     });
 
     testWidgets('maskUidInUi=true 顯示遮蔽 UID', (tester) async {
       await pumpWithUid(tester, uid: '123456789', maskUidInUi: true);
-      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123••••••'), findsOneWidget);
       expect(find.text('123456789'), findsNothing);
     });
 

--- a/test/widgets/share/share_card_test.dart
+++ b/test/widgets/share/share_card_test.dart
@@ -131,7 +131,7 @@ void main() {
     );
     await _pump(t, card, container);
     expect(t.takeException(), isNull);
-    expect(find.textContaining('800xxxxxx'), findsOneWidget);
+    expect(find.textContaining('800••••••'), findsOneWidget);
     expect(find.textContaining('800123456'), findsNothing);
   });
 

--- a/test/widgets/uid_indicator_test.dart
+++ b/test/widgets/uid_indicator_test.dart
@@ -183,7 +183,7 @@ void main() {
       await tester.pumpWidget(
         _wrap(const AccountTriggerLabel(activeUid: '123456789', maskUid: true)),
       );
-      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123••••••'), findsOneWidget);
       expect(find.text('123456789'), findsNothing);
     });
 
@@ -198,7 +198,7 @@ void main() {
         ),
       );
       expect(find.text('主帳'), findsOneWidget);
-      expect(find.text(' (123xxxxxx)'), findsOneWidget);
+      expect(find.text(' (123••••••)'), findsOneWidget);
       expect(find.text(' (123456789)'), findsNothing);
     });
 
@@ -227,7 +227,7 @@ void main() {
           ),
         ),
       );
-      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123••••••'), findsOneWidget);
     });
 
     testWidgets('with alias: alias primary, masked uid as subtitle', (
@@ -244,7 +244,7 @@ void main() {
         ),
       );
       expect(find.text('主帳'), findsOneWidget);
-      expect(find.text('123xxxxxx'), findsOneWidget);
+      expect(find.text('123••••••'), findsOneWidget);
       expect(find.text('123456789'), findsNothing);
     });
   });


### PR DESCRIPTION
## 背景

UID 遮蔽原本逐字以 `x` 取代（例如 `123xxxxxx`）。`x`／`*` 這類字元在多數字體裡會被畫在 em box 的上緣，與前 3 碼數字並排時看起來「置頂」而非置中，視覺上不協調。

## 變更

將遮蔽字元改為 **`•`（U+2022 BULLET）**——圓點垂直置中，能與前 3 碼數字自然對齊，例如 `123••••••`。

由於分享圖與介面隱私遮蔽共用 `maskUidForShare()`，兩處會一併套用。log 脫敏的 `***`（屬 log 檔、非畫面顯示）不在此範圍，維持不動。

### 影響檔案
- **核心邏輯**：`lib/services/share_uid_mask.dart`（含選用 `•` 而非 `*` 的 dartdoc 說明）。
- **dartdoc**：`uid_display.dart`、`account_management.dart`、`uid_indicator.dart`、`settings_storage.dart`。
- **i18n**：全 9 個已翻譯語系的 `settingsMaskUidInUiHint`（範例 `123•••••`）與 `shareImageShowFullUidHint`。
- **測試**：對應 5 個測試檔的期望值。

## 驗證
- `fvm flutter analyze` → `No issues found!`
- `fvm flutter test` → `All tests passed!`（854 個）
- 已確認寫入的皆為正牌 U+2022，無 `∙`／`·`／`●` 等相似字混入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)