### PR TITLE
feat(item-detail): image overflow menu (copy / save / re-fetch) with right-click support

### DIFF
--- a/docs/superpowers/plans/2026-06-08-item-detail-image-menu.md
+++ b/docs/superpowers/plans/2026-06-08-item-detail-image-menu.md
@@ -1,0 +1,1095 @@
+# Item Detail Image Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `GachaItemDetailDialog` 中央圖片右上角加一個溢出選單（複製圖片 / 儲存圖片 / 重抓圖片），並支援在圖片上按右鍵叫出同一份選單。
+
+**Architecture:** 把剪貼簿寫入、存檔選擇器、檔案寫入這三個原始操作抽到新共用模組 `image_clipboard_save.dart`（含可測 seam 與 `encodeImageFileToPng` / `copyImagePngToClipboard` / `saveImagePng`），既有 `share_image_export.dart` 改為複用同一份 seam。dialog 的 `_GalleryReady` 圖片區改為 `Stack`，疊上右上角 `PopupMenuButton`，並在底層 `GestureDetector` 加 `onSecondaryTapDown` 用 `showMenu` 叫出同一份選單；重抓依 chip 類別走既有 `_fetchAndCache`（gallery）或新增的 `_refetchIcon`（icon，含 `bumpCacheRevision`）。
+
+**Tech Stack:** Flutter / Dart / Riverpod / `super_clipboard` / `file_selector` / `dart:ui` 圖片編碼 / `package:logging` / Crowdin-pipelined ARB i18n（template = `app_zh.arb`）。
+
+> **Spec 對應**：`docs/superpowers/specs/2026-06-08-item-detail-image-menu-design.md`。
+>
+> **測試層次決策**：複製／儲存的剪貼簿與存檔 seam 在 **service 層**（`image_clipboard_save_test.dart`）完整覆蓋；dialog 層只驗證選單存在、右鍵叫出選單、重抓走 fetcher。原因：dialog 內圖片是測試用的假 PNG（4 bytes），`encodeImageFileToPng` 會解碼失敗回 null，無法在 widget 測試可靠驗證剪貼簿/存檔被呼叫；真實解碼放在 service 測試用一張合法 1×1 PNG 驗證。
+
+---
+
+## File Structure
+
+| 動作 | 檔案 | 責任 |
+|---|---|---|
+| 新增 | `lib/services/image_clipboard_save.dart` | 共用剪貼簿/存檔/檔案寫入 seam + `encodeImageFileToPng` / `copyImagePngToClipboard` / `saveImagePng` |
+| 修改 | `lib/services/share_image_export.dart` | 移除自身重複 primitive，`exportShareImage` 改用共用 seam；`resetShareImageExportSeams` 轉呼共用 reset |
+| 修改 | `lib/widgets/dialogs/gacha_item_detail_dialog.dart` | `_GalleryReady` 改 Stack + 右上角選單鈕 + 右鍵；新增選單/複製/儲存/重抓方法；失敗重試共用 `_refetchEntry` |
+| 修改 | `lib/l10n/app_zh.arb`（template）、`lib/l10n/app_en.arb` | 新 i18n keys |
+| 新增 | `test/services/image_clipboard_save_test.dart` | encode / copy / save 三組測試 |
+| 修改 | `test/services/share_image_export_test.dart` | seam 名稱改用共用層 |
+| 修改 | `test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart` | 新增「圖片選單 + 重抓」group（重用既有 `_FakeFetcher` 基礎設施） |
+
+---
+
+### Task 1: 共用低階層 `image_clipboard_save.dart`
+
+**Files:**
+- Create: `lib/services/image_clipboard_save.dart`
+- Test: `test/services/image_clipboard_save_test.dart`
+
+- [ ] **Step 1: 寫失敗的測試**
+
+Create `test/services/image_clipboard_save_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
+
+/// 合法的 1×1 透明 PNG，用來驗證 encodeImageFileToPng 真實解碼。
+final _png1x1 = Uint8List.fromList(const [
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, //
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, //
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, //
+  0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, //
+  0x0D, 0x0A, 0x2D, 0xB4, //
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+void main() {
+  final png = Uint8List.fromList([1, 2, 3, 4]);
+
+  tearDown(resetImageClipboardSaveSeams);
+
+  group('encodeImageFileToPng', () {
+    testWidgets('合法 PNG 檔 → 非 null PNG bytes', (tester) async {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/a.png')..writeAsBytesSync(_png1x1);
+        final out = await encodeImageFileToPng(f);
+        expect(out, isNotNull);
+        expect(out!.isNotEmpty, isTrue);
+      });
+    });
+
+    testWidgets('不存在的檔 → null', (tester) async {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final missing = File('${dir.path}/missing.png');
+        expect(await encodeImageFileToPng(missing), isNull);
+      });
+    });
+
+    testWidgets('壞檔（非圖片）→ null', (tester) async {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final garbage = File('${dir.path}/g.png')..writeAsBytesSync([1, 2, 3, 4]);
+        expect(await encodeImageFileToPng(garbage), isNull);
+      });
+    });
+  });
+
+  group('copyImagePngToClipboard', () {
+    test('seam 回 true → true', () async {
+      imageClipboardWriter = (b) async => true;
+      expect(await copyImagePngToClipboard(png), isTrue);
+    });
+
+    test('seam 回 false → false', () async {
+      imageClipboardWriter = (b) async => false;
+      expect(await copyImagePngToClipboard(png), isFalse);
+    });
+
+    test('seam 拋例外 → false', () async {
+      imageClipboardWriter = (b) async => throw Exception('boom');
+      expect(await copyImagePngToClipboard(png), isFalse);
+    });
+  });
+
+  group('saveImagePng', () {
+    test('選了路徑並寫檔成功 → 回實際路徑', () async {
+      final tmp = '${Directory.systemTemp.path}/img_save_out.png';
+      imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+      final path = await saveImagePng(png, suggestedName: 'a.png');
+      expect(path, tmp);
+      expect(await File(tmp).readAsBytes(), png);
+      await File(tmp).delete();
+    });
+
+    test('使用者取消 → null', () async {
+      imageSaveLocationPicker = (name) async => null;
+      expect(await saveImagePng(png, suggestedName: 'a.png'), isNull);
+    });
+
+    test('寫檔失敗 → rethrow', () async {
+      imageSaveLocationPicker = (name) async => FileSaveLocation('/x/y.png');
+      imageFileWriter = (p, b) async =>
+          throw const FileSystemException('write fail');
+      expect(
+        () => saveImagePng(png, suggestedName: 'a.png'),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/services/image_clipboard_save_test.dart`
+Expected: 編譯失敗（`image_clipboard_save.dart` 不存在 / 符號未定義）。
+
+- [ ] **Step 3: 寫實作**
+
+Create `lib/services/image_clipboard_save.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
+
+/// 圖片複製／儲存流程的 logger（命名空間 gacha.hoyowiki.save）。
+final _log = Logger('gacha.hoyowiki.save');
+
+/// 把任意格式的本地圖檔解碼後重新編碼成 PNG bytes；任何失敗（讀檔／解碼／編碼）
+/// 回 null，呼叫端據此提示失敗。
+///
+/// 統一輸出 PNG：來源 icon／gallery 副檔名隨 URL 可能是 webp／jpg，轉 PNG 後
+/// 存檔與複製到剪貼簿格式一致。
+Future<Uint8List?> encodeImageFileToPng(File file) async {
+  try {
+    final bytes = await file.readAsBytes();
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final data = await frame.image.toByteData(format: ui.ImageByteFormat.png);
+    frame.image.dispose();
+    if (data == null) {
+      _log.warning('encode png null path=${sanitizeFsPath(file.path)}');
+      return null;
+    }
+    return data.buffer.asUint8List();
+  } catch (e, st) {
+    _log.warning('encode png failed path=${sanitizeFsPath(file.path)}', e, st);
+    return null;
+  }
+}
+
+/// 預設存檔位置選擇器：開啟系統 save dialog，回傳使用者選擇的路徑（取消為 null）。
+Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) =>
+    getSaveLocation(
+      suggestedName: name,
+      acceptedTypeGroups: const [
+        XTypeGroup(label: 'PNG', extensions: ['png']),
+      ],
+    );
+
+/// 預設剪貼簿寫入：寫 PNG 到系統剪貼簿，回傳是否成功（平台不支援回 false）。
+Future<bool> _defaultClipboardWriter(Uint8List png) async {
+  final clipboard = SystemClipboard.instance;
+  if (clipboard == null) return false;
+  final item = DataWriterItem();
+  item.add(Formats.png(png));
+  await clipboard.write([item]);
+  return true;
+}
+
+/// 預設檔案寫入實作：直接寫入磁碟。
+Future<void> _defaultFileWriter(String path, Uint8List png) =>
+    File(path).writeAsBytes(png);
+
+/// 存檔位置選擇器 seam，讓 flutter test 不開啟真實系統 dialog。
+@visibleForTesting
+Future<FileSaveLocation?> Function(String suggestedName)
+imageSaveLocationPicker = _defaultSaveLocationPicker;
+
+/// 剪貼簿寫入 seam，讓 flutter test 不碰真實剪貼簿（SystemClipboard.instance 為 null）。
+@visibleForTesting
+Future<bool> Function(Uint8List png) imageClipboardWriter =
+    _defaultClipboardWriter;
+
+/// 檔案寫入 seam，讓 flutter test 不碰真實 FS。
+@visibleForTesting
+Future<void> Function(String path, Uint8List png) imageFileWriter =
+    _defaultFileWriter;
+
+/// 將所有 seam 重設為預設實作，供 tearDown 使用。
+@visibleForTesting
+void resetImageClipboardSaveSeams() {
+  imageSaveLocationPicker = _defaultSaveLocationPicker;
+  imageClipboardWriter = _defaultClipboardWriter;
+  imageFileWriter = _defaultFileWriter;
+}
+
+/// 把 PNG 寫入系統剪貼簿。成功回 true；平台不支援回 false；例外記 warning 後回 false。
+Future<bool> copyImagePngToClipboard(Uint8List png) async {
+  try {
+    final ok = await imageClipboardWriter(png);
+    _log.info('copy image clipboard=$ok bytes=${png.length}');
+    return ok;
+  } catch (e, st) {
+    _log.warning('copy image failed', e, st);
+    return false;
+  }
+}
+
+/// 讓使用者選位置存 PNG。成功回**實際存檔路徑**（供呼叫端在提示顯示完整路徑）；
+/// 使用者取消回 null（非錯誤）；已選路徑但寫檔失敗會記 severe log 後 rethrow。
+Future<String?> saveImagePng(
+  Uint8List png, {
+  required String suggestedName,
+}) async {
+  final loc = await imageSaveLocationPicker(suggestedName);
+  if (loc == null) {
+    _log.info('save cancelled');
+    return null;
+  }
+  try {
+    await imageFileWriter(loc.path, png);
+  } catch (e, st) {
+    _log.severe('save image failed ${sanitizeFsPath(loc.path)}', e, st);
+    rethrow;
+  }
+  _log.info('save image ok ${sanitizeFsPath(loc.path)} bytes=${png.length}');
+  return loc.path;
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/services/image_clipboard_save_test.dart`
+Expected: All tests passed!
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/image_clipboard_save.dart test/services/image_clipboard_save_test.dart
+git commit -m "feat(image-save): add shared clipboard/save service for item images"
+```
+
+---
+
+### Task 2: 重構 `share_image_export.dart` 複用共用 seam
+
+**Files:**
+- Modify: `lib/services/share_image_export.dart`
+- Test: `test/services/share_image_export_test.dart`
+
+- [ ] **Step 1: 先改測試（改用共用 seam 名稱）**
+
+把 `test/services/share_image_export_test.dart` 內所有 `shareSaveLocationPicker` 換成 `imageSaveLocationPicker`、`shareClipboardWriter` 換成 `imageClipboardWriter`，並新增 import。完整檔案：
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/share_image_export.dart';
+
+void main() {
+  final png = Uint8List.fromList([1, 2, 3, 4]);
+
+  tearDown(resetShareImageExportSeams);
+
+  test('使用者選了路徑 + 剪貼簿成功 → saved', () async {
+    final tmp = '${Directory.systemTemp.path}/share_test_a.png';
+    imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+    imageClipboardWriter = (bytes) async => true;
+
+    final r = await exportShareImage(png, suggestedName: 'a.png');
+
+    expect(r.status, ShareExportStatus.savedAndCopied);
+    expect(r.path, tmp);
+    expect(await File(tmp).readAsBytes(), png);
+    await File(tmp).delete();
+  });
+
+  test('使用者取消存檔但剪貼簿成功 → copiedOnly', () async {
+    imageSaveLocationPicker = (name) async => null;
+    imageClipboardWriter = (bytes) async => true;
+
+    final r = await exportShareImage(png, suggestedName: 'a.png');
+
+    expect(r.status, ShareExportStatus.copiedOnly);
+    expect(r.path, isNull);
+  });
+
+  test('剪貼簿不支援但存檔成功 → savedOnly', () async {
+    final tmp = '${Directory.systemTemp.path}/share_test_b.png';
+    imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+    imageClipboardWriter = (bytes) async => false;
+
+    final r = await exportShareImage(png, suggestedName: 'b.png');
+
+    expect(r.status, ShareExportStatus.savedOnly);
+    await File(tmp).delete();
+  });
+
+  test('剪貼簿失敗 + 使用者取消存檔 → copiedOnly', () async {
+    imageSaveLocationPicker = (name) async => null;
+    imageClipboardWriter = (bytes) async => false;
+
+    final r = await exportShareImage(png, suggestedName: 'a.png');
+
+    expect(r.status, ShareExportStatus.copiedOnly);
+    expect(r.path, isNull);
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/services/share_image_export_test.dart`
+Expected: 編譯失敗（`imageSaveLocationPicker` 等在 `share_image_export.dart` 重構前尚未被 share 流程使用；且 `resetShareImageExportSeams` 仍重設舊的私有 seam，與測試覆寫的共用 seam 不一致 → 行為錯）。實際會是編譯通過但測試失敗或型別不符；以「非全綠」為準。
+
+- [ ] **Step 3: 重構實作**
+
+把 `lib/services/share_image_export.dart` 改為：移除自身的 `_defaultClipboardWriter` / `_defaultSaveLocationPicker` / `_defaultFileWriter` 與 `shareClipboardWriter` / `shareSaveLocationPicker` / `shareFileWriter`，改用共用 seam。完整檔案：
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
+
+/// 分享圖匯出流程的 logger（命名空間 share.image）。
+final _log = Logger('share.image');
+
+/// 分享圖匯出結果狀態：同時存檔+複製、僅存檔、僅複製三種情況。
+enum ShareExportStatus {
+  /// 同時存檔並複製到剪貼簿。
+  savedAndCopied,
+
+  /// 僅存檔（剪貼簿寫入失敗或平台不支援）。
+  savedOnly,
+
+  /// 僅複製到剪貼簿（使用者取消存檔）。
+  copiedOnly,
+}
+
+/// 分享圖匯出結果，包含狀態與存檔路徑（僅存檔/同時存檔時不為 null）。
+class ShareExportResult {
+  /// 建立 [ShareExportResult]。
+  const ShareExportResult({required this.status, this.path});
+
+  /// 匯出結果狀態。
+  final ShareExportStatus status;
+
+  /// 存檔路徑；[ShareExportStatus.copiedOnly] 時為 null。
+  final String? path;
+}
+
+/// 將所有 seam 重設為預設實作，供 tearDown 使用（轉呼共用層 reset）。
+@visibleForTesting
+void resetShareImageExportSeams() => resetImageClipboardSaveSeams();
+
+/// 先寫剪貼簿（失敗不致命），再讓使用者選位置存檔（取消則只剩剪貼簿）。
+///
+/// 若使用者已選存檔路徑但寫入失敗，會記 severe log 後 rethrow `Exception`
+/// （通常為 `FileSystemException`），由呼叫端負責處理（顯示錯誤）。
+Future<ShareExportResult> exportShareImage(
+  Uint8List png, {
+  required String suggestedName,
+}) async {
+  bool copied;
+  try {
+    copied = await imageClipboardWriter(png);
+  } catch (e, st) {
+    _log.warning('clipboard write failed', e, st);
+    copied = false;
+  }
+
+  final loc = await imageSaveLocationPicker(suggestedName);
+  if (loc == null) {
+    _log.info('save cancelled; clipboard=$copied');
+    return const ShareExportResult(status: ShareExportStatus.copiedOnly);
+  }
+
+  try {
+    await imageFileWriter(loc.path, png);
+  } catch (e, st) {
+    _log.severe('share image write failed ${sanitizeFsPath(loc.path)}', e, st);
+    rethrow;
+  }
+  _log.info(
+    'share image saved ${sanitizeFsPath(loc.path)}; '
+    'bytes=${png.length} clipboard=$copied',
+  );
+  return ShareExportResult(
+    status: copied
+        ? ShareExportStatus.savedAndCopied
+        : ShareExportStatus.savedOnly,
+    path: loc.path,
+  );
+}
+```
+
+- [ ] **Step 4: 確認沒有殘留呼叫舊 seam 名稱**
+
+Run: `fvm flutter test test/services/share_image_export_test.dart`
+Expected: All tests passed!
+
+接著確認全專案無其他檔案還在用舊 seam 名稱（應只有測試與此檔）：
+Run（用 Grep 工具或）: `git grep -n "shareClipboardWriter\|shareSaveLocationPicker\|shareFileWriter"`
+Expected: 無輸出（或僅 plans 文件）。若有 lib 內呼叫，改為共用 seam。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/share_image_export.dart test/services/share_image_export_test.dart
+git commit -m "refactor(share): reuse shared clipboard/save seams in share image export"
+```
+
+---
+
+### Task 3: i18n keys
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（template）
+- Modify: `lib/l10n/app_en.arb`
+
+- [ ] **Step 1: 在 `app_zh.arb` 加入新鍵**
+
+在 `app_zh.arb` 最後一個鍵 `actionCloseImagePreview` 區塊之後、結尾 `}` 之前插入（注意前一個區塊結尾要補逗號）：
+
+```json
+,
+
+  "actionCopyImage": "複製圖片",
+  "@actionCopyImage": {
+    "description": "Item detail dialog image menu: option that copies the currently shown image to the system clipboard as PNG."
+  },
+
+  "actionSaveImage": "儲存圖片",
+  "@actionSaveImage": {
+    "description": "Item detail dialog image menu: option that opens the system save dialog to save the currently shown image as PNG."
+  },
+
+  "actionRefetchImage": "重抓圖片",
+  "@actionRefetchImage": {
+    "description": "Item detail dialog image menu: option that re-downloads the currently shown image, overwriting the cached copy."
+  },
+
+  "imageCopied": "圖片已複製到剪貼簿",
+  "@imageCopied": {
+    "description": "Item detail dialog snackbar shown when the image is successfully copied to the clipboard."
+  },
+
+  "imageCopyFailed": "複製圖片失敗",
+  "@imageCopyFailed": {
+    "description": "Item detail dialog snackbar shown when copying the image to the clipboard fails."
+  },
+
+  "imageSaveFailed": "儲存圖片失敗",
+  "@imageSaveFailed": {
+    "description": "Item detail dialog snackbar shown when saving the image to disk fails."
+  },
+
+  "imageSavedTo": "已儲存至 {path}",
+  "@imageSavedTo": {
+    "description": "Item detail dialog snackbar shown after the image is saved, with the full save path.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  }
+```
+
+- [ ] **Step 2: 在 `app_en.arb` 加入對應英文鍵**
+
+在 `app_en.arb` 對應位置（檔尾結構與 zh 一致，找到 `actionCloseImagePreview` 之後）插入。若該檔最後一鍵不同，插在最後一鍵之後、結尾 `}` 之前並補逗號：
+
+```json
+,
+
+  "actionCopyImage": "Copy Image",
+  "@actionCopyImage": {
+    "description": "Item detail dialog image menu: option that copies the currently shown image to the system clipboard as PNG."
+  },
+
+  "actionSaveImage": "Save Image",
+  "@actionSaveImage": {
+    "description": "Item detail dialog image menu: option that opens the system save dialog to save the currently shown image as PNG."
+  },
+
+  "actionRefetchImage": "Re-fetch Image",
+  "@actionRefetchImage": {
+    "description": "Item detail dialog image menu: option that re-downloads the currently shown image, overwriting the cached copy."
+  },
+
+  "imageCopied": "Image copied to clipboard",
+  "@imageCopied": {
+    "description": "Item detail dialog snackbar shown when the image is successfully copied to the clipboard."
+  },
+
+  "imageCopyFailed": "Failed to copy image",
+  "@imageCopyFailed": {
+    "description": "Item detail dialog snackbar shown when copying the image to the clipboard fails."
+  },
+
+  "imageSaveFailed": "Failed to save image",
+  "@imageSaveFailed": {
+    "description": "Item detail dialog snackbar shown when saving the image to disk fails."
+  },
+
+  "imageSavedTo": "Saved to {path}",
+  "@imageSavedTo": {
+    "description": "Item detail dialog snackbar shown after the image is saved, with the full save path.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  }
+```
+
+> 其他語系 ARB 不在此 plan 手動翻譯（空殼留給 Crowdin pipeline；已翻譯語系由 Crowdin 後續補上）。
+
+- [ ] **Step 3: 重新產生 localizations**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 出現 `actionCopyImage` / `actionSaveImage` / `actionRefetchImage` / `imageCopied` / `imageCopyFailed` / `imageSaveFailed` / `imageSavedTo(String path)` getter/method。
+
+- [ ] **Step 4: 驗證 analyze 通過**
+
+Run: `fvm flutter analyze`
+Expected: No issues found!
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/app_zh.arb lib/l10n/app_en.arb lib/l10n/generated/
+git commit -m "feat(l10n): add item image menu strings (copy/save/refetch)"
+```
+
+---
+
+### Task 4: dialog 圖片選單 + 右鍵 + 重抓
+
+**Files:**
+- Modify: `lib/widgets/dialogs/gacha_item_detail_dialog.dart`
+- Test: `test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart`
+
+- [ ] **Step 1: 先寫失敗的 widget 測試（新增 group）**
+
+在 `test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart` 檔案頂端 import 區，補上 `gestures`（for `kSecondaryButton`）：
+
+```dart
+import 'package:flutter/gestures.dart';
+```
+
+然後在 `main()` 內最後一個 `testWidgets(...)` 之後（仍在 `main` 的 `}` 之前）新增：
+
+```dart
+  group('圖片選單 + 右鍵 + 重抓', () {
+    /// 在 dialog 內定位中央 gallery 主圖（list[0] 的 gif 檔）。
+    Finder galleryMainImage() => find.byWidgetPredicate(
+      (w) =>
+          w is Image &&
+          w.image is FileImage &&
+          (w.image as FileImage).file.path.contains('_gallery_'),
+    );
+
+    testWidgets('ready 圖片右上角有溢出選單鈕', (tester) async {
+      final fakeBytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      final fetcher = _FakeFetcher(behaviorFor: (url, n) async => fakeBytes);
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+      });
+
+      await pumpDialogAndSettle(tester, c, _rec());
+
+      expect(find.byIcon(Icons.more_vert), findsWidgets);
+    });
+
+    testWidgets('點選單鈕 → 顯示複製/儲存/重抓三項', (tester) async {
+      final fakeBytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      final fetcher = _FakeFetcher(behaviorFor: (url, n) async => fakeBytes);
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+      });
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(l.actionCopyImage), findsOneWidget);
+      expect(find.text(l.actionSaveImage), findsOneWidget);
+      expect(find.text(l.actionRefetchImage), findsOneWidget);
+    });
+
+    testWidgets('右鍵圖片 → 叫出選單', (tester) async {
+      final fakeBytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      final fetcher = _FakeFetcher(behaviorFor: (url, n) async => fakeBytes);
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+      });
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      await tester.tap(galleryMainImage().first, buttons: kSecondaryButton);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(l.actionCopyImage), findsOneWidget);
+      expect(find.text(l.actionRefetchImage), findsOneWidget);
+    });
+
+    testWidgets('選「重抓圖片」(gallery) → 對該圖 URL 再打一次 fetch', (tester) async {
+      final fakeBytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      final fetcher = _FakeFetcher(behaviorFor: (url, n) async => fakeBytes);
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+      });
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      // 預設選中 chip 0 = list[0] = x1_g1.gif，初次已打 1 次。
+      expect(fetcher._calls['https://cdn/x1_g1.gif'], 1);
+
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text(l.actionRefetchImage));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fetcher._calls['https://cdn/x1_g1.gif'], 2);
+    });
+
+    testWidgets('切到 Icon chip 後重抓 → 對 icon URL 打一次 fetch', (tester) async {
+      final fakeBytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      final fetcher = _FakeFetcher(behaviorFor: (url, n) async => fakeBytes);
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+      });
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      // 切到最後一個 chip（Icon）
+      await tester.tap(find.text(l.galleryIconLabel));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // icon 初始不經 fetch（預先存在），重抓前 call 數為 null
+      expect(fetcher._calls['https://cdn/x1_icon.png'], isNull);
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text(l.actionRefetchImage));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fetcher._calls['https://cdn/x1_icon.png'], 1);
+    });
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart`
+Expected: 新 group 失敗（找不到 `Icons.more_vert` / 選單項文字 / refetch 未觸發）。既有測試仍應通過。
+
+- [ ] **Step 3: 改 dialog import 與 `_GalleryReady` 為 Stack + 選單**
+
+在 `lib/widgets/dialogs/gacha_item_detail_dialog.dart` import 區（現有 import 之後）新增：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
+```
+
+把 `_buildCurrentImageArea` 內 `switch (state)` 的 `_GalleryReady(:final file) => MouseRegion(...)` 整個 arm 換成下列 `Stack` 版本（保留 loading / failed 兩個 arm，但 failed arm 的重試按鈕改呼叫 `_refetchEntry`，見 Step 4）：
+
+```dart
+        _GalleryReady(:final file) => Stack(
+          children: [
+            Positioned.fill(
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    _log.info('open zoom path=${sanitizeFsPath(file.path)}');
+                    showZoomableImageOverlay(context, imageFile: file);
+                  },
+                  onSecondaryTapDown: (details) => unawaited(
+                    _showImageContextMenu(
+                      context,
+                      details.globalPosition,
+                      current,
+                    ),
+                  ),
+                  child: Image.file(
+                    file,
+                    key: ValueKey(file.path),
+                    fit: BoxFit.contain,
+                    alignment: Alignment.center,
+                    gaplessPlayback: true,
+                    errorBuilder: (_, e, st) {
+                      _log.warning(
+                        'gallery image errorBuilder '
+                        'path=${sanitizeFsPath(file.path)}',
+                        e,
+                        st,
+                      );
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              top: AppSpacing.s,
+              right: AppSpacing.s,
+              child: _buildImageMenu(context, current),
+            ),
+          ],
+        ),
+```
+
+- [ ] **Step 4: 新增選單／複製／儲存／重抓方法，並讓 failed 重試共用 `_refetchEntry`**
+
+把現有 `_GalleryFailed()` arm 內重試按鈕的 `onPressed` 由：
+
+```dart
+                onPressed: () => _retry(
+                  id: _extractIdFromPath(current.file.path) ?? '',
+                  url: current.url,
+                  file: current.file,
+                ),
+```
+
+改為：
+
+```dart
+                onPressed: () => _refetchEntry(current),
+```
+
+刪除已不再被使用的 `_retry` 方法（原 `void _retry({required String id, required String url, required File file})` 整段）。
+
+在 `_buildCurrentImageArea` 方法之前（class `_GachaItemDetailDialogState` 內）新增以下方法：
+
+```dart
+  /// 重抓某 chip 的圖：先 evict 既有 ImageCache、切回 loading，再依類別重抓。
+  ///
+  /// 路徑不變的重抓必須 evict，否則 ready 圖重建後仍讀到舊快取。
+  /// 同時供失敗狀態的「重試」按鈕與圖片選單的「重抓圖片」共用。
+  void _refetchEntry(_GalleryChipEntry e) {
+    PaintingBinding.instance.imageCache.evict(FileImage(e.file));
+    _precachedPaths.remove(e.file.path);
+    setState(() => _loadStates[e.file.path] = const _GalleryLoading());
+    switch (e.kind) {
+      case _ChipKind.galleryList:
+      case _ChipKind.galleryPic:
+        unawaited(
+          _fetchAndCache(
+            id: _extractIdFromPath(e.file.path) ?? '',
+            url: e.url,
+            file: e.file,
+          ),
+        );
+      case _ChipKind.icon:
+        unawaited(_refetchIcon(url: e.url, file: e.file));
+    }
+  }
+
+  /// 重抓 icon：重新下載 [url] 覆蓋 [file]，成功後 evict + bumpCacheRevision，
+  /// 讓 dialog 標題縮圖與記錄列表 [GachaItemIcon] 同步顯示新 icon。
+  ///
+  /// 失敗時保留磁碟既有 icon（writeHoYoWikiCacheImage 失敗不覆寫），
+  /// chip 狀態轉 failed（沿用既有失敗 UI 的重試按鈕）。
+  Future<void> _refetchIcon({required String url, required File file}) async {
+    final fetcher = ref.read(hoyowikiFetcherProvider);
+    try {
+      final bytes = await fetcher.downloadImage(url, _client);
+      if (bytes == null) {
+        if (!mounted) return;
+        setState(() {
+          _loadStates[file.path] = _GalleryFailed(
+            const FormatException('downloadImage returned null'),
+          );
+        });
+        _log.warning('icon refetch null url=${sanitizeUrl(url)}');
+        return;
+      }
+      await writeHoYoWikiCacheImage(file: file, bytes: bytes);
+      if (!mounted) return;
+      PaintingBinding.instance.imageCache.evict(FileImage(file));
+      setState(() => _loadStates[file.path] = _GalleryReady(file));
+      ref.read(hoyowikiIndexProvider.notifier).bumpCacheRevision();
+      ref.invalidate(hoyowikiCacheUsageProvider);
+      _log.info(
+        'icon refetch ok bytes=${bytes.length} '
+        'path=${sanitizeFsPath(file.path)}',
+      );
+    } catch (e, st) {
+      if (!mounted) return;
+      setState(() => _loadStates[file.path] = _GalleryFailed(e));
+      _log.warning('icon refetch failed url=${sanitizeUrl(url)}', e, st);
+    }
+  }
+
+  /// 圖片選單項目（複製圖片 / 儲存圖片 / --- / 重抓圖片）；右上角按鈕與右鍵選單共用。
+  List<PopupMenuEntry<String>> _imageMenuItems(AppLocalizations l) => [
+    PopupMenuItem(
+      value: 'copy',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.copy, size: 20),
+        title: Text(l.actionCopyImage),
+      ),
+    ),
+    PopupMenuItem(
+      value: 'save',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.save_alt, size: 20),
+        title: Text(l.actionSaveImage),
+      ),
+    ),
+    const PopupMenuDivider(),
+    PopupMenuItem(
+      value: 'refetch',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.refresh, size: 20),
+        title: Text(l.actionRefetchImage),
+      ),
+    ),
+  ];
+
+  /// 分派圖片選單選擇（按鈕與右鍵選單共用）：複製 / 儲存 / 重抓。
+  void _onImageMenuSelected(String value, _GalleryChipEntry current) {
+    switch (value) {
+      case 'copy':
+        unawaited(_copyImage(current));
+      case 'save':
+        unawaited(_saveImage(current));
+      case 'refetch':
+        _refetchEntry(current);
+    }
+  }
+
+  /// 圖片區右上角的溢出選單按鈕：複製圖片 / 儲存圖片 / --- / 重抓圖片。
+  /// 沿用 lightbox X 鈕的半透明黑底圓鈕視覺；僅在圖片 ready 時疊在圖上顯示。
+  Widget _buildImageMenu(BuildContext context, _GalleryChipEntry current) {
+    final l = AppLocalizations.of(context)!;
+    return Material(
+      color: Colors.black.withValues(alpha: 0.4),
+      shape: const CircleBorder(),
+      child: PopupMenuButton<String>(
+        icon: const Icon(Icons.more_vert, color: Colors.white),
+        tooltip: '',
+        onSelected: (value) => _onImageMenuSelected(value, current),
+        itemBuilder: (_) => _imageMenuItems(l),
+      ),
+    );
+  }
+
+  /// 右鍵在圖片上叫出與右上角按鈕相同的選單，位置跟著游標。
+  Future<void> _showImageContextMenu(
+    BuildContext context,
+    Offset globalPosition,
+    _GalleryChipEntry current,
+  ) async {
+    final l = AppLocalizations.of(context)!;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromRect(
+        globalPosition & Size.zero,
+        Offset.zero & overlay.size,
+      ),
+      items: _imageMenuItems(l),
+    );
+    if (selected == null || !mounted) return;
+    _onImageMenuSelected(selected, current);
+  }
+
+  /// 把 record 名稱與 chip 標籤組成存檔建議檔名，並去掉檔名非法字元。
+  String _suggestedFileName(_GalleryChipEntry e) {
+    final raw = '${widget.record.name}_${e.label}';
+    // Windows 檔名非法字元（< > : " / \ | ? *）一律換 _，避免存檔對話框拒絕。
+    final safe = raw.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_');
+    return '$safe.png';
+  }
+
+  /// 複製目前圖片到剪貼簿：解碼成 PNG → 寫剪貼簿，結果以 SnackBar 回報。
+  Future<void> _copyImage(_GalleryChipEntry e) async {
+    final l = AppLocalizations.of(context)!;
+    final png = await encodeImageFileToPng(e.file);
+    if (!mounted) return;
+    if (png == null) {
+      _showSnack(l.imageCopyFailed);
+      return;
+    }
+    final ok = await copyImagePngToClipboard(png);
+    if (!mounted) return;
+    _showSnack(ok ? l.imageCopied : l.imageCopyFailed);
+  }
+
+  /// 儲存目前圖片：解碼成 PNG → 系統存檔對話框，結果以 SnackBar 回報。
+  /// 使用者取消不提示；寫檔失敗提示失敗。
+  Future<void> _saveImage(_GalleryChipEntry e) async {
+    final l = AppLocalizations.of(context)!;
+    final png = await encodeImageFileToPng(e.file);
+    if (!mounted) return;
+    if (png == null) {
+      _showSnack(l.imageSaveFailed);
+      return;
+    }
+    try {
+      final savedPath = await saveImagePng(
+        png,
+        suggestedName: _suggestedFileName(e),
+      );
+      if (!mounted || savedPath == null) return;
+      _showSnack(l.imageSavedTo(savedPath));
+    } catch (_) {
+      if (!mounted) return;
+      _showSnack(l.imageSaveFailed);
+    }
+  }
+
+  /// 以 SnackBar 顯示 [message]（dialog 之上找最近的 ScaffoldMessenger）。
+  void _showSnack(String message) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger
+      ?..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+```
+
+- [ ] **Step 5: 跑 dialog 測試確認通過**
+
+Run: `fvm flutter test test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart`
+Expected: All tests passed!（新 group + 既有測試全綠；既有「重試：第一次 null 第二次成功」因重試按鈕改走 `_refetchEntry` 仍應通過。）
+
+- [ ] **Step 6: 跑主 dialog 測試確認沒回歸**
+
+Run: `fvm flutter test test/widgets/dialogs/gacha_item_detail_dialog_test.dart`
+Expected: All tests passed!
+（注意：「gallery 主圖 wrapper 有 click cursor」與「點 gallery 主圖 → 開啟 ZoomableImageOverlay」等仍應通過，因為 `_GalleryReady` 仍含 `MouseRegion(click)` 與 `onTap`。）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/widgets/dialogs/gacha_item_detail_dialog.dart test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart
+git commit -m "feat(item-detail): add image overflow menu (copy/save/refetch) and right-click menu"
+```
+
+---
+
+### Task 5: 全套品質檢查
+
+- [ ] **Step 1: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 數個檔案 formatted（或 unchanged）。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: No issues found!
+
+- [ ] **Step 3: 全套測試**
+
+Run: `fvm flutter test`
+Expected: All tests passed!
+
+- [ ] **Step 4: Commit（若 format 有改動）**
+
+```bash
+git add -A
+git commit -m "style: dart format after item image menu feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 右上角選單鈕 → Task 4 `_buildImageMenu` + Stack。✅
+- 複製/儲存/重抓三項 → Task 4 `_imageMenuItems` + Task 1 service。✅
+- 右鍵叫出選單 → Task 4 `onSecondaryTapDown` + `_showImageContextMenu`。✅
+- 抽共用低階層 → Task 1 + Task 2。✅
+- icon 重抓同步標題/列表 → Task 4 `_refetchIcon` + `bumpCacheRevision`。✅
+- 失敗重試與選單重抓共用 → Task 4 `_refetchEntry`。✅
+- SnackBar 回報 → Task 4 `_showSnack` + Task 3 i18n。✅
+- i18n keys → Task 3。✅
+- 測試（service + dialog + 既有 share）→ Task 1 / 2 / 4。✅
+- 驗收（format / analyze / test）→ Task 5。✅
+
+**Placeholder scan：** 無 TBD/TODO；每個 code step 都有完整程式碼。
+
+**Type consistency：**
+- 共用 seam 名稱 `imageClipboardWriter` / `imageSaveLocationPicker` / `imageFileWriter` 在 Task 1 定義、Task 2 重構、兩處測試一致使用。✅
+- `encodeImageFileToPng(File)→Future<Uint8List?>`、`copyImagePngToClipboard(Uint8List)→Future<bool>`、`saveImagePng(Uint8List,{required String suggestedName})→Future<String?>` 在 Task 1 定義、Task 4 `_copyImage`/`_saveImage` 呼叫一致。✅
+- `_refetchEntry(_GalleryChipEntry)`、`_refetchIcon({required String url, required File file})`、`_imageMenuItems(AppLocalizations)`、`_onImageMenuSelected(String,_GalleryChipEntry)`、`_buildImageMenu(BuildContext,_GalleryChipEntry)`、`_showImageContextMenu(BuildContext,Offset,_GalleryChipEntry)`、`_suggestedFileName(_GalleryChipEntry)`、`_showSnack(String)` 簽名與彼此呼叫一致。✅
+- i18n getter：`actionCopyImage` / `actionSaveImage` / `actionRefetchImage` / `imageCopied` / `imageCopyFailed` / `imageSaveFailed` / `imageSavedTo(String)` 在 Task 3 定義、Task 4 使用一致。✅
+- `_ChipKind` 既有值 `galleryList` / `galleryPic` / `icon` 在 `_refetchEntry` switch 完整涵蓋（無 default）。✅

--- a/docs/superpowers/specs/2026-06-08-item-detail-image-menu-design.md
+++ b/docs/superpowers/specs/2026-06-08-item-detail-image-menu-design.md
@@ -1,0 +1,162 @@
+# 物品詳細圖片選單（複製／儲存／重抓 + 右鍵）設計
+
+> 日期：2026-06-08
+> 對照來源：`GoneTone/wuthering-waves-convene-gacha-analyzer`（同作者姊妹專案）的同名功能，做法一致。
+
+## 目標
+
+在 `GachaItemDetailDialog`（物品詳細 dialog）中央 gallery 圖片的右上角新增一個浮動溢出選單，選單提供三項操作：
+
+1. **複製圖片** — 把目前顯示的圖片複製到系統剪貼簿（PNG）。
+2. **儲存圖片** — 開啟系統存檔對話框，把目前圖片存成 PNG。
+3. **重抓圖片** — 重新下載目前 chip 對應的圖片並覆寫快取。
+
+同一份選單也要能透過**在圖片上按滑鼠右鍵**叫出（位置跟著游標）。
+
+操作結果以 SnackBar 回報（複製成功／失敗、存檔成功顯示路徑／失敗；使用者取消存檔不提示）。
+
+## 非目標（YAGNI）
+
+- 不做批次匯出／全部圖片一次存檔（既有設定頁已有「強制重抓所有物品圖片」涵蓋全域重抓）。
+- 不在 lightbox（`ZoomableImageOverlay`）內加選單；本次只動物品詳細 dialog 的圖片區。
+- 不新增「複製圖片網址」「分享」等本次未要求的選項。
+- 不為「未來可能的其他圖片來源」預先抽象 chip 類別以外的擴充點。
+
+## 現況脈絡
+
+- 物品詳細 dialog：`lib/widgets/dialogs/gacha_item_detail_dialog.dart`。中央圖片由 `_buildCurrentImageArea` 依 `_GalleryLoadState`（`_GalleryReady` / `_GalleryLoading` / `_GalleryFailed`）繪製；ready 時是單一可點開縮放的 `Image.file`。
+- chip 類別 `_ChipKind`：`galleryList`、`galleryPic`、`icon`。gallery 圖走 lazy 下載（`_fetchAndCache`，一律重新下載並覆寫，無磁碟短路）；icon 由更新流程預抓、開 dialog 時永遠 `_GalleryReady`。
+- 既有圖片寫檔：`writeHoYoWikiCacheImage(file:, bytes:)`；下載：`hoyowikiFetcherProvider` 的 `downloadImage(url, client)`。
+- icon 同步機制：`GachaItemIcon` 與 dialog 標題縮圖都 `watch(hoyowikiIndexProvider)`；`HoYoWikiIndexNotifier.bumpCacheRevision()` 換 state identity 觸發重 build 以挑到新檔。快取用量由 `hoyowikiCacheUsageProvider` 提供，重抓後 `ref.invalidate` 之。
+- 剪貼簿／存檔 primitive 已存在於 `lib/services/share_image_export.dart`，但其對外 API（`exportShareImage`）是「複製＋存檔合併成單一流程」，與本次需要的「分開複製／分開存檔／圖檔轉 PNG」不同。專案有 `super_clipboard`、`file_selector` 相依。
+- SnackBar：全專案以 `ScaffoldMessenger.of(context)` 顯示；MaterialApp 提供 root ScaffoldMessenger，dialog context 內以 `ScaffoldMessenger.maybeOf(context)` 可取得。
+
+## 架構決策
+
+### 程式碼組織：抽共用低階層，再各自包裝
+
+避免與 `share_image_export.dart` 重複造輪子（CLAUDE.md「嚴禁重複造輪子」）：把剪貼簿寫入、存檔位置選擇器、檔案寫入這三個原始操作抽到共用模組，`share_image_export` 與新的 item-image 流程都複用同一份 seam。
+
+## 元件設計
+
+### 1. 共用低階層 — 新增 `lib/services/image_clipboard_save.dart`
+
+Logger：`Logger('gacha.hoyowiki.save')`。
+
+可測 seam（`@visibleForTesting` 可覆寫的 function 指標）與預設實作：
+
+| 成員 | 型別 / 預設 | 作用 |
+|---|---|---|
+| `imageClipboardWriter` | `Future<bool> Function(Uint8List png)` | 預設：`SystemClipboard.instance` 為 null 回 false；否則 `DataWriterItem` 加 `Formats.png(png)` 寫入回 true |
+| `imageSaveLocationPicker` | `Future<FileSaveLocation?> Function(String suggestedName)` | 預設：`getSaveLocation` 帶 `XTypeGroup(label:'PNG', extensions:['png'])` |
+| `imageFileWriter` | `Future<void> Function(String path, Uint8List png)` | 預設：`File(path).writeAsBytes(png)` |
+| `resetImageClipboardSaveSeams()` | `void` | 把三個 seam 重設為預設（供 tearDown） |
+
+公開函式：
+
+- `Future<Uint8List?> encodeImageFileToPng(File file)`
+  讀檔 → `ui.instantiateImageCodec` → `getNextFrame` → `toByteData(format: png)` → dispose frame。任何失敗（讀檔／解碼／編碼）記 warning（脫敏路徑）後回 null。統一輸出 PNG，因為來源 icon／gallery 副檔名隨 URL 可能是 webp／jpg。
+
+- `Future<bool> copyImagePngToClipboard(Uint8List png)`
+  呼叫 `imageClipboardWriter`，info log 結果與 bytes 數；例外記 warning 後回 false。
+
+- `Future<String?> saveImagePng(Uint8List png, {required String suggestedName})`
+  呼叫 `imageSaveLocationPicker`；null（取消）→ info log 後回 null。否則 `imageFileWriter` 寫入；寫入失敗記 severe log（脫敏路徑）後 rethrow。成功 info log 後回**實際存檔路徑**。
+
+### 2. 重構 `lib/services/share_image_export.dart`
+
+- 移除自身的 `_defaultClipboardWriter` / `_defaultSaveLocationPicker` / `_defaultFileWriter` 及 `shareClipboardWriter` / `shareSaveLocationPicker` / `shareFileWriter` 三個 seam。
+- `exportShareImage` 改為呼叫共用層的 `imageClipboardWriter` / `imageSaveLocationPicker` / `imageFileWriter`。**對外行為、回傳型別（`ShareExportResult` / `ShareExportStatus`）皆不變**。
+- `resetShareImageExportSeams()` 改為轉呼 `resetImageClipboardSaveSeams()`（保留函式名供既有測試呼叫）。
+- 連帶更新 `test/services/share_image_export_test.dart`：把覆寫的 seam 名稱由 `shareSaveLocationPicker` / `shareClipboardWriter` 換成共用層的 `imageSaveLocationPicker` / `imageClipboardWriter`。
+
+### 3. 改造 `lib/widgets/dialogs/gacha_item_detail_dialog.dart`
+
+`_buildCurrentImageArea` 的 `_GalleryReady` 分支由單一 `Image.file` 改為 `Stack`：
+
+- **底層** `Positioned.fill`：保留現有 `MouseRegion(cursor: click)` + `GestureDetector`（`onTap` 開 `showZoomableImageOverlay`），**新增** `onSecondaryTapDown: (d) => _showImageContextMenu(context, d.globalPosition, current)`。`Image.file` 設定（`ValueKey(file.path)`、`gaplessPlayback`、`errorBuilder`）維持不變。
+- **疊層** `Positioned(top: AppSpacing.s, right: AppSpacing.s, child: _buildImageMenu(context, current))`。
+
+新增方法（與 WW 同構）：
+
+- `List<PopupMenuEntry<String>> _imageMenuItems(AppLocalizations l)`
+  三項 `PopupMenuItem`（value `copy` / `save` / `refetch`），各為 `ListTile(dense, contentPadding: zero, leading: Icon(size:20), title: Text(...))`；`copy`（`Icons.copy`）與 `save`（`Icons.save_alt`）之後接 `PopupMenuDivider()`，再 `refetch`（`Icons.refresh`）。
+- `void _onImageMenuSelected(String value, _GalleryChipEntry current)`
+  `switch`：`copy` → `unawaited(_copyImage(current))`；`save` → `unawaited(_saveImage(current))`；`refetch` → `_refetchEntry(current)`。
+- `Widget _buildImageMenu(BuildContext, _GalleryChipEntry current)`
+  `Material(color: Colors.black.withValues(alpha:0.4), shape: CircleBorder())` 包 `PopupMenuButton<String>(icon: Icon(Icons.more_vert, color: white), tooltip: '', onSelected: ..., itemBuilder: (_) => _imageMenuItems(l))`。沿用 lightbox X 鈕視覺。
+- `Future<void> _showImageContextMenu(BuildContext, Offset globalPosition, _GalleryChipEntry current)`
+  以 `Overlay.of(context)` 的 RenderBox 算 `RelativeRect.fromRect(globalPosition & Size.zero, Offset.zero & overlay.size)`，`showMenu` 顯示 `_imageMenuItems`；選取後（非 null 且 mounted）`_onImageMenuSelected`。
+- `String _suggestedFileName(_GalleryChipEntry e)`
+  `'${record.name}_${e.label}'` 把 Windows 非法字元 `[<>:"/\\|?*]` 換成 `_`，加 `.png`。
+- `Future<void> _copyImage(_GalleryChipEntry e)`
+  `encodeImageFileToPng(e.file)` → null 則 SnackBar `imageCopyFailed`；否則 `copyImagePngToClipboard` → SnackBar `imageCopied`／`imageCopyFailed`。各 await 後檢查 `mounted`。
+- `Future<void> _saveImage(_GalleryChipEntry e)`
+  `encodeImageFileToPng` → null 則 `imageSaveFailed`；否則 `try { saveImagePng(png, suggestedName: _suggestedFileName(e)) }`，回傳 path 非 null 且 mounted → SnackBar `imageSavedTo(path)`；取消（null）不提示；catch → `imageSaveFailed`。
+- `void _refetchEntry(_GalleryChipEntry e)`
+  `PaintingBinding.instance.imageCache.evict(FileImage(e.file))` → `_precachedPaths.remove(e.file.path)` → `setState(() => _loadStates[e.file.path] = const _GalleryLoading())`，再依 `e.kind`：
+  - `galleryList` / `galleryPic` → `unawaited(_fetchAndCache(id: <id>, url: e.url, file: e.file))`（既有方法，一律重新下載覆寫）。`id` 由 `_extractIdFromPath(e.file.path)` 取得（與既有 retry 路徑一致）。
+  - `icon` → `unawaited(_refetchIcon(url: e.url, file: e.file))`。
+- `Future<void> _refetchIcon({required String url, required File file})`
+  `hoyowikiFetcherProvider.downloadImage(url, _client)` → null 則 setState `_GalleryFailed` + warning；否則 `writeHoYoWikiCacheImage(file:, bytes:)` 覆寫 → `imageCache.evict(FileImage(file))` → setState `_GalleryReady(file)` → `ref.read(hoyowikiIndexProvider.notifier).bumpCacheRevision()` → `ref.invalidate(hoyowikiCacheUsageProvider)` → info log。讓標題縮圖與記錄列表 `GachaItemIcon` 同步顯示新 icon。失敗保留磁碟既有 icon（`writeHoYoWikiCacheImage` 失敗不覆寫）。
+- `void _showSnack(String message)`
+  `ScaffoldMessenger.maybeOf(context)?..clearSnackBars()..showSnackBar(SnackBar(content: Text(message)))`。
+
+**DRY**：`_GalleryFailed` 分支現有「重試」按鈕的 `onPressed` 改呼叫 `_refetchEntry(current)`（與選單「重抓」共用同一條路徑），取代原本內聯的 `_retry(...)`。原 `_retry` 若無其他呼叫端則移除。
+
+選單與右鍵僅在 `_GalleryReady` 疊出；loading／failed 狀態維持原樣（failed 仍有重試按鈕）。
+
+### 4. i18n（`lib/l10n/app_zh.arb` 起手，只加已有實體翻譯的 ARB）
+
+新增鍵（繁中值）：
+
+| key | zh 值 | 備註 |
+|---|---|---|
+| `actionCopyImage` | 複製圖片 | 選單標籤 |
+| `actionSaveImage` | 儲存圖片 | 選單標籤 |
+| `actionRefetchImage` | 重抓圖片 | 選單標籤 |
+| `imageCopied` | 圖片已複製到剪貼簿 | SnackBar |
+| `imageCopyFailed` | 複製圖片失敗 | SnackBar |
+| `imageSaveFailed` | 儲存圖片失敗 | SnackBar |
+| `imageSavedTo` | 已儲存至 {path} | SnackBar，`path` placeholder（type String）|
+
+先寫 `app_zh.arb`，再以中文為基準翻已有實體翻譯的語系；空殼 ARB 留給 Crowdin pipeline。`gen-l10n` 重新產生。
+
+## 資料流
+
+```
+使用者點右上角選單鈕 / 右鍵圖片
+  → _imageMenuItems 顯示（PopupMenuButton / showMenu）
+  → _onImageMenuSelected(value, current)
+      copy   → encodeImageFileToPng → copyImagePngToClipboard(imageClipboardWriter) → SnackBar
+      save   → encodeImageFileToPng → saveImagePng(imageSaveLocationPicker→imageFileWriter) → SnackBar
+      refetch→ evict + loading → _fetchAndCache（gallery） / _refetchIcon（icon, +bumpCacheRevision）
+```
+
+## 錯誤處理
+
+- 編碼失敗（壞檔／解碼失敗）：`encodeImageFileToPng` 回 null → 複製／儲存皆 SnackBar 失敗訊息。
+- 剪貼簿平台不支援：`copyImagePngToClipboard` 回 false → SnackBar 失敗。
+- 存檔使用者取消：`saveImagePng` 回 null → 不提示（非錯誤）。
+- 存檔寫入失敗：`saveImagePng` rethrow → `_saveImage` catch → SnackBar 失敗。
+- 重抓下載失敗：setState `_GalleryFailed`（沿用既有失敗 UI 的重試按鈕）；icon 重抓失敗保留磁碟舊 icon。
+- 所有 I/O／下載節點都帶 context（id、bytes、脫敏 URL／路徑）寫 log（對齊 `gacha.hoyowiki.*` 樹）。
+
+## 測試
+
+- **新增** `test/services/image_clipboard_save_test.dart`：
+  - `encodeImageFileToPng`：真實 PNG 檔 → 非 null；不存在／壞檔 → null。
+  - `copyImagePngToClipboard`：seam 回 true / false / throw 三情境。
+  - `saveImagePng`：選路徑寫檔成功（驗檔內容）/ 取消 → null / 寫入失敗 → rethrow。tearDown `resetImageClipboardSaveSeams`。
+- **更新** `test/services/share_image_export_test.dart`：seam 名稱改用共用層。
+- **擴充** `test/widgets/dialogs/gacha_item_detail_dialog_test.dart`：
+  - ready 圖片上存在選單鈕（`Icons.more_vert`）。
+  - 點選單「複製」「儲存」分別觸發 `imageClipboardWriter` / `imageSaveLocationPicker` seam。
+  - 右鍵（`onSecondaryTapDown`）能叫出選單。
+  - 「重抓」走 fetcher（以既有測試的 fetcher 注入方式）並回到 ready。
+
+## 驗收條件
+
+1. `fvm dart format lib/ test/`
+2. `fvm flutter analyze` → `No issues found!`
+3. `fvm flutter test` → `All tests passed!`

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -831,5 +831,45 @@
   "actionCloseImagePreview": "Close image preview",
   "@actionCloseImagePreview": {
     "description": "Tooltip and semantic label for the close (X) button on the full-screen zoomable image overlay opened from the item detail dialog gallery."
+  },
+
+  "actionCopyImage": "Copy Image",
+  "@actionCopyImage": {
+    "description": "Item detail dialog image menu: option that copies the currently shown image to the system clipboard as PNG."
+  },
+
+  "actionSaveImage": "Save Image",
+  "@actionSaveImage": {
+    "description": "Item detail dialog image menu: option that opens the system save dialog to save the currently shown image as PNG."
+  },
+
+  "actionRefetchImage": "Re-fetch Image",
+  "@actionRefetchImage": {
+    "description": "Item detail dialog image menu: option that re-downloads the currently shown image, overwriting the cached copy."
+  },
+
+  "imageCopied": "Image copied to clipboard",
+  "@imageCopied": {
+    "description": "Item detail dialog snackbar shown when the image is successfully copied to the clipboard."
+  },
+
+  "imageCopyFailed": "Failed to copy image",
+  "@imageCopyFailed": {
+    "description": "Item detail dialog snackbar shown when copying the image to the clipboard fails."
+  },
+
+  "imageSaveFailed": "Failed to save image",
+  "@imageSaveFailed": {
+    "description": "Item detail dialog snackbar shown when saving the image to disk fails."
+  },
+
+  "imageSavedTo": "Saved to {path}",
+  "@imageSavedTo": {
+    "description": "Item detail dialog snackbar shown after the image is saved, with the full save path.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -628,5 +628,45 @@
   "actionCloseImagePreview": "關閉圖片預覽",
   "@actionCloseImagePreview": {
     "description": "Tooltip and semantic label for the close (X) button on the full-screen zoomable image overlay opened from the item detail dialog gallery."
+  },
+
+  "actionCopyImage": "複製圖片",
+  "@actionCopyImage": {
+    "description": "Item detail dialog image menu: option that copies the currently shown image to the system clipboard as PNG."
+  },
+
+  "actionSaveImage": "儲存圖片",
+  "@actionSaveImage": {
+    "description": "Item detail dialog image menu: option that opens the system save dialog to save the currently shown image as PNG."
+  },
+
+  "actionRefetchImage": "重抓圖片",
+  "@actionRefetchImage": {
+    "description": "Item detail dialog image menu: option that re-downloads the currently shown image, overwriting the cached copy."
+  },
+
+  "imageCopied": "圖片已複製到剪貼簿",
+  "@imageCopied": {
+    "description": "Item detail dialog snackbar shown when the image is successfully copied to the clipboard."
+  },
+
+  "imageCopyFailed": "複製圖片失敗",
+  "@imageCopyFailed": {
+    "description": "Item detail dialog snackbar shown when copying the image to the clipboard fails."
+  },
+
+  "imageSaveFailed": "儲存圖片失敗",
+  "@imageSaveFailed": {
+    "description": "Item detail dialog snackbar shown when saving the image to disk fails."
+  },
+
+  "imageSavedTo": "已儲存至 {path}",
+  "@imageSavedTo": {
+    "description": "Item detail dialog snackbar shown after the image is saved, with the full save path.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/services/image_clipboard_save.dart
+++ b/lib/services/image_clipboard_save.dart
@@ -97,8 +97,22 @@ Future<bool> _defaultClipboardWriter(
 }) async {
   final clipboard = SystemClipboard.instance;
   if (clipboard == null) return false;
-  final item = DataWriterItem();
+  final item = DataWriterItem(suggestedName: isGif ? 'image.gif' : 'image.png');
   item.add(isGif ? Formats.gif(bytes) : Formats.png(bytes));
+  // GIF 額外掛一份 virtual file：讓「貼上檔案」的目標（Discord、檔案總管、聊天
+  // 軟體）拿到真正的 .gif 檔以保留動畫。純圖片貼上的目標（小畫家等）仍只會拿到
+  // 系統合成的靜態點陣圖 — 這是 Windows 剪貼簿圖片模型的限制，無法避免。
+  if (isGif && item.virtualFileSupported) {
+    item.addVirtualFile(
+      format: Formats.gif,
+      storageSuggestion: VirtualFileStorage.memory,
+      provider: (sinkProvider, progress) {
+        final sink = sinkProvider(fileSize: bytes.length);
+        sink.add(bytes);
+        sink.close();
+      },
+    );
+  }
   await clipboard.write([item]);
   return true;
 }

--- a/lib/services/image_clipboard_save.dart
+++ b/lib/services/image_clipboard_save.dart
@@ -11,51 +11,101 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
 /// 圖片複製／儲存流程的 logger（命名空間 gacha.hoyowiki.save）。
 final _log = Logger('gacha.hoyowiki.save');
 
-/// 把任意格式的本地圖檔解碼後重新編碼成 PNG bytes；任何失敗（讀檔／解碼／編碼）
-/// 回 null，呼叫端據此提示失敗。
-///
-/// 統一輸出 PNG：來源 icon／gallery 副檔名隨 URL 可能是 webp／jpg，轉 PNG 後
-/// 存檔與複製到剪貼簿格式一致。
-Future<Uint8List?> encodeImageFileToPng(File file) async {
+/// 要複製／儲存的圖片輸出：GIF 保留原始 bytes（保留動畫），其餘一律轉成 PNG。
+class OutputImage {
+  /// 建立 [OutputImage]。
+  const OutputImage({required this.bytes, required this.isGif});
+
+  /// 實際要寫出／複製的 bytes。
+  final Uint8List bytes;
+
+  /// 是否為 GIF（true 時 [bytes] 為原始 GIF）。
+  final bool isGif;
+
+  /// 對應副檔名（不含點）：gif 或 png。
+  String get ext => isGif ? 'gif' : 'png';
+}
+
+/// 判斷 [bytes] 開頭是否為 GIF magic（`GIF87a` / `GIF89a`）。用 magic bytes 而非
+/// 副檔名判斷，較不受 URL／快取檔命名影響。
+bool _isGifBytes(Uint8List bytes) =>
+    bytes.length >= 6 &&
+    bytes[0] == 0x47 && // G
+    bytes[1] == 0x49 && // I
+    bytes[2] == 0x46 && // F
+    bytes[3] == 0x38 && // 8
+    (bytes[4] == 0x37 || bytes[4] == 0x39) && // 7 或 9
+    bytes[5] == 0x61; // a
+
+/// 把 [bytes]（任意格式）解碼後重新編碼成 PNG bytes；失敗回 null。
+Future<Uint8List?> _encodeBytesToPng(
+  Uint8List bytes, {
+  required String debugPath,
+}) async {
   try {
-    final bytes = await file.readAsBytes();
     final codec = await ui.instantiateImageCodec(bytes);
     final frame = await codec.getNextFrame();
     final data = await frame.image.toByteData(format: ui.ImageByteFormat.png);
     frame.image.dispose();
     if (data == null) {
-      _log.warning('encode png null path=${sanitizeFsPath(file.path)}');
+      _log.warning('encode png null path=${sanitizeFsPath(debugPath)}');
       return null;
     }
     return data.buffer.asUint8List();
   } catch (e, st) {
-    _log.warning('encode png failed path=${sanitizeFsPath(file.path)}', e, st);
+    _log.warning('encode png failed path=${sanitizeFsPath(debugPath)}', e, st);
     return null;
   }
 }
 
-/// 預設存檔位置選擇器：開啟系統 save dialog，回傳使用者選擇的路徑（取消為 null）。
-Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) =>
-    getSaveLocation(
-      suggestedName: name,
-      acceptedTypeGroups: const [
-        XTypeGroup(label: 'PNG', extensions: ['png']),
-      ],
-    );
+/// 由本地圖檔 [file] 準備輸出 bytes：GIF 保留原始 bytes（保留動畫），其餘解碼重編
+/// 成 PNG（icon／gallery 副檔名隨 URL 可能是 webp／jpg，轉 PNG 後存檔與貼上相容性
+/// 最佳）。讀檔或解碼失敗回 null。
+Future<OutputImage?> prepareOutputImage(File file) async {
+  Uint8List bytes;
+  try {
+    bytes = await file.readAsBytes();
+  } catch (e, st) {
+    _log.warning('read image failed path=${sanitizeFsPath(file.path)}', e, st);
+    return null;
+  }
+  if (_isGifBytes(bytes)) {
+    return OutputImage(bytes: bytes, isGif: true);
+  }
+  final png = await _encodeBytesToPng(bytes, debugPath: file.path);
+  if (png == null) return null;
+  return OutputImage(bytes: png, isGif: false);
+}
 
-/// 預設剪貼簿寫入：寫 PNG 到系統剪貼簿，回傳是否成功（平台不支援回 false）。
-Future<bool> _defaultClipboardWriter(Uint8List png) async {
+/// 預設存檔位置選擇器：開啟系統 save dialog，type group 依 [name] 副檔名（gif/png）
+/// 設定；回傳使用者選擇的路徑（取消為 null）。
+Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) {
+  final ext = name.toLowerCase().endsWith('.gif') ? 'gif' : 'png';
+  return getSaveLocation(
+    suggestedName: name,
+    acceptedTypeGroups: [
+      XTypeGroup(label: ext.toUpperCase(), extensions: [ext]),
+    ],
+  );
+}
+
+/// 預設剪貼簿寫入：寫圖片 [bytes] 到系統剪貼簿，[isGif] 決定用 GIF 或 PNG 格式；
+/// 回傳是否成功（平台不支援回 false）。
+Future<bool> _defaultClipboardWriter(
+  Uint8List bytes, {
+  required bool isGif,
+}) async {
   final clipboard = SystemClipboard.instance;
   if (clipboard == null) return false;
   final item = DataWriterItem();
-  item.add(Formats.png(png));
+  item.add(isGif ? Formats.gif(bytes) : Formats.png(bytes));
   await clipboard.write([item]);
   return true;
 }
 
 /// 預設檔案寫入實作：直接寫入磁碟。
-Future<void> _defaultFileWriter(String path, Uint8List png) =>
-    File(path).writeAsBytes(png);
+Future<void> _defaultFileWriter(String path, Uint8List bytes) =>
+    File(path).writeAsBytes(bytes);
 
 /// 存檔位置選擇器 seam，讓 flutter test 不開啟真實系統 dialog。
 @visibleForTesting
@@ -64,12 +114,12 @@ imageSaveLocationPicker = _defaultSaveLocationPicker;
 
 /// 剪貼簿寫入 seam，讓 flutter test 不碰真實剪貼簿（SystemClipboard.instance 為 null）。
 @visibleForTesting
-Future<bool> Function(Uint8List png) imageClipboardWriter =
-    _defaultClipboardWriter;
+Future<bool> Function(Uint8List bytes, {required bool isGif})
+imageClipboardWriter = _defaultClipboardWriter;
 
 /// 檔案寫入 seam，讓 flutter test 不碰真實 FS。
 @visibleForTesting
-Future<void> Function(String path, Uint8List png) imageFileWriter =
+Future<void> Function(String path, Uint8List bytes) imageFileWriter =
     _defaultFileWriter;
 
 /// 將所有 seam 重設為預設實作，供 tearDown 使用。
@@ -80,11 +130,15 @@ void resetImageClipboardSaveSeams() {
   imageFileWriter = _defaultFileWriter;
 }
 
-/// 把 PNG 寫入系統剪貼簿。成功回 true；平台不支援回 false；例外記 warning 後回 false。
-Future<bool> copyImagePngToClipboard(Uint8List png) async {
+/// 把圖片 [bytes] 寫入系統剪貼簿（[isGif] 選 GIF／PNG 格式）。成功回 true；
+/// 平台不支援或例外回 false。
+Future<bool> _copyBytesToClipboard(
+  Uint8List bytes, {
+  required bool isGif,
+}) async {
   try {
-    final ok = await imageClipboardWriter(png);
-    _log.info('copy image clipboard=$ok bytes=${png.length}');
+    final ok = await imageClipboardWriter(bytes, isGif: isGif);
+    _log.info('copy image clipboard=$ok gif=$isGif bytes=${bytes.length}');
     return ok;
   } catch (e, st) {
     _log.warning('copy image failed', e, st);
@@ -92,10 +146,21 @@ Future<bool> copyImagePngToClipboard(Uint8List png) async {
   }
 }
 
-/// 讓使用者選位置存 PNG。成功回**實際存檔路徑**（供呼叫端在提示顯示完整路徑）；
-/// 使用者取消回 null（非錯誤）；已選路徑但寫檔失敗會記 severe log 後 rethrow。
-Future<String?> saveImagePng(
-  Uint8List png, {
+/// 把 PNG [png] 複製到系統剪貼簿（分享圖匯出用）。成功回 true。
+Future<bool> copyImagePngToClipboard(Uint8List png) =>
+    _copyBytesToClipboard(png, isGif: false);
+
+/// 把本地圖檔 [file] 複製到系統剪貼簿：GIF 保留原始（保留動畫），其餘轉 PNG。
+/// 讀檔／解碼失敗或平台不支援回 false。
+Future<bool> copyImageFileToClipboard(File file) async {
+  final out = await prepareOutputImage(file);
+  if (out == null) return false;
+  return _copyBytesToClipboard(out.bytes, isGif: out.isGif);
+}
+
+/// 讓使用者選位置存 [bytes]。成功回實際路徑、取消回 null、寫檔失敗記 severe 後 rethrow。
+Future<String?> _saveBytes(
+  Uint8List bytes, {
   required String suggestedName,
 }) async {
   final loc = await imageSaveLocationPicker(suggestedName);
@@ -104,11 +169,30 @@ Future<String?> saveImagePng(
     return null;
   }
   try {
-    await imageFileWriter(loc.path, png);
+    await imageFileWriter(loc.path, bytes);
   } catch (e, st) {
     _log.severe('save image failed ${sanitizeFsPath(loc.path)}', e, st);
     rethrow;
   }
-  _log.info('save image ok ${sanitizeFsPath(loc.path)} bytes=${png.length}');
+  _log.info('save image ok ${sanitizeFsPath(loc.path)} bytes=${bytes.length}');
   return loc.path;
+}
+
+/// 讓使用者選位置存 PNG（分享圖匯出用）。成功回**實際存檔路徑**；取消回 null；
+/// 寫檔失敗 rethrow。
+Future<String?> saveImagePng(Uint8List png, {required String suggestedName}) =>
+    _saveBytes(png, suggestedName: suggestedName);
+
+/// 讓使用者選位置存本地圖檔：GIF 保留原始 bytes 與 `.gif`；其餘轉 PNG 與 `.png`。
+/// [suggestedBaseName] 為**不含副檔名**的建議檔名（副檔名依實際格式自動補上）。
+/// 成功回實際路徑；取消回 null；準備（讀檔／解碼）失敗 throw；寫檔失敗 rethrow。
+Future<String?> saveImageFile(
+  File file, {
+  required String suggestedBaseName,
+}) async {
+  final out = await prepareOutputImage(file);
+  if (out == null) {
+    throw const FormatException('prepare output image failed');
+  }
+  return _saveBytes(out.bytes, suggestedName: '$suggestedBaseName.${out.ext}');
 }

--- a/lib/services/image_clipboard_save.dart
+++ b/lib/services/image_clipboard_save.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
+
+/// 圖片複製／儲存流程的 logger（命名空間 gacha.hoyowiki.save）。
+final _log = Logger('gacha.hoyowiki.save');
+
+/// 把任意格式的本地圖檔解碼後重新編碼成 PNG bytes；任何失敗（讀檔／解碼／編碼）
+/// 回 null，呼叫端據此提示失敗。
+///
+/// 統一輸出 PNG：來源 icon／gallery 副檔名隨 URL 可能是 webp／jpg，轉 PNG 後
+/// 存檔與複製到剪貼簿格式一致。
+Future<Uint8List?> encodeImageFileToPng(File file) async {
+  try {
+    final bytes = await file.readAsBytes();
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final data = await frame.image.toByteData(format: ui.ImageByteFormat.png);
+    frame.image.dispose();
+    if (data == null) {
+      _log.warning('encode png null path=${sanitizeFsPath(file.path)}');
+      return null;
+    }
+    return data.buffer.asUint8List();
+  } catch (e, st) {
+    _log.warning('encode png failed path=${sanitizeFsPath(file.path)}', e, st);
+    return null;
+  }
+}
+
+/// 預設存檔位置選擇器：開啟系統 save dialog，回傳使用者選擇的路徑（取消為 null）。
+Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) =>
+    getSaveLocation(
+      suggestedName: name,
+      acceptedTypeGroups: const [
+        XTypeGroup(label: 'PNG', extensions: ['png']),
+      ],
+    );
+
+/// 預設剪貼簿寫入：寫 PNG 到系統剪貼簿，回傳是否成功（平台不支援回 false）。
+Future<bool> _defaultClipboardWriter(Uint8List png) async {
+  final clipboard = SystemClipboard.instance;
+  if (clipboard == null) return false;
+  final item = DataWriterItem();
+  item.add(Formats.png(png));
+  await clipboard.write([item]);
+  return true;
+}
+
+/// 預設檔案寫入實作：直接寫入磁碟。
+Future<void> _defaultFileWriter(String path, Uint8List png) =>
+    File(path).writeAsBytes(png);
+
+/// 存檔位置選擇器 seam，讓 flutter test 不開啟真實系統 dialog。
+@visibleForTesting
+Future<FileSaveLocation?> Function(String suggestedName)
+imageSaveLocationPicker = _defaultSaveLocationPicker;
+
+/// 剪貼簿寫入 seam，讓 flutter test 不碰真實剪貼簿（SystemClipboard.instance 為 null）。
+@visibleForTesting
+Future<bool> Function(Uint8List png) imageClipboardWriter =
+    _defaultClipboardWriter;
+
+/// 檔案寫入 seam，讓 flutter test 不碰真實 FS。
+@visibleForTesting
+Future<void> Function(String path, Uint8List png) imageFileWriter =
+    _defaultFileWriter;
+
+/// 將所有 seam 重設為預設實作，供 tearDown 使用。
+@visibleForTesting
+void resetImageClipboardSaveSeams() {
+  imageSaveLocationPicker = _defaultSaveLocationPicker;
+  imageClipboardWriter = _defaultClipboardWriter;
+  imageFileWriter = _defaultFileWriter;
+}
+
+/// 把 PNG 寫入系統剪貼簿。成功回 true；平台不支援回 false；例外記 warning 後回 false。
+Future<bool> copyImagePngToClipboard(Uint8List png) async {
+  try {
+    final ok = await imageClipboardWriter(png);
+    _log.info('copy image clipboard=$ok bytes=${png.length}');
+    return ok;
+  } catch (e, st) {
+    _log.warning('copy image failed', e, st);
+    return false;
+  }
+}
+
+/// 讓使用者選位置存 PNG。成功回**實際存檔路徑**（供呼叫端在提示顯示完整路徑）；
+/// 使用者取消回 null（非錯誤）；已選路徑但寫檔失敗會記 severe log 後 rethrow。
+Future<String?> saveImagePng(
+  Uint8List png, {
+  required String suggestedName,
+}) async {
+  final loc = await imageSaveLocationPicker(suggestedName);
+  if (loc == null) {
+    _log.info('save cancelled');
+    return null;
+  }
+  try {
+    await imageFileWriter(loc.path, png);
+  } catch (e, st) {
+    _log.severe('save image failed ${sanitizeFsPath(loc.path)}', e, st);
+    rethrow;
+  }
+  _log.info('save image ok ${sanitizeFsPath(loc.path)} bytes=${png.length}');
+  return loc.path;
+}

--- a/lib/services/image_clipboard_save.dart
+++ b/lib/services/image_clipboard_save.dart
@@ -89,30 +89,24 @@ Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) {
   );
 }
 
-/// 預設剪貼簿寫入：寫圖片 [bytes] 到系統剪貼簿，[isGif] 決定用 GIF 或 PNG 格式；
-/// 回傳是否成功（平台不支援回 false）。
+/// 預設剪貼簿寫入：寫圖片 [bytes] 到系統剪貼簿，[isGif] 決定用 GIF 或 PNG 格式。
+/// GIF 且有 [filePath] 時，額外掛上實體檔路徑（Windows 為 `CF_HDROP`），讓以
+/// 「檔案」貼上的目標（Discord、檔案總管、聊天軟體）取得真正的 `.gif` 檔以保留
+/// 動畫；放最前面提高優先序。純圖片貼上的目標（小畫家等）仍只會拿到系統合成的
+/// 靜態點陣圖 — 這是 Windows 剪貼簿圖片模型的限制，無法避免。回是否成功（平台
+/// 不支援回 false）。
 Future<bool> _defaultClipboardWriter(
   Uint8List bytes, {
   required bool isGif,
+  String? filePath,
 }) async {
   final clipboard = SystemClipboard.instance;
   if (clipboard == null) return false;
   final item = DataWriterItem(suggestedName: isGif ? 'image.gif' : 'image.png');
-  item.add(isGif ? Formats.gif(bytes) : Formats.png(bytes));
-  // GIF 額外掛一份 virtual file：讓「貼上檔案」的目標（Discord、檔案總管、聊天
-  // 軟體）拿到真正的 .gif 檔以保留動畫。純圖片貼上的目標（小畫家等）仍只會拿到
-  // 系統合成的靜態點陣圖 — 這是 Windows 剪貼簿圖片模型的限制，無法避免。
-  if (isGif && item.virtualFileSupported) {
-    item.addVirtualFile(
-      format: Formats.gif,
-      storageSuggestion: VirtualFileStorage.memory,
-      provider: (sinkProvider, progress) {
-        final sink = sinkProvider(fileSize: bytes.length);
-        sink.add(bytes);
-        sink.close();
-      },
-    );
+  if (isGif && filePath != null) {
+    item.add(Formats.fileUri(Uri.file(filePath)));
   }
+  item.add(isGif ? Formats.gif(bytes) : Formats.png(bytes));
   await clipboard.write([item]);
   return true;
 }
@@ -128,7 +122,7 @@ imageSaveLocationPicker = _defaultSaveLocationPicker;
 
 /// 剪貼簿寫入 seam，讓 flutter test 不碰真實剪貼簿（SystemClipboard.instance 為 null）。
 @visibleForTesting
-Future<bool> Function(Uint8List bytes, {required bool isGif})
+Future<bool> Function(Uint8List bytes, {required bool isGif, String? filePath})
 imageClipboardWriter = _defaultClipboardWriter;
 
 /// 檔案寫入 seam，讓 flutter test 不碰真實 FS。
@@ -144,14 +138,19 @@ void resetImageClipboardSaveSeams() {
   imageFileWriter = _defaultFileWriter;
 }
 
-/// 把圖片 [bytes] 寫入系統剪貼簿（[isGif] 選 GIF／PNG 格式）。成功回 true；
-/// 平台不支援或例外回 false。
+/// 把圖片 [bytes] 寫入系統剪貼簿（[isGif] 選 GIF／PNG 格式；[filePath] 供 GIF 掛
+/// 實體檔路徑）。成功回 true；平台不支援或例外回 false。
 Future<bool> _copyBytesToClipboard(
   Uint8List bytes, {
   required bool isGif,
+  String? filePath,
 }) async {
   try {
-    final ok = await imageClipboardWriter(bytes, isGif: isGif);
+    final ok = await imageClipboardWriter(
+      bytes,
+      isGif: isGif,
+      filePath: filePath,
+    );
     _log.info('copy image clipboard=$ok gif=$isGif bytes=${bytes.length}');
     return ok;
   } catch (e, st) {
@@ -164,12 +163,17 @@ Future<bool> _copyBytesToClipboard(
 Future<bool> copyImagePngToClipboard(Uint8List png) =>
     _copyBytesToClipboard(png, isGif: false);
 
-/// 把本地圖檔 [file] 複製到系統剪貼簿：GIF 保留原始（保留動畫），其餘轉 PNG。
-/// 讀檔／解碼失敗或平台不支援回 false。
+/// 把本地圖檔 [file] 複製到系統剪貼簿：GIF 保留原始（保留動畫，並掛實體檔路徑供
+/// 以「檔案」貼上的目標取得真正的 .gif），其餘轉 PNG。讀檔／解碼失敗或平台不支援
+/// 回 false。
 Future<bool> copyImageFileToClipboard(File file) async {
   final out = await prepareOutputImage(file);
   if (out == null) return false;
-  return _copyBytesToClipboard(out.bytes, isGif: out.isGif);
+  return _copyBytesToClipboard(
+    out.bytes,
+    isGif: out.isGif,
+    filePath: out.isGif ? file.path : null,
+  );
 }
 
 /// 讓使用者選位置存 [bytes]。成功回實際路徑、取消回 null、寫檔失敗記 severe 後 rethrow。

--- a/lib/services/share_image_export.dart
+++ b/lib/services/share_image_export.dart
@@ -1,10 +1,7 @@
-import 'dart:io';
-
-import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
-import 'package:super_clipboard/super_clipboard.dart';
 
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
 
 /// 分享圖匯出流程的 logger（命名空間 share.image）。
@@ -34,86 +31,32 @@ class ShareExportResult {
   final String? path;
 }
 
-/// 預設剪貼簿寫入：寫 PNG 到系統剪貼簿，回傳是否成功
-/// （平台不支援時回傳 false）。
-/// 平台原生路徑；unit test 以 [shareClipboardWriter] seam 取代覆蓋（flutter test 環境 SystemClipboard.instance 為 null）。
-Future<bool> _defaultClipboardWriter(Uint8List png) async {
-  final clipboard = SystemClipboard.instance;
-  if (clipboard == null) return false;
-  final item = DataWriterItem();
-  item.add(Formats.png(png));
-  await clipboard.write([item]);
-  return true;
-}
-
-/// 預設存檔位置選擇器：開啟系統 save dialog，回傳使用者選擇的路徑（取消為 null）。
-Future<FileSaveLocation?> _defaultSaveLocationPicker(String name) =>
-    getSaveLocation(
-      suggestedName: name,
-      acceptedTypeGroups: const [
-        XTypeGroup(label: 'PNG', extensions: ['png']),
-      ],
-    );
-
-/// 存檔位置選擇器 seam，讓 flutter test 不開啟真實系統 dialog。
-@visibleForTesting
-Future<FileSaveLocation?> Function(String suggestedName)
-shareSaveLocationPicker = _defaultSaveLocationPicker;
-
-/// 剪貼簿寫入 seam，讓 flutter test 不碰真實剪貼簿（SystemClipboard.instance 為 null）。
-@visibleForTesting
-Future<bool> Function(Uint8List png) shareClipboardWriter =
-    _defaultClipboardWriter;
-
-/// 檔案寫入 seam，讓 flutter test 不碰真實 FS。
-@visibleForTesting
-Future<void> Function(String path, Uint8List png) shareFileWriter =
-    (path, png) => File(path).writeAsBytes(png);
-
-/// 將所有 seam 重設為預設實作，供 tearDown 使用。
-@visibleForTesting
-void resetShareImageExportSeams() {
-  shareSaveLocationPicker = _defaultSaveLocationPicker;
-  shareClipboardWriter = _defaultClipboardWriter;
-  shareFileWriter = (path, png) => File(path).writeAsBytes(png);
-}
-
 /// 先寫剪貼簿（失敗不致命），再讓使用者選位置存檔（取消則只剩剪貼簿）。
 ///
-/// 若使用者已選存檔路徑但寫入失敗，會記 severe log 後 rethrow `Exception`
-/// （通常為 `FileSystemException`），由呼叫端負責處理（顯示錯誤）。
+/// 組合共用層的 [copyImagePngToClipboard]（永不拋、回是否成功）與
+/// [saveImagePng]（取消回 null、成功回實際路徑、寫檔失敗 rethrow）。
+/// 若使用者已選存檔路徑但寫入失敗，[saveImagePng] 會記 severe log 後 rethrow
+/// `Exception`（通常為 `FileSystemException`），由呼叫端負責處理（顯示錯誤）。
 Future<ShareExportResult> exportShareImage(
   Uint8List png, {
   required String suggestedName,
 }) async {
-  bool copied;
-  try {
-    copied = await shareClipboardWriter(png);
-  } catch (e, st) {
-    _log.warning('clipboard write failed', e, st);
-    copied = false;
-  }
+  final copied = await copyImagePngToClipboard(png);
 
-  final loc = await shareSaveLocationPicker(suggestedName);
-  if (loc == null) {
+  final savedPath = await saveImagePng(png, suggestedName: suggestedName);
+  if (savedPath == null) {
     _log.info('save cancelled; clipboard=$copied');
     return const ShareExportResult(status: ShareExportStatus.copiedOnly);
   }
 
-  try {
-    await shareFileWriter(loc.path, png);
-  } catch (e, st) {
-    _log.severe('share image write failed ${sanitizeFsPath(loc.path)}', e, st);
-    rethrow;
-  }
   _log.info(
-    'share image saved ${sanitizeFsPath(loc.path)}; '
+    'share image saved ${sanitizeFsPath(savedPath)}; '
     'bytes=${png.length} clipboard=$copied',
   );
   return ShareExportResult(
     status: copied
         ? ShareExportStatus.savedAndCopied
         : ShareExportStatus.savedOnly,
-    path: loc.path,
+    path: savedPath,
   );
 }

--- a/lib/widgets/dialogs/dialog_toast.dart
+++ b/lib/widgets/dialogs/dialog_toast.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// 目前在畫面上的 toast entry；新 toast 出現前先移除舊的，避免堆疊重疊。
+OverlayEntry? _activeToast;
+
+/// 在最上層 [Overlay] 顯示一則短暫提示（toast），會疊在 dialog／modal barrier
+/// **之上**。
+///
+/// 用來取代 dialog 內的 `ScaffoldMessenger` SnackBar — 後者由 app 層級 Scaffold
+/// 繪製，會被 dialog 的 modal barrier 蓋住。toast 改插到 `Overlay.of(context)`
+/// （承載 dialog route 的 navigator overlay），新 entry 疊在 dialog route 之上，
+/// 因此可見。樣式對齊 Material SnackBar（inverseSurface 底色）。
+void showDialogToast(BuildContext context, String message) {
+  if (_activeToast?.mounted ?? false) {
+    _activeToast!.remove();
+  }
+  _activeToast = null;
+
+  final overlay = Overlay.of(context);
+  late final OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (_) => _DialogToast(
+      message: message,
+      onDismissed: () {
+        if (entry.mounted) entry.remove();
+        if (identical(_activeToast, entry)) _activeToast = null;
+      },
+    ),
+  );
+  _activeToast = entry;
+  overlay.insert(entry);
+}
+
+/// [showDialogToast] 用的內部 widget：淡入 → 停留 → 淡出，結束後呼叫 [onDismissed]。
+class _DialogToast extends StatefulWidget {
+  /// 建立 [_DialogToast]。
+  const _DialogToast({required this.message, required this.onDismissed});
+
+  /// 要顯示的提示文字。
+  final String message;
+
+  /// 淡出結束後的回呼；呼叫端據此移除 [OverlayEntry]。
+  final VoidCallback onDismissed;
+
+  @override
+  State<_DialogToast> createState() => _DialogToastState();
+}
+
+/// [_DialogToast] 的 state：管理淡入淡出動畫與停留計時。
+class _DialogToastState extends State<_DialogToast>
+    with SingleTickerProviderStateMixin {
+  /// 淡入淡出動畫控制器（forward = 淡入、reverse = 淡出）。
+  late final AnimationController _ctrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 200),
+  );
+
+  /// 停留計時器；時間到觸發淡出。
+  Timer? _holdTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl.forward();
+    _holdTimer = Timer(const Duration(milliseconds: 2200), _dismiss);
+  }
+
+  /// 淡出後通知呼叫端移除 entry；重複呼叫安全。
+  Future<void> _dismiss() async {
+    _holdTimer?.cancel();
+    if (!mounted) return;
+    await _ctrl.reverse();
+    if (!mounted) return;
+    widget.onDismissed();
+  }
+
+  @override
+  void dispose() {
+    _holdTimer?.cancel();
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: FadeTransition(
+              opacity: _ctrl,
+              child: Material(
+                color: theme.colorScheme.inverseSurface,
+                borderRadius: BorderRadius.circular(8),
+                elevation: 6,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 480),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                    child: Text(
+                      widget.message,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onInverseSurface,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -17,6 +17,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/dialog_toast.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/zoomable_image_overlay.dart';
 
 /// 頌願卡池 gachaType 集合 — 永遠不可點。
@@ -328,12 +329,12 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
     }
   }
 
-  /// 以 SnackBar 顯示 [message]（dialog 之上找最近的 ScaffoldMessenger）。
+  /// 以 toast 顯示 [message]。用 [showDialogToast]（疊在 dialog 之上的 overlay）
+  /// 而非 SnackBar — SnackBar 由 app 層級 Scaffold 繪製，會被 dialog 的 modal
+  /// barrier 蓋住。
   void _showSnack(String message) {
-    final messenger = ScaffoldMessenger.maybeOf(context);
-    messenger
-      ?..clearSnackBars()
-      ..showSnackBar(SnackBar(content: Text(message)));
+    if (!mounted) return;
+    showDialogToast(context, message);
   }
 
   /// 依當前 chip 的 [_GalleryLoadState] 顯示對應內容：

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -284,42 +284,30 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
     _onImageMenuSelected(selected, current);
   }
 
-  /// 把 record 名稱與 chip 標籤組成存檔建議檔名，並去掉檔名非法字元。
-  String _suggestedFileName(_GalleryChipEntry e) {
+  /// 把 record 名稱與 chip 標籤組成存檔建議檔名（不含副檔名），並去掉非法字元。
+  /// 副檔名由 [saveImageFile] 依實際格式（gif／png）補上。
+  String _suggestedBaseName(_GalleryChipEntry e) {
     final raw = '${widget.record.name}_${e.label}';
     // Windows 檔名非法字元（< > : " / \ | ? *）一律換 _，避免存檔對話框拒絕。
-    final safe = raw.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_');
-    return '$safe.png';
+    return raw.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_');
   }
 
-  /// 複製目前圖片到剪貼簿：解碼成 PNG → 寫剪貼簿，結果以 SnackBar 回報。
+  /// 複製目前圖片到剪貼簿（GIF 保留原始、其餘轉 PNG），結果以 toast 回報。
   Future<void> _copyImage(_GalleryChipEntry e) async {
     final l = AppLocalizations.of(context)!;
-    final png = await encodeImageFileToPng(e.file);
-    if (!mounted) return;
-    if (png == null) {
-      _showSnack(l.imageCopyFailed);
-      return;
-    }
-    final ok = await copyImagePngToClipboard(png);
+    final ok = await copyImageFileToClipboard(e.file);
     if (!mounted) return;
     _showSnack(ok ? l.imageCopied : l.imageCopyFailed);
   }
 
-  /// 儲存目前圖片：解碼成 PNG → 系統存檔對話框，結果以 SnackBar 回報。
-  /// 使用者取消不提示；寫檔失敗提示失敗。
+  /// 儲存目前圖片（GIF 存成 .gif 保留動畫、其餘轉 PNG）→ 系統存檔對話框，
+  /// 結果以 toast 回報。使用者取消不提示；準備／寫檔失敗提示失敗。
   Future<void> _saveImage(_GalleryChipEntry e) async {
     final l = AppLocalizations.of(context)!;
-    final png = await encodeImageFileToPng(e.file);
-    if (!mounted) return;
-    if (png == null) {
-      _showSnack(l.imageSaveFailed);
-      return;
-    }
     try {
-      final savedPath = await saveImagePng(
-        png,
-        suggestedName: _suggestedFileName(e),
+      final savedPath = await saveImageFile(
+        e.file,
+        suggestedBaseName: _suggestedBaseName(e),
       );
       if (!mounted || savedPath == null) return;
       _showSnack(l.imageSavedTo(savedPath));

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -10,6 +10,7 @@ import 'package:logging/logging.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/log_sanitize.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_cache_usage.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
@@ -126,15 +127,6 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
     }
   }
 
-  /// 對某張圖檔由 [_GalleryFailed] 重試，改回 [_GalleryLoading] 並再次呼叫
-  /// [_fetchAndCache]。
-  void _retry({required String id, required String url, required File file}) {
-    setState(() {
-      _loadStates[file.path] = const _GalleryLoading();
-    });
-    unawaited(_fetchAndCache(id: id, url: url, file: file));
-  }
-
   /// 只 precache [_GalleryReady] 的圖檔；未下載完的 chip 略過。
   void _precacheChipImages(
     BuildContext context,
@@ -147,6 +139,201 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
         precacheImage(FileImage(e.file), context);
       }
     }
+  }
+
+  /// 重抓某 chip 的圖：先 evict 既有 ImageCache、切回 loading，再依類別重抓。
+  ///
+  /// 路徑不變的重抓必須 evict，否則 ready 圖重建後仍讀到舊快取。
+  /// 同時供失敗狀態的「重試」按鈕與圖片選單的「重抓圖片」共用。
+  void _refetchEntry(_GalleryChipEntry e) {
+    PaintingBinding.instance.imageCache.evict(FileImage(e.file));
+    _precachedPaths.remove(e.file.path);
+    setState(() => _loadStates[e.file.path] = const _GalleryLoading());
+    switch (e.kind) {
+      case _ChipKind.galleryList:
+      case _ChipKind.galleryPic:
+        unawaited(
+          _fetchAndCache(
+            id: _extractIdFromPath(e.file.path) ?? '',
+            url: e.url,
+            file: e.file,
+          ),
+        );
+      case _ChipKind.icon:
+        unawaited(_refetchIcon(url: e.url, file: e.file));
+    }
+  }
+
+  /// 重抓 icon：重新下載 [url] 覆蓋 [file]，成功後 evict + bumpCacheRevision，
+  /// 讓 dialog 標題縮圖與記錄列表 [GachaItemIcon] 同步顯示新 icon。
+  ///
+  /// 失敗時保留磁碟既有 icon（writeHoYoWikiCacheImage 失敗不覆寫），
+  /// chip 狀態轉 failed（沿用既有失敗 UI 的重試按鈕）。
+  Future<void> _refetchIcon({required String url, required File file}) async {
+    final fetcher = ref.read(hoyowikiFetcherProvider);
+    try {
+      final bytes = await fetcher.downloadImage(url, _client);
+      if (bytes == null) {
+        if (!mounted) return;
+        setState(() {
+          _loadStates[file.path] = _GalleryFailed(
+            const FormatException('downloadImage returned null'),
+          );
+        });
+        _log.warning('icon refetch null url=${sanitizeUrl(url)}');
+        return;
+      }
+      await writeHoYoWikiCacheImage(file: file, bytes: bytes);
+      if (!mounted) return;
+      PaintingBinding.instance.imageCache.evict(FileImage(file));
+      setState(() => _loadStates[file.path] = _GalleryReady(file));
+      ref.read(hoyowikiIndexProvider.notifier).bumpCacheRevision();
+      ref.invalidate(hoyowikiCacheUsageProvider);
+      _log.info(
+        'icon refetch ok bytes=${bytes.length} '
+        'path=${sanitizeFsPath(file.path)}',
+      );
+    } catch (e, st) {
+      if (!mounted) return;
+      setState(() => _loadStates[file.path] = _GalleryFailed(e));
+      _log.warning('icon refetch failed url=${sanitizeUrl(url)}', e, st);
+    }
+  }
+
+  /// 圖片選單項目（複製圖片 / 儲存圖片 / --- / 重抓圖片）；右上角按鈕與右鍵選單共用。
+  List<PopupMenuEntry<String>> _imageMenuItems(AppLocalizations l) => [
+    PopupMenuItem(
+      value: 'copy',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.copy, size: 20),
+        title: Text(l.actionCopyImage),
+      ),
+    ),
+    PopupMenuItem(
+      value: 'save',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.save_alt, size: 20),
+        title: Text(l.actionSaveImage),
+      ),
+    ),
+    const PopupMenuDivider(),
+    PopupMenuItem(
+      value: 'refetch',
+      child: ListTile(
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.refresh, size: 20),
+        title: Text(l.actionRefetchImage),
+      ),
+    ),
+  ];
+
+  /// 分派圖片選單選擇（按鈕與右鍵選單共用）：複製 / 儲存 / 重抓。
+  void _onImageMenuSelected(String value, _GalleryChipEntry current) {
+    switch (value) {
+      case 'copy':
+        unawaited(_copyImage(current));
+      case 'save':
+        unawaited(_saveImage(current));
+      case 'refetch':
+        _refetchEntry(current);
+    }
+  }
+
+  /// 圖片區右上角的溢出選單按鈕：複製圖片 / 儲存圖片 / --- / 重抓圖片。
+  /// 沿用 lightbox X 鈕的半透明黑底圓鈕視覺；僅在圖片 ready 時疊在圖上顯示。
+  Widget _buildImageMenu(BuildContext context, _GalleryChipEntry current) {
+    final l = AppLocalizations.of(context)!;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: Material(
+        color: Colors.black.withValues(alpha: 0.4),
+        shape: const CircleBorder(),
+        child: PopupMenuButton<String>(
+          icon: const Icon(Icons.more_vert, color: Colors.white),
+          tooltip: '',
+          onSelected: (value) => _onImageMenuSelected(value, current),
+          itemBuilder: (_) => _imageMenuItems(l),
+        ),
+      ),
+    );
+  }
+
+  /// 右鍵在圖片上叫出與右上角按鈕相同的選單，位置跟著游標。
+  Future<void> _showImageContextMenu(
+    BuildContext context,
+    Offset globalPosition,
+    _GalleryChipEntry current,
+  ) async {
+    final l = AppLocalizations.of(context)!;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromRect(
+        globalPosition & Size.zero,
+        Offset.zero & overlay.size,
+      ),
+      items: _imageMenuItems(l),
+    );
+    if (selected == null || !mounted) return;
+    _onImageMenuSelected(selected, current);
+  }
+
+  /// 把 record 名稱與 chip 標籤組成存檔建議檔名，並去掉檔名非法字元。
+  String _suggestedFileName(_GalleryChipEntry e) {
+    final raw = '${widget.record.name}_${e.label}';
+    // Windows 檔名非法字元（< > : " / \ | ? *）一律換 _，避免存檔對話框拒絕。
+    final safe = raw.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_');
+    return '$safe.png';
+  }
+
+  /// 複製目前圖片到剪貼簿：解碼成 PNG → 寫剪貼簿，結果以 SnackBar 回報。
+  Future<void> _copyImage(_GalleryChipEntry e) async {
+    final l = AppLocalizations.of(context)!;
+    final png = await encodeImageFileToPng(e.file);
+    if (!mounted) return;
+    if (png == null) {
+      _showSnack(l.imageCopyFailed);
+      return;
+    }
+    final ok = await copyImagePngToClipboard(png);
+    if (!mounted) return;
+    _showSnack(ok ? l.imageCopied : l.imageCopyFailed);
+  }
+
+  /// 儲存目前圖片：解碼成 PNG → 系統存檔對話框，結果以 SnackBar 回報。
+  /// 使用者取消不提示；寫檔失敗提示失敗。
+  Future<void> _saveImage(_GalleryChipEntry e) async {
+    final l = AppLocalizations.of(context)!;
+    final png = await encodeImageFileToPng(e.file);
+    if (!mounted) return;
+    if (png == null) {
+      _showSnack(l.imageSaveFailed);
+      return;
+    }
+    try {
+      final savedPath = await saveImagePng(
+        png,
+        suggestedName: _suggestedFileName(e),
+      );
+      if (!mounted || savedPath == null) return;
+      _showSnack(l.imageSavedTo(savedPath));
+    } catch (_) {
+      if (!mounted) return;
+      _showSnack(l.imageSaveFailed);
+    }
+  }
+
+  /// 以 SnackBar 顯示 [message]（dialog 之上找最近的 ScaffoldMessenger）。
+  void _showSnack(String message) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger
+      ?..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   /// 依當前 chip 的 [_GalleryLoadState] 顯示對應內容：
@@ -164,32 +351,51 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
     return ClipRRect(
       borderRadius: BorderRadius.circular(AppRadius.md),
       child: switch (state) {
-        _GalleryReady(:final file) => MouseRegion(
-          cursor: SystemMouseCursors.click,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () {
-              _log.info('open zoom path=${sanitizeFsPath(file.path)}');
-              showZoomableImageOverlay(context, imageFile: file);
-            },
-            child: Image.file(
-              file,
-              key: ValueKey(file.path),
-              fit: BoxFit.contain,
-              alignment: Alignment.center,
-              // 切 chip / 同圖重 build 時保留前一張 frame，等新 frame
-              // 解碼完才換；配合 precacheImage 消除「閃一下」。
-              gaplessPlayback: true,
-              errorBuilder: (_, e, st) {
-                _log.warning(
-                  'gallery image errorBuilder path=${sanitizeFsPath(file.path)}',
-                  e,
-                  st,
-                );
-                return const SizedBox.shrink();
-              },
+        _GalleryReady(:final file) => Stack(
+          children: [
+            Positioned.fill(
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () {
+                    _log.info('open zoom path=${sanitizeFsPath(file.path)}');
+                    showZoomableImageOverlay(context, imageFile: file);
+                  },
+                  onSecondaryTapDown: (details) => unawaited(
+                    _showImageContextMenu(
+                      context,
+                      details.globalPosition,
+                      current,
+                    ),
+                  ),
+                  child: Image.file(
+                    file,
+                    key: ValueKey(file.path),
+                    fit: BoxFit.contain,
+                    alignment: Alignment.center,
+                    // 切 chip / 同圖重 build 時保留前一張 frame，等新 frame
+                    // 解碼完才換；配合 precacheImage 消除「閃一下」。
+                    gaplessPlayback: true,
+                    errorBuilder: (_, e, st) {
+                      _log.warning(
+                        'gallery image errorBuilder '
+                        'path=${sanitizeFsPath(file.path)}',
+                        e,
+                        st,
+                      );
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              ),
             ),
-          ),
+            Positioned(
+              top: AppSpacing.s,
+              right: AppSpacing.s,
+              child: _buildImageMenu(context, current),
+            ),
+          ],
         ),
         _GalleryLoading() => Center(
           child: SizedBox(
@@ -219,11 +425,7 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
               ),
               const SizedBox(height: AppSpacing.s),
               TextButton.icon(
-                onPressed: () => _retry(
-                  id: _extractIdFromPath(current.file.path) ?? '',
-                  url: current.url,
-                  file: current.file,
-                ),
+                onPressed: () => _refetchEntry(current),
                 icon: const Icon(Icons.refresh, size: 18),
                 label: Text(l.actionRetry),
               ),

--- a/test/services/image_clipboard_save_test.dart
+++ b/test/services/image_clipboard_save_test.dart
@@ -6,73 +6,161 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
 
+/// GIF89a magic（_isGifBytes 只看開頭，後面補幾個 byte 即可）。
+final _gifBytes = Uint8List.fromList([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, // GIF89a
+  0x01, 0x00, 0x01, 0x00, 0x00, 0x3B,
+]);
+
+/// 用引擎產生一張合法 2×2 PNG bytes（需在 tester.runAsync 內呼叫）。
+Future<Uint8List> _makePng() async {
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder).drawRect(
+    const ui.Rect.fromLTWH(0, 0, 2, 2),
+    ui.Paint()..color = const ui.Color(0xFFFF0000),
+  );
+  final image = await recorder.endRecording().toImage(2, 2);
+  final data = await image.toByteData(format: ui.ImageByteFormat.png);
+  image.dispose();
+  return data!.buffer.asUint8List();
+}
+
 void main() {
   final png = Uint8List.fromList([1, 2, 3, 4]);
 
   tearDown(resetImageClipboardSaveSeams);
 
-  group('encodeImageFileToPng', () {
-    testWidgets('合法 PNG 檔 → 非 null PNG bytes', (tester) async {
+  group('prepareOutputImage', () {
+    test('GIF → isGif=true 且保留原始 bytes', () async {
+      final dir = await Directory.systemTemp.createTemp('img_prep_');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
+      });
+      final f = File('${dir.path}/a.gif')..writeAsBytesSync(_gifBytes);
+
+      final out = await prepareOutputImage(f);
+
+      expect(out, isNotNull);
+      expect(out!.isGif, isTrue);
+      expect(out.ext, 'gif');
+      expect(out.bytes, _gifBytes);
+    });
+
+    testWidgets('非 GIF 合法圖 → isGif=false 且轉成 PNG', (tester) async {
       await tester.runAsync(() async {
-        // 用引擎自身產生一張合法 PNG，避免硬編碼 byte array 不合法。
-        final recorder = ui.PictureRecorder();
-        ui.Canvas(recorder).drawRect(
-          const ui.Rect.fromLTWH(0, 0, 2, 2),
-          ui.Paint()..color = const ui.Color(0xFFFF0000),
-        );
-        final image = await recorder.endRecording().toImage(2, 2);
-        final pngData = await image.toByteData(format: ui.ImageByteFormat.png);
-        image.dispose();
-        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        final dir = await Directory.systemTemp.createTemp('img_prep_');
         addTearDown(() async {
           if (await dir.exists()) await dir.delete(recursive: true);
         });
-        final f = File('${dir.path}/a.png')
-          ..writeAsBytesSync(pngData!.buffer.asUint8List());
-        final out = await encodeImageFileToPng(f);
+        final f = File('${dir.path}/a.png')..writeAsBytesSync(await _makePng());
+
+        final out = await prepareOutputImage(f);
+
         expect(out, isNotNull);
-        expect(out!.isNotEmpty, isTrue);
+        expect(out!.isGif, isFalse);
+        expect(out.ext, 'png');
+        expect(out.bytes.isNotEmpty, isTrue);
       });
     });
 
-    testWidgets('不存在的檔 → null', (tester) async {
+    testWidgets('壞檔（非 GIF 非圖片）→ null', (tester) async {
       await tester.runAsync(() async {
-        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        final dir = await Directory.systemTemp.createTemp('img_prep_');
         addTearDown(() async {
           if (await dir.exists()) await dir.delete(recursive: true);
         });
-        final missing = File('${dir.path}/missing.png');
-        expect(await encodeImageFileToPng(missing), isNull);
+        final f = File('${dir.path}/g.bin')..writeAsBytesSync([1, 2, 3, 4]);
+
+        expect(await prepareOutputImage(f), isNull);
       });
     });
 
-    testWidgets('壞檔（非圖片）→ null', (tester) async {
-      await tester.runAsync(() async {
-        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
-        addTearDown(() async {
-          if (await dir.exists()) await dir.delete(recursive: true);
-        });
-        final garbage = File('${dir.path}/g.png')
-          ..writeAsBytesSync([1, 2, 3, 4]);
-        expect(await encodeImageFileToPng(garbage), isNull);
+    test('不存在的檔 → null', () async {
+      final dir = await Directory.systemTemp.createTemp('img_prep_');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
       });
+      expect(await prepareOutputImage(File('${dir.path}/missing.png')), isNull);
     });
   });
 
   group('copyImagePngToClipboard', () {
-    test('seam 回 true → true', () async {
-      imageClipboardWriter = (b) async => true;
+    test('seam 回 true → true（isGif=false）', () async {
+      bool? capturedIsGif;
+      imageClipboardWriter = (b, {required isGif}) async {
+        capturedIsGif = isGif;
+        return true;
+      };
       expect(await copyImagePngToClipboard(png), isTrue);
+      expect(capturedIsGif, isFalse);
     });
 
     test('seam 回 false → false', () async {
-      imageClipboardWriter = (b) async => false;
+      imageClipboardWriter = (b, {required isGif}) async => false;
       expect(await copyImagePngToClipboard(png), isFalse);
     });
 
     test('seam 拋例外 → false', () async {
-      imageClipboardWriter = (b) async => throw Exception('boom');
+      imageClipboardWriter = (b, {required isGif}) async =>
+          throw Exception('x');
       expect(await copyImagePngToClipboard(png), isFalse);
+    });
+  });
+
+  group('copyImageFileToClipboard', () {
+    test('GIF → 以 isGif=true、原始 bytes 寫剪貼簿', () async {
+      bool? capturedIsGif;
+      Uint8List? capturedBytes;
+      imageClipboardWriter = (b, {required isGif}) async {
+        capturedIsGif = isGif;
+        capturedBytes = b;
+        return true;
+      };
+      final dir = await Directory.systemTemp.createTemp('img_copy_');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
+      });
+      final f = File('${dir.path}/a.gif')..writeAsBytesSync(_gifBytes);
+
+      expect(await copyImageFileToClipboard(f), isTrue);
+      expect(capturedIsGif, isTrue);
+      expect(capturedBytes, _gifBytes);
+    });
+
+    testWidgets('非 GIF → 以 isGif=false（PNG）寫剪貼簿', (tester) async {
+      await tester.runAsync(() async {
+        bool? capturedIsGif;
+        imageClipboardWriter = (b, {required isGif}) async {
+          capturedIsGif = isGif;
+          return true;
+        };
+        final dir = await Directory.systemTemp.createTemp('img_copy_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/a.png')..writeAsBytesSync(await _makePng());
+
+        expect(await copyImageFileToClipboard(f), isTrue);
+        expect(capturedIsGif, isFalse);
+      });
+    });
+
+    testWidgets('壞檔 → false（不呼叫 seam）', (tester) async {
+      await tester.runAsync(() async {
+        var called = false;
+        imageClipboardWriter = (b, {required isGif}) async {
+          called = true;
+          return true;
+        };
+        final dir = await Directory.systemTemp.createTemp('img_copy_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/g.bin')..writeAsBytesSync([1, 2, 3, 4]);
+
+        expect(await copyImageFileToClipboard(f), isFalse);
+        expect(called, isFalse);
+      });
     });
   });
 
@@ -102,6 +190,81 @@ void main() {
         saveImagePng(png, suggestedName: 'a.png'),
         throwsA(isA<FileSystemException>()),
       );
+    });
+  });
+
+  group('saveImageFile', () {
+    test('GIF → 建議檔名 .gif 且寫入原始 bytes', () async {
+      String? pickedName;
+      String? writtenPath;
+      Uint8List? writtenBytes;
+      imageSaveLocationPicker = (name) async {
+        pickedName = name;
+        return FileSaveLocation('${Directory.systemTemp.path}/out.gif');
+      };
+      imageFileWriter = (p, b) async {
+        writtenPath = p;
+        writtenBytes = b;
+      };
+      final dir = await Directory.systemTemp.createTemp('img_savef_');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
+      });
+      final f = File('${dir.path}/a.gif')..writeAsBytesSync(_gifBytes);
+
+      final path = await saveImageFile(f, suggestedBaseName: 'Hu Tao_Idle');
+
+      expect(pickedName, 'Hu Tao_Idle.gif');
+      expect(writtenBytes, _gifBytes);
+      expect(path, writtenPath);
+    });
+
+    testWidgets('非 GIF → 建議檔名 .png', (tester) async {
+      await tester.runAsync(() async {
+        String? pickedName;
+        imageSaveLocationPicker = (name) async {
+          pickedName = name;
+          return FileSaveLocation('${Directory.systemTemp.path}/out.png');
+        };
+        imageFileWriter = (p, b) async {};
+        final dir = await Directory.systemTemp.createTemp('img_savef_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/a.png')..writeAsBytesSync(await _makePng());
+
+        await saveImageFile(f, suggestedBaseName: 'X_Card');
+
+        expect(pickedName, 'X_Card.png');
+      });
+    });
+
+    testWidgets('壞檔 → throw（準備失敗）', (tester) async {
+      await tester.runAsync(() async {
+        imageSaveLocationPicker = (name) async =>
+            FileSaveLocation('${Directory.systemTemp.path}/out.png');
+        final dir = await Directory.systemTemp.createTemp('img_savef_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/g.bin')..writeAsBytesSync([1, 2, 3, 4]);
+
+        await expectLater(
+          saveImageFile(f, suggestedBaseName: 'X'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    test('使用者取消 → null', () async {
+      imageSaveLocationPicker = (name) async => null;
+      final dir = await Directory.systemTemp.createTemp('img_savef_');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
+      });
+      final f = File('${dir.path}/a.gif')..writeAsBytesSync(_gifBytes);
+
+      expect(await saveImageFile(f, suggestedBaseName: 'X'), isNull);
     });
   });
 }

--- a/test/services/image_clipboard_save_test.dart
+++ b/test/services/image_clipboard_save_test.dart
@@ -87,7 +87,7 @@ void main() {
   group('copyImagePngToClipboard', () {
     test('seam 回 true → true（isGif=false）', () async {
       bool? capturedIsGif;
-      imageClipboardWriter = (b, {required isGif}) async {
+      imageClipboardWriter = (b, {required isGif, filePath}) async {
         capturedIsGif = isGif;
         return true;
       };
@@ -96,24 +96,26 @@ void main() {
     });
 
     test('seam 回 false → false', () async {
-      imageClipboardWriter = (b, {required isGif}) async => false;
+      imageClipboardWriter = (b, {required isGif, filePath}) async => false;
       expect(await copyImagePngToClipboard(png), isFalse);
     });
 
     test('seam 拋例外 → false', () async {
-      imageClipboardWriter = (b, {required isGif}) async =>
+      imageClipboardWriter = (b, {required isGif, filePath}) async =>
           throw Exception('x');
       expect(await copyImagePngToClipboard(png), isFalse);
     });
   });
 
   group('copyImageFileToClipboard', () {
-    test('GIF → 以 isGif=true、原始 bytes 寫剪貼簿', () async {
+    test('GIF → 以 isGif=true、原始 bytes、實體檔路徑寫剪貼簿', () async {
       bool? capturedIsGif;
       Uint8List? capturedBytes;
-      imageClipboardWriter = (b, {required isGif}) async {
+      String? capturedFilePath;
+      imageClipboardWriter = (b, {required isGif, filePath}) async {
         capturedIsGif = isGif;
         capturedBytes = b;
+        capturedFilePath = filePath;
         return true;
       };
       final dir = await Directory.systemTemp.createTemp('img_copy_');
@@ -125,13 +127,18 @@ void main() {
       expect(await copyImageFileToClipboard(f), isTrue);
       expect(capturedIsGif, isTrue);
       expect(capturedBytes, _gifBytes);
+      expect(capturedFilePath, f.path);
     });
 
-    testWidgets('非 GIF → 以 isGif=false（PNG）寫剪貼簿', (tester) async {
+    testWidgets('非 GIF → 以 isGif=false（PNG）、無實體檔路徑寫剪貼簿', (tester) async {
       await tester.runAsync(() async {
         bool? capturedIsGif;
-        imageClipboardWriter = (b, {required isGif}) async {
+        String? capturedFilePath;
+        var filePathWasSet = false;
+        imageClipboardWriter = (b, {required isGif, filePath}) async {
           capturedIsGif = isGif;
+          capturedFilePath = filePath;
+          filePathWasSet = true;
           return true;
         };
         final dir = await Directory.systemTemp.createTemp('img_copy_');
@@ -142,13 +149,15 @@ void main() {
 
         expect(await copyImageFileToClipboard(f), isTrue);
         expect(capturedIsGif, isFalse);
+        expect(filePathWasSet, isTrue);
+        expect(capturedFilePath, isNull);
       });
     });
 
     testWidgets('壞檔 → false（不呼叫 seam）', (tester) async {
       await tester.runAsync(() async {
         var called = false;
-        imageClipboardWriter = (b, {required isGif}) async {
+        imageClipboardWriter = (b, {required isGif, filePath}) async {
           called = true;
           return true;
         };

--- a/test/services/image_clipboard_save_test.dart
+++ b/test/services/image_clipboard_save_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
+
+void main() {
+  final png = Uint8List.fromList([1, 2, 3, 4]);
+
+  tearDown(resetImageClipboardSaveSeams);
+
+  group('encodeImageFileToPng', () {
+    testWidgets('合法 PNG 檔 → 非 null PNG bytes', (tester) async {
+      await tester.runAsync(() async {
+        // 用引擎自身產生一張合法 PNG，避免硬編碼 byte array 不合法。
+        final recorder = ui.PictureRecorder();
+        ui.Canvas(recorder).drawRect(
+          const ui.Rect.fromLTWH(0, 0, 2, 2),
+          ui.Paint()..color = const ui.Color(0xFFFF0000),
+        );
+        final image = await recorder.endRecording().toImage(2, 2);
+        final pngData = await image.toByteData(format: ui.ImageByteFormat.png);
+        image.dispose();
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final f = File('${dir.path}/a.png')
+          ..writeAsBytesSync(pngData!.buffer.asUint8List());
+        final out = await encodeImageFileToPng(f);
+        expect(out, isNotNull);
+        expect(out!.isNotEmpty, isTrue);
+      });
+    });
+
+    testWidgets('不存在的檔 → null', (tester) async {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final missing = File('${dir.path}/missing.png');
+        expect(await encodeImageFileToPng(missing), isNull);
+      });
+    });
+
+    testWidgets('壞檔（非圖片）→ null', (tester) async {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('img_save_enc_');
+        addTearDown(() async {
+          if (await dir.exists()) await dir.delete(recursive: true);
+        });
+        final garbage = File('${dir.path}/g.png')
+          ..writeAsBytesSync([1, 2, 3, 4]);
+        expect(await encodeImageFileToPng(garbage), isNull);
+      });
+    });
+  });
+
+  group('copyImagePngToClipboard', () {
+    test('seam 回 true → true', () async {
+      imageClipboardWriter = (b) async => true;
+      expect(await copyImagePngToClipboard(png), isTrue);
+    });
+
+    test('seam 回 false → false', () async {
+      imageClipboardWriter = (b) async => false;
+      expect(await copyImagePngToClipboard(png), isFalse);
+    });
+
+    test('seam 拋例外 → false', () async {
+      imageClipboardWriter = (b) async => throw Exception('boom');
+      expect(await copyImagePngToClipboard(png), isFalse);
+    });
+  });
+
+  group('saveImagePng', () {
+    test('選了路徑並寫檔成功 → 回實際路徑', () async {
+      final tmp = '${Directory.systemTemp.path}/img_save_out.png';
+      addTearDown(() async {
+        final f = File(tmp);
+        if (await f.exists()) await f.delete();
+      });
+      imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+      final path = await saveImagePng(png, suggestedName: 'a.png');
+      expect(path, tmp);
+      expect(await File(tmp).readAsBytes(), png);
+    });
+
+    test('使用者取消 → null', () async {
+      imageSaveLocationPicker = (name) async => null;
+      expect(await saveImagePng(png, suggestedName: 'a.png'), isNull);
+    });
+
+    test('寫檔失敗 → rethrow', () async {
+      imageSaveLocationPicker = (name) async => FileSaveLocation('/x/y.png');
+      imageFileWriter = (p, b) async =>
+          throw const FileSystemException('write fail');
+      await expectLater(
+        saveImagePng(png, suggestedName: 'a.png'),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+  });
+}

--- a/test/services/share_image_export_test.dart
+++ b/test/services/share_image_export_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('使用者選了路徑 + 剪貼簿成功 → saved', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_a.png';
     imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    imageClipboardWriter = (bytes, {required isGif}) async => true;
+    imageClipboardWriter = (bytes, {required isGif, filePath}) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -26,7 +26,7 @@ void main() {
 
   test('使用者取消存檔但剪貼簿成功 → copiedOnly', () async {
     imageSaveLocationPicker = (name) async => null;
-    imageClipboardWriter = (bytes, {required isGif}) async => true;
+    imageClipboardWriter = (bytes, {required isGif, filePath}) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -37,7 +37,7 @@ void main() {
   test('剪貼簿不支援但存檔成功 → savedOnly', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_b.png';
     imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    imageClipboardWriter = (bytes, {required isGif}) async => false;
+    imageClipboardWriter = (bytes, {required isGif, filePath}) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'b.png');
 
@@ -47,7 +47,7 @@ void main() {
 
   test('剪貼簿不支援 + 使用者取消存檔 → copiedOnly', () async {
     imageSaveLocationPicker = (name) async => null;
-    imageClipboardWriter = (bytes, {required isGif}) async => false;
+    imageClipboardWriter = (bytes, {required isGif, filePath}) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -56,7 +56,7 @@ void main() {
   });
 
   test('存檔失敗 → rethrow', () async {
-    imageClipboardWriter = (bytes, {required isGif}) async => true;
+    imageClipboardWriter = (bytes, {required isGif, filePath}) async => true;
     imageSaveLocationPicker = (name) async =>
         FileSaveLocation('${Directory.systemTemp.path}/share_fail.png');
     imageFileWriter = (path, png) async =>

--- a/test/services/share_image_export_test.dart
+++ b/test/services/share_image_export_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('使用者選了路徑 + 剪貼簿成功 → saved', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_a.png';
     imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    imageClipboardWriter = (bytes) async => true;
+    imageClipboardWriter = (bytes, {required isGif}) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -26,7 +26,7 @@ void main() {
 
   test('使用者取消存檔但剪貼簿成功 → copiedOnly', () async {
     imageSaveLocationPicker = (name) async => null;
-    imageClipboardWriter = (bytes) async => true;
+    imageClipboardWriter = (bytes, {required isGif}) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -37,7 +37,7 @@ void main() {
   test('剪貼簿不支援但存檔成功 → savedOnly', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_b.png';
     imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    imageClipboardWriter = (bytes) async => false;
+    imageClipboardWriter = (bytes, {required isGif}) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'b.png');
 
@@ -47,7 +47,7 @@ void main() {
 
   test('剪貼簿不支援 + 使用者取消存檔 → copiedOnly', () async {
     imageSaveLocationPicker = (name) async => null;
-    imageClipboardWriter = (bytes) async => false;
+    imageClipboardWriter = (bytes, {required isGif}) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -56,7 +56,7 @@ void main() {
   });
 
   test('存檔失敗 → rethrow', () async {
-    imageClipboardWriter = (bytes) async => true;
+    imageClipboardWriter = (bytes, {required isGif}) async => true;
     imageSaveLocationPicker = (name) async =>
         FileSaveLocation('${Directory.systemTemp.path}/share_fail.png');
     imageFileWriter = (path, png) async =>

--- a/test/services/share_image_export_test.dart
+++ b/test/services/share_image_export_test.dart
@@ -3,17 +3,18 @@ import 'dart:typed_data';
 
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/services/image_clipboard_save.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/share_image_export.dart';
 
 void main() {
   final png = Uint8List.fromList([1, 2, 3, 4]);
 
-  tearDown(resetShareImageExportSeams);
+  tearDown(resetImageClipboardSaveSeams);
 
   test('使用者選了路徑 + 剪貼簿成功 → saved', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_a.png';
-    shareSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    shareClipboardWriter = (bytes) async => true;
+    imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+    imageClipboardWriter = (bytes) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -24,8 +25,8 @@ void main() {
   });
 
   test('使用者取消存檔但剪貼簿成功 → copiedOnly', () async {
-    shareSaveLocationPicker = (name) async => null;
-    shareClipboardWriter = (bytes) async => true;
+    imageSaveLocationPicker = (name) async => null;
+    imageClipboardWriter = (bytes) async => true;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
@@ -35,8 +36,8 @@ void main() {
 
   test('剪貼簿不支援但存檔成功 → savedOnly', () async {
     final tmp = '${Directory.systemTemp.path}/share_test_b.png';
-    shareSaveLocationPicker = (name) async => FileSaveLocation(tmp);
-    shareClipboardWriter = (bytes) async => false;
+    imageSaveLocationPicker = (name) async => FileSaveLocation(tmp);
+    imageClipboardWriter = (bytes) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'b.png');
 
@@ -44,13 +45,26 @@ void main() {
     await File(tmp).delete();
   });
 
-  test('剪貼簿失敗 + 使用者取消存檔 → copiedOnly', () async {
-    shareSaveLocationPicker = (name) async => null;
-    shareClipboardWriter = (bytes) async => false;
+  test('剪貼簿不支援 + 使用者取消存檔 → copiedOnly', () async {
+    imageSaveLocationPicker = (name) async => null;
+    imageClipboardWriter = (bytes) async => false;
 
     final r = await exportShareImage(png, suggestedName: 'a.png');
 
     expect(r.status, ShareExportStatus.copiedOnly);
     expect(r.path, isNull);
+  });
+
+  test('存檔失敗 → rethrow', () async {
+    imageClipboardWriter = (bytes) async => true;
+    imageSaveLocationPicker = (name) async =>
+        FileSaveLocation('${Directory.systemTemp.path}/share_fail.png');
+    imageFileWriter = (path, png) async =>
+        throw const FileSystemException('disk full');
+
+    await expectLater(
+      exportShareImage(png, suggestedName: 'a.png'),
+      throwsA(isA<FileSystemException>()),
+    );
   });
 }

--- a/test/widgets/dialogs/dialog_toast_test.dart
+++ b/test/widgets/dialogs/dialog_toast_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/dialog_toast.dart';
+
+void main() {
+  testWidgets('toast 顯示訊息並在停留後自動消失', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () => showDialogToast(ctx, 'hello toast'),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('go'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250)); // 淡入完成
+    expect(find.text('hello toast'), findsOneWidget);
+
+    // 停留 2200ms + 淡出 200ms 後移除。
+    await tester.pump(const Duration(milliseconds: 2200));
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    expect(find.text('hello toast'), findsNothing);
+  });
+
+  testWidgets('toast 可從 dialog 內叫出（疊在 dialog 之上）', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: ctx,
+                builder: (dctx) => AlertDialog(
+                  content: ElevatedButton(
+                    onPressed: () => showDialogToast(dctx, 'over dialog'),
+                    child: const Text('toast'),
+                  ),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('toast'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    // 在 dialog（modal barrier）之上仍可見：證明用 overlay 而非 app Scaffold 的
+    // SnackBar（後者會被 barrier 蓋住）。
+    expect(find.text('over dialog'), findsOneWidget);
+
+    // 清掉 toast 計時器，避免 timer pending。
+    await tester.pump(const Duration(milliseconds: 2200));
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+  });
+
+  testWidgets('連續兩次 toast：先前的被移除，只剩最新一則', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Column(
+              children: [
+                ElevatedButton(
+                  onPressed: () => showDialogToast(ctx, 'first'),
+                  child: const Text('a'),
+                ),
+                ElevatedButton(
+                  onPressed: () => showDialogToast(ctx, 'second'),
+                  child: const Text('b'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('a'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(find.text('first'), findsOneWidget);
+
+    await tester.tap(find.text('b'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(find.text('first'), findsNothing);
+    expect(find.text('second'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 2200));
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+  });
+}

--- a/test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart
+++ b/test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -280,5 +281,153 @@ void main() {
     });
     await tester.pump();
     expect(tester.takeException(), isNull);
+  });
+
+  group('圖片選單 + 右鍵 + 重抓', () {
+    /// 在 dialog 內定位中央 gallery 主圖（cache 檔名含 _gallery_）。
+    Finder galleryMainImage() => find.byWidgetPredicate(
+      (w) =>
+          w is Image &&
+          w.image is FileImage &&
+          (w.image as FileImage).file.path.contains('_gallery_'),
+    );
+
+    /// 預先建立某 gallery URL 的 cache 檔（4-byte PNG magic），讓對應 chip 在
+    /// build() 時即同步判定為 _GalleryReady，不依賴 lazy fetch 時序。
+    Future<void> touchGallery(String url) async {
+      final f = hoyowikiGalleryCacheFile(baseDir: tempDir, id: 'x1', url: url);
+      await f.writeAsBytes([0x89, 0x50, 0x4E, 0x47]);
+    }
+
+    /// 建立 container + 植入 entry + 預先建好 icon 與兩張 gallery cache 檔，
+    /// 讓 dialog 一開即三個 chip 全部同步 ready。
+    Future<ProviderContainer> seedAllReady(
+      WidgetTester tester,
+      _FakeFetcher fetcher,
+    ) async {
+      late ProviderContainer c;
+      await tester.runAsync(() async {
+        c = await setupContainer(fetcher, tempDir);
+        addTearDown(c.dispose);
+        await seedEntry(c);
+        await _touchIcon(tempDir, 'x1');
+        await touchGallery('https://cdn/x1_g1.gif');
+        await touchGallery('https://cdn/x1_pic.png');
+      });
+      return c;
+    }
+
+    testWidgets('ready 圖片右上角有溢出選單鈕', (tester) async {
+      final fetcher = _FakeFetcher(
+        behaviorFor: (url, n) async =>
+            Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+      final c = await seedAllReady(tester, fetcher);
+
+      await pumpDialogAndSettle(tester, c, _rec());
+
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+    });
+
+    testWidgets('點選單鈕 → 顯示複製/儲存/重抓三項', (tester) async {
+      final fetcher = _FakeFetcher(
+        behaviorFor: (url, n) async =>
+            Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+      final c = await seedAllReady(tester, fetcher);
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(l.actionCopyImage), findsOneWidget);
+      expect(find.text(l.actionSaveImage), findsOneWidget);
+      expect(find.text(l.actionRefetchImage), findsOneWidget);
+    });
+
+    testWidgets('右鍵圖片 → 叫出選單', (tester) async {
+      final fetcher = _FakeFetcher(
+        behaviorFor: (url, n) async =>
+            Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+      final c = await seedAllReady(tester, fetcher);
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      await tester.tap(galleryMainImage().first, buttons: kSecondaryButton);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(l.actionCopyImage), findsOneWidget);
+      expect(find.text(l.actionRefetchImage), findsOneWidget);
+    });
+
+    testWidgets('選「重抓圖片」(gallery) → 對該圖 URL 觸發 fetch', (tester) async {
+      final fetcher = _FakeFetcher(
+        behaviorFor: (url, n) async =>
+            Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+      final c = await seedAllReady(tester, fetcher);
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      // 預先建檔 → 開 dialog 不觸發 lazy fetch。
+      expect(fetcher._calls['https://cdn/x1_g1.gif'], isNull);
+
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text(l.actionRefetchImage));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fetcher._calls['https://cdn/x1_g1.gif'], 1);
+    });
+
+    testWidgets('切到 Icon chip 後重抓 → 對 icon URL 觸發 fetch', (tester) async {
+      final fetcher = _FakeFetcher(
+        behaviorFor: (url, n) async =>
+            Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+      final c = await seedAllReady(tester, fetcher);
+
+      await pumpDialogAndSettle(tester, c, _rec());
+      final l = AppLocalizations.of(
+        tester.element(find.byType(GachaItemDetailDialog)),
+      )!;
+
+      await tester.tap(find.text(l.galleryIconLabel));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(fetcher._calls['https://cdn/x1_icon.png'], isNull);
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text(l.actionRefetchImage));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fetcher._calls['https://cdn/x1_icon.png'], 1);
+    });
   });
 }


### PR DESCRIPTION
## 概要

在物品詳情 dialog（`GachaItemDetailDialog`）中央圖片右上角新增溢出選單，並支援在圖片上按右鍵叫出同一份選單，提供三項操作：

- **複製圖片**：複製到系統剪貼簿。
- **儲存圖片**：開啟系統存檔對話框存成檔案。
- **重抓圖片**：重新下載目前圖片並覆寫快取（icon 重抓會同步更新標題縮圖與記錄列表）。

做法對齊姊妹專案 `wuthering-waves-convene-gacha-analyzer`。

## 主要變更

- **新增共用低階層** `lib/services/image_clipboard_save.dart`：剪貼簿寫入／存檔位置選擇器／檔案寫入三個可測 seam，以及 `prepareOutputImage` / `copyImageFileToClipboard` / `saveImageFile`（與分享圖共用的 `copyImagePngToClipboard` / `saveImagePng`）。
- **重構** `lib/services/share_image_export.dart` 改為複用上述共用 seam，消除重複 primitive（對外行為不變）。
- **dialog 改造** `gacha_item_detail_dialog.dart`：`_GalleryReady` 圖片區改 `Stack` 疊上右上角 `PopupMenuButton`，`GestureDetector` 加 `onSecondaryTapDown` 用 `showMenu` 叫出同一選單；失敗狀態的「重試」與選單「重抓」共用 `_refetchEntry`。
- **新增 overlay toast** `lib/widgets/dialogs/dialog_toast.dart`：操作結果回報改用疊在 dialog 之上的 toast（原本的 SnackBar 由 app 層 Scaffold 繪製，會被 dialog 的 modal barrier 蓋住）。
- **GIF 保真**：GIF 的複製／儲存保留原始格式（依 magic bytes 判斷），不再一律轉 PNG 丟失動畫——儲存為 `.gif`、複製額外掛上實體檔路徑（Windows `CF_HDROP`），讓 Discord／檔案總管等以「檔案」貼上的目標取得真正的動圖；其餘格式（webp／jpg）維持轉 PNG 以利相容性。
- **i18n**：新增 `actionCopyImage` / `actionSaveImage` / `actionRefetchImage` / `imageCopied` / `imageCopyFailed` / `imageSaveFailed` / `imageSavedTo`（`app_zh.arb` + `app_en.arb`）。

## 設計／計畫文件

- Spec：`docs/superpowers/specs/2026-06-08-item-detail-image-menu-design.md`
- Plan：`docs/superpowers/plans/2026-06-08-item-detail-image-menu.md`

## 測試

- `fvm dart format lib/ test/`：無變動
- `fvm flutter analyze`：No issues found!
- `fvm flutter test`：**880 passed**（含 service 層 copy／save／GIF 各情境、dialog 選單／右鍵／重抓、toast 行為等新增測試）

## 已知限制

貼到「只吃圖片」的程式（小畫家等）時，GIF 會退化為靜態第一幀——這是 Windows 剪貼簿圖片本質為單張點陣圖的限制，無法避免。以「檔案」接收的目標（Discord 等）則保留動畫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)