### PR TITLE
feat(import): merge data on import instead of overwriting

### DIFF
--- a/docs/superpowers/plans/2026-06-09-import-merge.md
+++ b/docs/superpowers/plans/2026-06-09-import-merge.md
@@ -1,0 +1,1030 @@
+# Import Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把「匯入全部資料」從整帳號覆蓋改為非破壞性合併——依 `GachaRecord.id` union 去重、永不丟本機資料、偏好只補空缺、放寬確認流程、回報新增/已存在筆數。
+
+**Architecture:** 新增純函式合併原語 `BannerStorage.mergeWith`（記錄級 helper `_mergeRecordsById`）；`_runImport` 改成「本機沒有 → 直接存、已有 → mergeWith 後存」並統計 added/duplicate；`ImportResult` 改欄位；確認流程抽取既有內聯 confirm 成共用 `showConfirmDialog`（不重造輪子），picker badge 與文案改合併語意。
+
+**Tech Stack:** Flutter / Dart、Riverpod、`flutter gen-l10n`（ARB 多語）、`flutter_test`。一律優先用 `fvm`（找不到再退回 `flutter`／`dart`）。
+
+**規格依據：** `docs/superpowers/specs/2026-06-09-import-merge-design.md`。**分支：** `feat/import-merge`（已建立）。
+
+---
+
+## File Structure
+
+| 檔案 | 角色 |
+|------|------|
+| `lib/models/banner_storage.dart` | 新增合併原語 `mergeWith` + `static _mergeRecordsById` |
+| `test/models/banner_storage_test.dart` | **新建**：`mergeWith` 單元測試 |
+| `lib/state/update_progress.dart` | `ImportResult` 欄位：`addedRecords`/`duplicateRecords`（移除 `totalRecords`） |
+| `lib/state/gacha_repository.dart` | `_runImport` 合併邏輯＋計數＋偏好只補空缺＋兩處 log；`importAccountsAndFetchHoYoWiki` log 改欄位 |
+| `lib/widgets/update_progress_dialog.dart` | 完成摘要改新欄位／新 `progressDoneImportSummary` 簽名 |
+| `lib/widgets/dialogs/confirm_dialog.dart` | 新增無打字 `showConfirmDialog`（`isDanger` 參數） |
+| `lib/widgets/dialogs/accounts_picker_dialog.dart` | `_PickerRow` badge 改中性色 |
+| `lib/pages/settings_page.dart` | `_import` 改合併語意＋用 `showConfirmDialog`；`_clearGallery`／`_refetchAll` 改用共用 helper |
+| `lib/l10n/app_*.arb`（9 個已翻譯語系） | 新增/改寫/刪除 key（見各 Task） |
+| 既有測試 | `test/state/gacha_repository_test.dart`、`test/state/gacha_repository_import_with_hoyowiki_test.dart`、`test/widgets/dialogs/accounts_picker_dialog_test.dart`、`test/widgets/dialogs/confirm_dialog_test.dart` 改新語意 |
+
+**已翻譯語系（其餘 22 個 ARB 為 Crowdin 空殼，不動）：** `app_zh.arb`(template)、`app_en.arb`、`app_es.arb`、`app_fr.arb`、`app_ja.arb`、`app_pt_BR.arb`、`app_th.arb`、`app_vi.arb`、`app_zh_Hans.arb`。
+
+---
+
+## Task 1: `BannerStorage.mergeWith` 合併原語
+
+**Files:**
+- Modify: `lib/models/banner_storage.dart`
+- Test: `test/models/banner_storage_test.dart`（新建）
+
+- [ ] **Step 1: 寫失敗測試**
+
+建立 `test/models/banner_storage_test.dart`：
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+
+GachaRecord _r(String id, {String lang = 'zh-tw'}) => GachaRecord(
+  id: id,
+  uid: '100000001',
+  gachaType: '301',
+  name: 'x',
+  itemType: '武器',
+  rankType: 3,
+  time: DateTime.utc(2025, 1, 1),
+  lang: lang,
+);
+
+BannerStorage _s(
+  Map<String, List<GachaRecord>> banners, {
+  DateTime? lastUpdated,
+}) => BannerStorage(
+  uid: '100000001',
+  lastUpdated: lastUpdated ?? DateTime.utc(2026, 1, 1),
+  banners: banners,
+);
+
+void main() {
+  test('union by id, dedup, sorted desc', () {
+    final local = _s({
+      '301': [_r('3'), _r('1')],
+    });
+    final incoming = _s({
+      '301': [_r('2'), _r('1')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.map((r) => r.id).toList(), ['3', '2', '1']);
+  });
+
+  test('banner keys are unioned', () {
+    final local = _s({
+      '301': [_r('1')],
+    });
+    final incoming = _s({
+      '302': [_r('2')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners.keys.toSet(), {'301', '302'});
+    expect(merged.banners['301']!.single.id, '1');
+    expect(merged.banners['302']!.single.id, '2');
+  });
+
+  test('lastUpdated takes the newer of the two', () {
+    final local = _s({'301': []}, lastUpdated: DateTime.utc(2026, 1, 1));
+    final incoming = _s({'301': []}, lastUpdated: DateTime.utc(2026, 5, 12));
+    expect(local.mergeWith(incoming).lastUpdated, DateTime.utc(2026, 5, 12));
+    expect(incoming.mergeWith(local).lastUpdated, DateTime.utc(2026, 5, 12));
+  });
+
+  test('same id: keep local, but backfill empty local lang from incoming', () {
+    final local = _s({
+      '301': [_r('1', lang: '')],
+    });
+    final incoming = _s({
+      '301': [_r('1', lang: 'en-us')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.single.lang, 'en-us');
+  });
+
+  test('same id: non-empty local lang is NOT overwritten by incoming', () {
+    final local = _s({
+      '301': [_r('1', lang: 'zh-tw')],
+    });
+    final incoming = _s({
+      '301': [_r('1', lang: 'en-us')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.single.lang, 'zh-tw');
+  });
+
+  test('empty local merges to incoming content', () {
+    final local = _s({});
+    final incoming = _s({
+      '301': [_r('2'), _r('1')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.map((r) => r.id).toList(), ['2', '1']);
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/models/banner_storage_test.dart`
+Expected: FAIL（`mergeWith` 未定義 → 編譯錯誤）。
+
+- [ ] **Step 3: 實作 `mergeWith` + `_mergeRecordsById`**
+
+在 `lib/models/banner_storage.dart`，於 `copyWith`（約第 51-58 行）之後、`allRecords` getter 之前，新增：
+
+```dart
+  /// 將 [incoming]（同一 UID 的另一份存檔）合併進本份，回傳新的 [BannerStorage]。
+  ///
+  /// 逐 banner 依 [GachaRecord.id] union 去重後降序排序；本機既有記錄一律保留，
+  /// 同 id 時保留本機那筆（若本機 lang 為空、[incoming] 非空則回填 lang）。
+  /// [lastUpdated] 取兩者較新者。
+  BannerStorage mergeWith(BannerStorage incoming) {
+    final keys = {...banners.keys, ...incoming.banners.keys};
+    final mergedBanners = <String, List<GachaRecord>>{
+      for (final key in keys)
+        key: _mergeRecordsById(
+          banners[key] ?? const [],
+          incoming.banners[key] ?? const [],
+        ),
+    };
+    final newer = incoming.lastUpdated.isAfter(lastUpdated)
+        ? incoming.lastUpdated
+        : lastUpdated;
+    return BannerStorage(uid: uid, lastUpdated: newer, banners: mergedBanners);
+  }
+
+  /// 合併兩條同 banner 的記錄：依 id union 去重（同 id 保留 [local]，必要時以
+  /// [incoming] 的非空 lang 回填）→ 依 id 降序排序（id 等長 19 碼，字典序＝數值序）。
+  static List<GachaRecord> _mergeRecordsById(
+    List<GachaRecord> local,
+    List<GachaRecord> incoming,
+  ) {
+    final byId = <String, GachaRecord>{};
+    for (final r in local) {
+      byId[r.id] = r;
+    }
+    for (final r in incoming) {
+      final existing = byId[r.id];
+      if (existing == null) {
+        byId[r.id] = r;
+      } else if (existing.lang.isEmpty && r.lang.isNotEmpty) {
+        byId[r.id] = existing.copyWith(lang: r.lang);
+      }
+    }
+    return byId.values.toList()..sort((a, b) => b.id.compareTo(a.id));
+  }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/models/banner_storage_test.dart`
+Expected: PASS（6 個 test 全綠）。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add lib/models/banner_storage.dart test/models/banner_storage_test.dart
+git commit -m "feat(import): add BannerStorage.mergeWith union-by-id primitive"
+```
+
+---
+
+## Task 2: `_runImport` 合併邏輯 + `ImportResult` 欄位
+
+把覆蓋改成合併、統計 added/duplicate、偏好只補空缺、active 保留本機，並改 `ImportResult` 欄位與下游摘要／log。此 Task 因欄位耦合需一次改到綠。
+
+**Files:**
+- Modify: `lib/state/update_progress.dart`（`ImportResult`）
+- Modify: `lib/state/gacha_repository.dart`（`_runImport`、`importAccountsAndFetchHoYoWiki` log）
+- Modify: `lib/widgets/update_progress_dialog.dart`（摘要呼叫）
+- Modify: `lib/l10n/app_zh.arb` + 其餘 8 個已翻譯語系（`progressDoneImportSummary`）
+- Test: `test/state/gacha_repository_test.dart`、`test/state/gacha_repository_import_with_hoyowiki_test.dart`
+
+- [ ] **Step 1: 改 `ImportResult` 欄位**
+
+`lib/state/update_progress.dart`，把 `ImportResult`（約 49-65 行）整段改為：
+
+```dart
+/// 帳號批次匯入的結果摘要。
+class ImportResult {
+  /// 建立 [ImportResult]。
+  const ImportResult({
+    required this.successAccounts,
+    required this.addedRecords,
+    required this.duplicateRecords,
+    required this.failedUids,
+  });
+
+  /// 成功匯入的帳號數。
+  final int successAccounts;
+
+  /// 合併後新增的記錄數（備份中 id 本機原本沒有的）。
+  final int addedRecords;
+
+  /// 合併時已存在而略過的記錄數（備份中 id 本機原本就有的）。
+  final int duplicateRecords;
+
+  /// 匯入失敗的 UID 列表。
+  final List<String> failedUids;
+}
+```
+
+- [ ] **Step 2: 改寫 `_runImport` 的合併迴圈與計數**
+
+`lib/state/gacha_repository.dart`，把 `_runImport` 開頭到帳號迴圈結束（約 665-692 行）改為：
+
+```dart
+  Future<ImportResult> _runImport(AccountsBundle bundle) async {
+    final storage = ref.read(gachaStorageProvider);
+    final settingsNotifier = ref.read(settingsProvider.notifier);
+
+    final newByUid = Map<String, BannerStorage>.from(state.byUid);
+    final failed = <String>[];
+    var addedRecords = 0;
+    var duplicateRecords = 0;
+    var successCount = 0;
+
+    for (final account in bundle.accounts) {
+      final incoming = account.data;
+      try {
+        final localBefore = newByUid[incoming.uid];
+        final toSave = localBefore == null
+            ? incoming
+            : localBefore.mergeWith(incoming);
+        await storage.save(toSave);
+        if (!ref.mounted) {
+          return ImportResult(
+            successAccounts: successCount,
+            addedRecords: addedRecords,
+            duplicateRecords: duplicateRecords,
+            failedUids: failed,
+          );
+        }
+        final added =
+            toSave.allRecords.length - (localBefore?.allRecords.length ?? 0);
+        addedRecords += added;
+        duplicateRecords += incoming.allRecords.length - added;
+        newByUid[incoming.uid] = toSave;
+        successCount++;
+      } catch (_) {
+        failed.add(incoming.uid);
+      }
+    }
+```
+
+- [ ] **Step 3: 改別名為「只補空缺」**
+
+同檔，把別名段（約 694-704 行）改為：
+
+```dart
+    final currentSettings = ref.read(settingsProvider);
+    final mergedAliases = Map<String, String>.from(currentSettings.uidAliases);
+    for (final account in bundle.accounts) {
+      final uid = account.data.uid;
+      if (failed.contains(uid)) continue;
+      if (mergedAliases.containsKey(uid)) continue; // 本機已有別名 → 保留
+      final a = account.alias?.trim();
+      if (a != null && a.isNotEmpty) {
+        mergedAliases[uid] = a;
+      }
+    }
+```
+
+- [ ] **Step 4: 改 `uidOrder` 為「本機不動、新 UID 接最後」**
+
+同檔，把排序段（約 706-714 行）改為：
+
+```dart
+    final localOrder = currentSettings.uidOrder;
+    final localSet = localOrder.toSet();
+    final appended = bundle.accounts
+        .where((a) => !failed.contains(a.data.uid))
+        .map((a) => a.data.uid)
+        .where((uid) => !localSet.contains(uid))
+        .toList(growable: false);
+    final newOrder = [...localOrder, ...appended];
+```
+
+- [ ] **Step 5: 改 active 為「保留本機優先」**
+
+同檔，把 active 計算段（約 716-726 行，`final desiredActive = ...` 到 `final newActive = ...`）改為：
+
+```dart
+    final localActive = state.activeUid;
+    final desiredActive = bundle.lastActiveUid;
+    final newActive =
+        (localActive != null && newByUid.containsKey(localActive))
+        ? localActive
+        : (desiredActive != null && newByUid.containsKey(desiredActive))
+        ? desiredActive
+        : (newByUid.isEmpty
+              ? null
+              : (newOrder.isEmpty ? newByUid.keys.first : newOrder.first));
+```
+
+- [ ] **Step 6: 改兩處 `ImportResult` 建構與收尾 log**
+
+同檔：
+
+1. `_runImport` 的 unmount 提前返回（約 733-739 行，在 `applyImportedPreferences` 之後）改為帶 `addedRecords`/`duplicateRecords`：
+
+```dart
+    if (!ref.mounted) {
+      return ImportResult(
+        successAccounts: successCount,
+        addedRecords: addedRecords,
+        duplicateRecords: duplicateRecords,
+        failedUids: failed,
+      );
+    }
+```
+
+2. 收尾 log（約 747-751 行）改為脫敏 + added/duplicate：
+
+```dart
+    _log.info(
+      'import: success=$successCount '
+      'failed=[${failed.map(sanitizeUid).join(",")}] '
+      'added=$addedRecords duplicate=$duplicateRecords',
+    );
+```
+
+3. 最終 return（約 752-756 行）改為：
+
+```dart
+    return ImportResult(
+      successAccounts: successCount,
+      addedRecords: addedRecords,
+      duplicateRecords: duplicateRecords,
+      failedUids: failed,
+    );
+```
+
+4. `importAccountsAndFetchHoYoWiki` 的 log（約 608-612 行）改為：
+
+```dart
+      _importLog.info(
+        'import done: success=${result.successAccounts} '
+        'failed=[${result.failedUids.map(sanitizeUid).join(",")}] '
+        'added=${result.addedRecords} duplicate=${result.duplicateRecords}',
+      );
+```
+
+- [ ] **Step 7: 改 `progressDoneImportSummary` ARB（9 語系）**
+
+`lib/l10n/app_zh.arb`（template），把 `progressDoneImportSummary`（約 164-171 行，含 `@` block）整段改為：
+
+```json
+  "progressDoneImportSummary": "已合併 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆",
+  "@progressDoneImportSummary": {
+    "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts merged, plus new vs already-present record counts.",
+    "placeholders": {
+      "accounts": { "type": "int" },
+      "added": { "type": "int" },
+      "duplicate": { "type": "int" }
+    }
+  },
+```
+
+其餘 8 個語系把 `progressDoneImportSummary` 的字串值改為下表（`app_en.arb` 連同其 `@` block 的 placeholders 一併補上 `added`/`duplicate`；其他語系僅改字串值即可，`@` block 非 template 不影響 codegen）：
+
+| 語系 | 值 |
+|------|----|
+| en | `{accounts, plural, =1{Merged 1 account} other{Merged {accounts} accounts}}: {added} new, {duplicate} already present` |
+| es | `{accounts, plural, =1{Se combinó 1 cuenta} other{Se combinaron {accounts} cuentas}}: {added} nuevos, {duplicate} ya existentes` |
+| fr | `{accounts, plural, =1{1 compte fusionné} other{{accounts} comptes fusionnés}} : {added} nouveaux, {duplicate} déjà présents` |
+| ja | `{accounts} 個のアカウントを結合しました：新規 {added} 件、既存 {duplicate} 件` |
+| pt_BR | `{accounts, plural, =1{1 conta mesclada} other{{accounts} contas mescladas}}: {added} novos, {duplicate} já existentes` |
+| th | `ผสาน {accounts} บัญชีแล้ว: ใหม่ {added} รายการ, มีอยู่แล้ว {duplicate} รายการ` |
+| vi | `Đã hợp nhất {accounts} tài khoản: {added} mới, {duplicate} đã có` |
+| zh_Hans | `已合并 {accounts} 个账号：新增 {added} 条、已存在 {duplicate} 条` |
+
+- [ ] **Step 8: 改完成對話框呼叫點**
+
+`lib/widgets/update_progress_dialog.dart`（約 233-239 行），把 `progressDoneImportSummary` 呼叫改為：
+
+```dart
+            if (importSummary != null)
+              Text(
+                l.progressDoneImportSummary(
+                  importSummary.successAccounts,
+                  importSummary.addedRecords,
+                  importSummary.duplicateRecords,
+                ),
+              )
+```
+
+- [ ] **Step 9: 重新產生 l10n**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`progressDoneImportSummary(int, int, int)` 生成於 `lib/l10n/generated/`。
+
+- [ ] **Step 10: 改既有 repo 測試到合併語意（先讓它們表達新預期 → 紅）**
+
+`test/state/gacha_repository_test.dart`：
+
+(a) 測試 `importAccounts: per-UID overwrite preserves non-imported accounts`（約 1047-1127 行）：
+- 改 test 名稱為 `importAccounts: merges into existing UID, preserves non-imported`。
+- 在 `SharedPreferences.setMockInitialValues`（約 1066-1068 行）補上 `uidOrder`、`lastActiveUid` 使結果決定性：
+
+```dart
+      SharedPreferences.setMockInitialValues({
+        'pref.uidAliases': jsonEncode({'100000003': '另一支'}),
+        'pref.uidOrder': jsonEncode(['100000001', '100000003']),
+        'pref.lastActiveUid': '100000001',
+      });
+```
+
+- 把註解「`// 100000001 overwritten`」改成「`// 100000001 merged: lastUpdated takes newer`」（斷言值 `DateTime.utc(2026, 5, 12)` 不變，因 max(2026-01-01, 2026-05-12)）。
+- 把 uidOrder 斷言（約 1124 行）改為完整新順序：
+
+```dart
+      expect(settings.uidOrder, ['100000001', '100000003', '100000002']);
+```
+
+(b) 測試 `importAccounts: uidOrder merges imported order first, then remaining`（約 1129-1193 行）：
+- 改名為 `importAccounts: uidOrder keeps local order, appends new UIDs`。
+- 把結尾斷言（約 1190-1191 行）改為：
+
+```dart
+      // local order [100000004, 100000001, 100000003] unchanged; new 100000002 appended
+      expect(order, ['100000004', '100000001', '100000003', '100000002']);
+```
+
+(c) 測試 `importAccounts: bundle lastActiveUid switches active to it when imported`（約 1258-1314 行）：
+- 改名為 `importAccounts: keeps local active when local active is valid`。
+- 把結尾兩個斷言（約 1311-1312 行）改為：
+
+```dart
+      expect(container.read(gachaRepositoryProvider).activeUid, '200000001');
+      expect(container.read(settingsProvider).lastActiveUid, '200000001');
+```
+
+(d) 在 (c) 之後新增一個互補測試（本機無 active → 採用備份 active），以及一個記錄級合併測試。貼在 (c) 的 `);` 之後：
+
+```dart
+  test(
+    'importAccounts: adopts bundle lastActiveUid when local has no active',
+    () async {
+      final storage = GachaStorage(tempDir);
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(
+              client: MockClient((_) async => http.Response('{}', 200)),
+              cancel: () {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(gachaRepositoryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final bundle = AccountsBundle(
+        exportedAt: DateTime.utc(2026, 5, 12),
+        appVersion: 'x',
+        lastActiveUid: '200000002',
+        accounts: [
+          ExportedAccount(
+            data: BannerStorage(
+              uid: '200000002',
+              lastUpdated: DateTime.utc(2026, 5, 12),
+              banners: const {'301': []},
+            ),
+          ),
+        ],
+      );
+
+      await container
+          .read(gachaRepositoryProvider.notifier)
+          .debugImportOnly(bundle);
+
+      expect(container.read(gachaRepositoryProvider).activeUid, '200000002');
+    },
+  );
+
+  test(
+    'importAccounts: merges records by id, never drops local, counts added/duplicate',
+    () async {
+      GachaRecord rec(String id) => GachaRecord(
+        id: id,
+        uid: '100000001',
+        gachaType: '301',
+        name: 'x',
+        itemType: '武器',
+        rankType: 3,
+        time: DateTime.utc(2025, 1, 1),
+        lang: 'zh-tw',
+      );
+
+      final storage = GachaStorage(tempDir);
+      await storage.save(
+        BannerStorage(
+          uid: '100000001',
+          lastUpdated: DateTime.utc(2026, 1, 1),
+          banners: {
+            '301': [rec('3'), rec('1')],
+          },
+        ),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(
+              client: MockClient((_) async => http.Response('{}', 200)),
+              cancel: () {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(gachaRepositoryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final bundle = AccountsBundle(
+        exportedAt: DateTime.utc(2026, 5, 12),
+        appVersion: 'x',
+        lastActiveUid: null,
+        accounts: [
+          ExportedAccount(
+            data: BannerStorage(
+              uid: '100000001',
+              lastUpdated: DateTime.utc(2026, 5, 12),
+              banners: {
+                '301': [rec('2'), rec('1')],
+              },
+            ),
+          ),
+        ],
+      );
+
+      final result = await container
+          .read(gachaRepositoryProvider.notifier)
+          .debugImportOnly(bundle);
+
+      expect(result.addedRecords, 1); // id 2 是新的
+      expect(result.duplicateRecords, 1); // id 1 已存在
+      final merged = container
+          .read(gachaRepositoryProvider)
+          .byUid['100000001']!
+          .banners['301']!
+          .map((r) => r.id)
+          .toList();
+      expect(merged, ['3', '2', '1']); // 本機 id 3 沒被丟、降序
+    },
+  );
+```
+
+> 注意：若 `GachaRecord` 未在此測試檔 import，於檔頭補 `import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';`。
+
+`test/state/gacha_repository_import_with_hoyowiki_test.dart`：
+- 把 `totalRecords` 斷言（約 184 行）改為：
+
+```dart
+    expect(completed.importSummary!.addedRecords, 2);
+    expect(completed.importSummary!.duplicateRecords, 0);
+```
+
+- 把空 bundle 的 `totalRecords` 斷言（約 230 行）改為：
+
+```dart
+    expect(completed.importSummary!.addedRecords, 0);
+    expect(completed.importSummary!.duplicateRecords, 0);
+```
+
+- [ ] **Step 11: 跑相關測試確認通過**
+
+Run: `fvm flutter test test/state/gacha_repository_test.dart test/state/gacha_repository_import_with_hoyowiki_test.dart`
+Expected: PASS（含新合併語意、新計數測試）。
+
+- [ ] **Step 12: commit**
+
+```bash
+git add lib/state/update_progress.dart lib/state/gacha_repository.dart lib/widgets/update_progress_dialog.dart lib/l10n/ test/state/gacha_repository_test.dart test/state/gacha_repository_import_with_hoyowiki_test.dart
+git commit -m "feat(import): merge records by id instead of overwriting account"
+```
+
+---
+
+## Task 3: 共用 `showConfirmDialog`（抽取既有內聯 confirm）
+
+`settings_page.dart` 的 `_clearGallery`／`_refetchAll` 已各自手寫無打字 confirm。抽成共用 helper（不重造輪子），新匯入確認也用它。
+
+**Files:**
+- Modify: `lib/widgets/dialogs/confirm_dialog.dart`（新增 `showConfirmDialog`）
+- Modify: `lib/pages/settings_page.dart`（`_clearGallery`、`_refetchAll` 改用）
+- Test: `test/widgets/dialogs/confirm_dialog_test.dart`
+
+- [ ] **Step 1: 寫失敗測試**
+
+`test/widgets/dialogs/confirm_dialog_test.dart`，在最後一個 `testWidgets` 之後、`main` 的結尾 `}` 之前插入：
+
+```dart
+  testWidgets('showConfirmDialog: confirm enabled immediately, returns true', (
+    tester,
+  ) async {
+    bool? confirmed;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  confirmed = await showConfirmDialog(
+                    context: ctx,
+                    title: 'Merge',
+                    body: 'About to merge',
+                    cancelLabel: 'Cancel',
+                    confirmLabel: 'Import',
+                    confirmIcon: Icons.check,
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    // 無 TextField；確認鍵一開始就 enabled
+    expect(find.byType(TextField), findsNothing);
+    final confirmBtn = find.widgetWithText(FilledButton, 'Import');
+    expect(tester.widget<FilledButton>(confirmBtn).onPressed, isNotNull);
+
+    await tester.tap(confirmBtn);
+    await tester.pumpAndSettle();
+    expect(confirmed, isTrue);
+  });
+
+  testWidgets('showConfirmDialog: cancel returns false', (tester) async {
+    bool? confirmed;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  confirmed = await showConfirmDialog(
+                    context: ctx,
+                    title: 'Merge',
+                    body: 'About to merge',
+                    cancelLabel: 'Cancel',
+                    confirmLabel: 'Import',
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(confirmed, isFalse);
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/dialogs/confirm_dialog_test.dart`
+Expected: FAIL（`showConfirmDialog` 未定義）。
+
+- [ ] **Step 3: 新增 `showConfirmDialog`**
+
+`lib/widgets/dialogs/confirm_dialog.dart`，在 `showConfirmTypeDialog` 函式（約 29 行結束）之後新增：
+
+```dart
+/// 顯示一個一般確認 dialog（無打字閘）。
+/// 回傳值：true = 確認 / false = 取消 / null = 系統 dismiss。
+/// [isDanger] 為 true 時確認鍵用 danger 紅；false 時用預設（中性）配色。
+Future<bool?> showConfirmDialog({
+  required BuildContext context,
+  required String title,
+  required String body,
+  required String cancelLabel,
+  required String confirmLabel,
+  IconData? confirmIcon,
+  bool isDanger = false,
+}) {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) {
+      final tokens = Theme.of(ctx).gacha;
+      return AppDialog(
+        title: Text(title),
+        content: Text(body),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(cancelLabel),
+          ),
+          FilledButton(
+            style: isDanger
+                ? FilledButton.styleFrom(
+                    backgroundColor: tokens.stateDanger,
+                    foregroundColor: Colors.white,
+                  )
+                : null,
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: confirmIcon == null
+                ? Text(confirmLabel)
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(confirmIcon, size: 18),
+                      const SizedBox(width: 8),
+                      Text(confirmLabel),
+                    ],
+                  ),
+          ),
+        ],
+      );
+    },
+  );
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/widgets/dialogs/confirm_dialog_test.dart`
+Expected: PASS（既有打字測試 + 2 個新測試）。
+
+- [ ] **Step 5: 把 `_clearGallery` 改用共用 helper**
+
+`lib/pages/settings_page.dart`，把 `_clearGallery` 內的 `showDialog<bool>(...)`（約 784-804 行）整段替換為：
+
+```dart
+    final ok = await showConfirmDialog(
+      context: ctx,
+      title: l.confirmClearGalleryCacheTitle,
+      body: l.confirmClearGalleryCacheBody(sizeText),
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmClearGalleryCacheConfirm,
+      isDanger: true,
+    );
+```
+
+- [ ] **Step 6: 把 `_refetchAll` 改用共用 helper**
+
+同檔，把 `_refetchAll` 內的 `showDialog<bool>(...)`（約 825-845 行）整段替換為：
+
+```dart
+    final ok = await showConfirmDialog(
+      context: ctx,
+      title: l.confirmRefetchHoyoWikiTitle,
+      body: l.confirmRefetchHoyoWikiBody,
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmRefetchHoyoWikiConfirm,
+      isDanger: true,
+    );
+```
+
+> 確認 `settings_page.dart` 已 import `confirm_dialog.dart`（既有 `showConfirmTypeDialog` 已在用，應已 import；若無則補）。
+
+- [ ] **Step 7: 跑分析 + 相關測試**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+Run: `fvm flutter test test/widgets/dialogs/confirm_dialog_test.dart`
+Expected: PASS
+
+- [ ] **Step 8: commit**
+
+```bash
+git add lib/widgets/dialogs/confirm_dialog.dart lib/pages/settings_page.dart test/widgets/dialogs/confirm_dialog_test.dart
+git commit -m "refactor(dialogs): extract shared showConfirmDialog from inline confirms"
+```
+
+---
+
+## Task 4: `_import` 改合併語意 + picker badge 中性化 + ARB
+
+**Files:**
+- Modify: `lib/pages/settings_page.dart`（`_import`）
+- Modify: `lib/widgets/dialogs/accounts_picker_dialog.dart`（`_PickerRow` badge 色）
+- Modify: `lib/l10n/app_*.arb`（9 語系：新增/改寫/刪除）
+- Test: `test/widgets/dialogs/accounts_picker_dialog_test.dart`
+
+- [ ] **Step 1: ARB — 新增 / 改寫 / 刪除（先 template）**
+
+`lib/l10n/app_zh.arb`：
+- `settingsImportConfirmIntro`（約 439 行）字串改為：`"即將合併 {accounts} 個帳號（共 {records} 筆紀錄）："`（`@` block 不變）。
+- 刪除 `settingsImportConfirmOverwriteHeader`（約 446 行）、`settingsImportConfirmWarning`（約 452 行）、`settingsImportOverwriteBadge`（約 475 行）整行。
+- 新增 `settingsImportConfirmMergeHeader` 與 `settingsImportMergeBadge`。建議把 `settingsImportConfirmMergeHeader` 補在原 `settingsImportConfirmOverwriteHeader` 位置、`settingsImportMergeBadge` 補在原 `settingsImportOverwriteBadge` 位置：
+
+```json
+  "settingsImportConfirmMergeHeader": "下列帳號將與本機資料合併，不會刪除既有記錄：",
+```
+```json
+  "settingsImportMergeBadge": "合併",
+```
+
+- [ ] **Step 2: ARB — 其餘 8 個已翻譯語系**
+
+對 `app_en / app_es / app_fr / app_ja / app_pt_BR / app_th / app_vi / app_zh_Hans`：改 `settingsImportConfirmIntro`、刪 `settingsImportConfirmOverwriteHeader` + `settingsImportConfirmWarning` + `settingsImportOverwriteBadge`、新增 `settingsImportConfirmMergeHeader` + `settingsImportMergeBadge`，值如下表。
+
+`settingsImportConfirmIntro`：
+
+| 語系 | 值 |
+|------|----|
+| en | `About to merge {accounts} accounts ({records} records total):` |
+| es | `A punto de combinar {accounts} cuentas ({records} registros en total):` |
+| fr | `Sur le point de fusionner {accounts} comptes ({records} enregistrements au total) :` |
+| ja | `{accounts} 個のアカウントを結合します（合計 {records} 件の記録）：` |
+| pt_BR | `Prestes a mesclar {accounts} contas ({records} registros no total):` |
+| th | `กำลังจะผสาน {accounts} บัญชี (รวม {records} ระเบียน):` |
+| vi | `Sắp hợp nhất {accounts} tài khoản (tổng {records} bản ghi):` |
+| zh_Hans | `即将合并 {accounts} 个账号（共 {records} 条记录）：` |
+
+`settingsImportConfirmMergeHeader`：
+
+| 語系 | 值 |
+|------|----|
+| en | `The following accounts will be merged with local data; existing records won't be deleted:` |
+| es | `Las siguientes cuentas se combinarán con los datos locales; no se eliminarán los registros existentes:` |
+| fr | `Les comptes suivants seront fusionnés avec les données locales ; les enregistrements existants ne seront pas supprimés :` |
+| ja | `以下のアカウントはローカルデータと結合されます。既存の記録は削除されません：` |
+| pt_BR | `As seguintes contas serão mescladas com os dados locais; os registros existentes não serão excluídos:` |
+| th | `บัญชีต่อไปนี้จะถูกผสานกับข้อมูลในเครื่อง โดยจะไม่ลบระเบียนที่มีอยู่:` |
+| vi | `Các tài khoản sau sẽ được hợp nhất với dữ liệu cục bộ; các bản ghi hiện có sẽ không bị xóa:` |
+| zh_Hans | `以下账号将与本机数据合并，不会删除既有记录：` |
+
+`settingsImportMergeBadge`：
+
+| 語系 | 值 |
+|------|----|
+| en | `Merge` |
+| es | `Combinar` |
+| fr | `Fusionner` |
+| ja | `結合` |
+| pt_BR | `Mesclar` |
+| th | `ผสาน` |
+| vi | `Hợp nhất` |
+| zh_Hans | `合并` |
+
+- [ ] **Step 3: 重新產生 l10n**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`settingsImportMergeBadge`、`settingsImportConfirmMergeHeader` getter 生成，舊三個 key 的 getter 消失。
+
+- [ ] **Step 4: 改 `_import` badge → 合併**
+
+`lib/pages/settings_page.dart`，把 picker entry 的 badge（約 556-558 行）改為：
+
+```dart
+          badge: existing.contains(a.data.uid)
+              ? l.settingsImportMergeBadge
+              : null,
+```
+
+- [ ] **Step 5: 改 `_import` 衝突區塊 + 移除警告 + 改確認 dialog**
+
+同檔，把確認內文組裝與 dialog（約 608-632 行）整段改為：
+
+```dart
+    if (conflicts.isEmpty) {
+      buf.writeln(l.settingsImportConfirmNoConflict);
+    } else {
+      buf.writeln(l.settingsImportConfirmMergeHeader);
+      for (final uid in conflicts) {
+        buf.writeln('  • $uid');
+      }
+    }
+    if (preserved.isNotEmpty) {
+      buf.writeln();
+      buf.writeln(l.settingsImportConfirmPreserveFooter(preserved.join(', ')));
+    }
+
+    final ok = await showConfirmDialog(
+      context: ctx,
+      title: l.settingsImportConfirmTitle,
+      body: buf.toString(),
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmImport,
+      confirmIcon: Icons.check,
+    );
+    if (ok != true) return;
+    if (!ctx.mounted) return;
+```
+
+> 此段移除了原本 `buf.writeln()` + `buf.write(l.settingsImportConfirmWarning)`（約 620-621 行）與 `showConfirmTypeDialog(... expectedText: 'IMPORT' ...)`。其餘 `_import`（檔案讀取、picker、`filteredBundle`、`incoming/conflicts/preserved`、`settingsImportConfirmIntro` 前言、fire-and-forget 呼叫）不變。
+
+- [ ] **Step 6: picker badge 改中性色**
+
+`lib/widgets/dialogs/accounts_picker_dialog.dart`，`_PickerRow.build` 的 badge `Container`（約 218-232 行），把兩處 `tokens.stateDanger` 改為 `tokens.accentPrimary`：
+
+```dart
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: tokens.accentPrimary.withValues(alpha: 0.18),
+                borderRadius: BorderRadius.circular(99),
+              ),
+              child: Text(
+                badge,
+                style: TextStyle(
+                  color: tokens.accentPrimary,
+                  fontSize: 11,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+```
+
+同檔把 `AccountPickerEntry.badge` 的 dartdoc（約 31 行「可選的紅色警示徽章文字」）改為中性描述：
+
+```dart
+  /// 可選的徽章文字（如「合併」提示）。
+```
+
+- [ ] **Step 7: 改 picker 測試的 badge 文案**
+
+`test/widgets/dialogs/accounts_picker_dialog_test.dart`：
+- fixture（約 26 行）`badge: '覆蓋'` 改為 `badge: '合併'`。
+- 測試 `overwrite badge shown only when entry.badge != null`（約 162-167 行）改名為 `badge shown only when entry.badge != null`，並把斷言（約 166 行）改為：
+
+```dart
+    expect(find.text('合併'), findsOneWidget);
+```
+
+- [ ] **Step 8: 跑分析 + 相關測試**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+Run: `fvm flutter test test/widgets/dialogs/accounts_picker_dialog_test.dart`
+Expected: PASS
+
+- [ ] **Step 9: commit**
+
+```bash
+git add lib/pages/settings_page.dart lib/widgets/dialogs/accounts_picker_dialog.dart lib/l10n/ test/widgets/dialogs/accounts_picker_dialog_test.dart
+git commit -m "feat(import): non-destructive merge confirm flow and neutral badge"
+```
+
+---
+
+## Task 5: 全套品質檢查
+
+**Files:** 無（驗證）。
+
+- [ ] **Step 1: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 僅顯示被格式化的檔案數，無錯誤。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: 全套測試**
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 確認舊 key 無殘留引用**
+
+Run: `git grep -n "settingsImportOverwriteBadge\|settingsImportConfirmWarning\|settingsImportConfirmOverwriteHeader"`
+Expected: 在 `lib/` 與 `test/` 無命中（只可能殘留於 Crowdin 空殼 ARB——本計畫不動它們，可忽略；若 `lib/l10n/generated/` 仍有，表示 gen-l10n 未重跑）。
+
+- [ ] **Step 5: 若 format 有改動則 commit**
+
+```bash
+git add -A
+git commit -m "style(import): apply dart format"
+```
+
+（若 Step 1 無改動則略過。）
+
+---
+
+## 完成後
+
+- 本計畫不主動 `git push`。
+- 22 個 Crowdin 空殼語系的新 key 由 Crowdin pipeline 後補，不在本計畫手動處理。
+- 後續若要驗證實機行為（匯入兩份重疊備份看記錄是否合併、確認框是否免打字），可用 `/run` 或 `/verify`。

--- a/docs/superpowers/specs/2026-06-09-import-merge-design.md
+++ b/docs/superpowers/specs/2026-06-09-import-merge-design.md
@@ -1,0 +1,182 @@
+# 匯入資料改為合併（非覆蓋）設計
+
+## 背景與目標
+
+目前「匯入全部資料」採**整帳號覆蓋**：對備份檔裡的每個帳號直接 `storage.save(account.data)`，用備份的整包 `BannerStorage` 換掉該 UID 的磁碟檔，完全不去重。同一 UID 重複匯入 → 本機既有資料被整包蓋掉；本機有、備份沒有的 UID 則保留不動。此行為是當初 `2026-05-12-export-import-all-accounts-design.md` 刻意選的（「衝突一律覆蓋整個帳號」）。
+
+本設計把匯入改為**永遠合併、非破壞性**：匯入是純加法，本機既有的祈願記錄絕不會因匯入而消失。移除覆蓋模式（不提供切換）。
+
+**成功條件**
+
+- 既有 UID 重複匯入時，本機與備份的祈願記錄依 `id` union 去重，兩邊都保留。
+- 本機有、備份沒有的 UID、記錄、偏好一律不受影響。
+- 匯入流程改為非破壞性語意（移除「輸入 IMPORT」強確認），並回報「新增 / 已存在」筆數。
+- `fvm flutter analyze` 全綠、`fvm flutter test` 全綠。
+
+## 決策摘要
+
+| 面向 | 決策 |
+|------|------|
+| 衝突策略 | 永遠合併（union by `id`），移除覆蓋；不提供切換 |
+| 去重 key | `GachaRecord.id`（HoYoverse 19 碼遞增流水號，天然唯一） |
+| 同 id 衝突 | 保留本機那筆；本機 `lang` 空、備份非空 → 回填 `lang` |
+| `lastUpdated` | 合併後取兩者較新者 |
+| 別名 | 只補空缺：本機該 UID 已有別名則保留；僅當本機無別名且備份非空時採用備份；備份空別名不清掉本機別名 |
+| 上次選取帳號（active） | 本機已有有效 active 則保留；否則採用備份 `lastActiveUid`（須存在）；再否則 fallback 到 `newOrder.first`（皆無則 null） |
+| 帳號顯示順序（`uidOrder`） | 本機既有順序原封不動；這次新出現的 UID 依備份檔順序接在最後 |
+| 確認流程 | 移除打字閘，改一般確認；badge／文案改合併語意；非 danger 配色 |
+| 結果回報 | 顯示「已合併 N 個帳號：新增 X 筆、已存在 Y 筆」 |
+
+## 設計
+
+### 1. 合併原語：`BannerStorage.mergeWith`
+
+在 `lib/models/banner_storage.dart` 新增純函式方法（可獨立單測，不依賴 I/O 或 Riverpod）：
+
+```dart
+/// 將 [incoming]（同一 UID 的另一份存檔）合併進本份，回傳新的 [BannerStorage]。
+/// 逐 banner 依 record.id union 去重後降序排序；本機既有記錄一律保留。
+BannerStorage mergeWith(BannerStorage incoming)
+```
+
+行為：
+
+- **逐 banner（gacha_type）union**：兩邊 `banners` 的 key 取聯集；每個 banner 內把本機與備份兩條 list 依 `id` 去重後**降序排序**。`id` 等長 19 碼，字典序＝數值序，排序用 `(a, b) => b.id.compareTo(a.id)`（與 `gacha_fetcher.dart` 的 `_idGreater` 同一套字典序規則）。
+- **同 `id` 衝突**：保留本機那筆；但若本機該筆 `lang` 為空字串、備份那筆 `lang` 非空 → 以 `GachaRecord.copyWith(lang:)` 回填（鏡像 `fetchBannerWithMerge` 既有的頌願 lang 補值哲學；一般祈願記錄 `lang` 必非空，不受影響）。
+- **`lastUpdated`**：取 `this.lastUpdated` 與 `incoming.lastUpdated` 較新者。
+- 記錄級合併抽成 `static` 私有 helper：`static List<GachaRecord> _mergeRecordsById(List<GachaRecord> local, List<GachaRecord> incoming)`，集中「兩條 list → 依 id union 去重（同 id 保留 local，必要時回填 lang）→ 依 id 降序排序」的邏輯，避免散落於 banner 迴圈。
+
+逐 banner 合併（pseudocode）：
+
+```
+for (final key in {...local.banners.keys, ...incoming.banners.keys}) {
+  merged[key] = _mergeRecordsById(
+    local.banners[key] ?? const [],
+    incoming.banners[key] ?? const [],
+  );
+}
+```
+
+> 註：不重用 `fetchBannerWithMerge`。該方法靠「網路分頁掃到 `existingMaxId` 即停」做增量抓取，回傳 `[...fresh, ...existing]`（fresh 為嚴格更新者，非任意重疊集合的 union），語意與匯入合併不同。抓取流程維持原樣，不在本次改動範圍（YAGNI、控制 blast radius）。
+
+### 2. `_runImport` 改寫（`lib/state/gacha_repository.dart`）
+
+**記錄合併**：把「直接覆蓋」改為「合併」——
+
+- 備份的 UID 本機**沒有** → 直接 `storage.save(account.data)`（等同合併進空存檔）。
+- 備份的 UID 本機**已有** → `final merged = state.byUid[uid]!.mergeWith(account.data); await storage.save(merged);` 並以 `merged` 更新 `newByUid[uid]`。
+- 保留現有 per-account `try/catch`：單一 UID 寫入失敗 → 加入 `failedUids`、其餘帳號繼續；保留 `ref.mounted` 檢查與提前返回。
+
+**新增 / 已存在計數**（用既有的 `BannerStorage.allRecords` getter，免讓 `mergeWith` 回傳 tuple）：
+
+- 每帳號：`addedThisAccount = merged.allRecords.length - localBefore.allRecords.length`（union 的性質：恰等於「備份記錄中 id 本機原本沒有的數量」）；`duplicateThisAccount = incoming.allRecords.length - addedThisAccount`。
+- 新 UID（本機無）時 `localBefore` 視為空 → `added` ＝ 備份全部、`duplicate` ＝ 0。
+- 累加為整體 `addedRecords` / `duplicateRecords`，提前返回路徑也帶當前累計值。
+
+**偏好「只補空缺」**：
+
+- **別名**：移除「備份空別名 → `mergedAliases.remove(uid)`」這條覆蓋邏輯。改為：僅當 `currentSettings.uidAliases` 不含該 UID（本機無別名）且備份別名非空時，才 `mergedAliases[uid] = a`；本機已有別名則保留不動。
+- **`uidOrder`**：
+
+  ```dart
+  final localOrder = currentSettings.uidOrder; // 本機既有順序原封不動
+  final localSet = localOrder.toSet();
+  final appended = bundle.accounts
+      .where((a) => !failed.contains(a.data.uid))
+      .map((a) => a.data.uid)
+      .where((uid) => !localSet.contains(uid)) // 只取本機原本沒有的
+      .toList(growable: false);
+  final newOrder = [...localOrder, ...appended];
+  ```
+
+- **active UID**：本機目前若已有有效 active（`state.activeUid != null && newByUid.containsKey(state.activeUid)`）→ 保留本機；否則才採用備份的 `lastActiveUid`（仍須存在於 `newByUid`）；再否則 fallback 到 `newOrder.first`；皆無則 null。此選擇在所有 per-account `save()` 與 `applyImportedPreferences()` 之後才定案。
+
+### 3. 確認流程改非破壞性
+
+涉及 `lib/pages/settings_page.dart`（`_import`）、`lib/widgets/dialogs/confirm_dialog.dart`、`lib/widgets/dialogs/accounts_picker_dialog.dart`。
+
+**共用一般確認 dialog（不重造輪子）**：`settings_page.dart` 內 `_clearGallery`（約 784-804）與 `_refetchAll`（約 825-845）已各自手寫一份「`showDialog<bool>` + `AppDialog` + 取消/確認」的無打字確認（兩者目前都用 danger 紅）。依 CLAUDE.md「抽出來共用」，在 `confirm_dialog.dart` 新增一支抽取自這兩處的 `showConfirmDialog`，並把 `_clearGallery`／`_refetchAll` 改呼叫它（兩者傳 `isDanger: true` 維持現有紅色，不改其視覺）：
+
+```dart
+Future<bool?> showConfirmDialog({
+  required BuildContext context,
+  required String title,
+  required String body,
+  required String cancelLabel,
+  required String confirmLabel,
+  IconData? confirmIcon,
+  bool isDanger = false, // true → stateDanger 紅；false → 中性 accentPrimary
+})
+```
+
+匯入確認改用 `showConfirmDialog(..., isDanger: false)`，取代原本的 `showConfirmTypeDialog(expectedText: 'IMPORT')`。`settings_page.dart` 另外三處危險確認（`_clearActive` 646、`_clearAll` 1069，及 `account_management.dart:101` 的 `_remove`）維持打字閘，不動。
+
+**Picker badge**：既有 UID 的 badge 文字由 `settingsImportOverwriteBadge`（「覆蓋」）改為 `settingsImportMergeBadge`（「合併」）。`accounts_picker_dialog.dart` 的 `_PickerRow`（約 217-232）目前把 badge 底色／文字硬編為 `tokens.stateDanger`；由於 badge 唯一消費者就是這個匯入流程（export picker 不帶 badge），直接把該處改為中性 token（如 `tokens.textSecondary`／`tokens.accentPrimary`），不另加 enum 參數（YAGNI）。
+
+**內文改寫**：
+
+- 前言改合併語意（改寫 `settingsImportConfirmIntro`：「即將匯入…」→「即將合併…」），沿用既有 `• UID (別名)` 清單格式。
+- 衝突區塊：把「覆蓋」標頭（`settingsImportConfirmOverwriteHeader`）改為新 key `settingsImportConfirmMergeHeader`（「下列帳號將與本機資料合併，不會刪除既有記錄：」），列出衝突 UID。
+- 移除危險警告句（刪 `_import` 對 `settingsImportConfirmWarning` 的引用與該 ARB key）。
+- 保留「未匯入的帳號維持不動」footer（`settingsImportConfirmPreserveFooter`）與「無資料衝突」（`settingsImportConfirmNoConflict`）。
+
+### 4. 結果回報「新增 / 已存在」（`lib/state/update_progress.dart` 與 `lib/widgets/update_progress_dialog.dart`）
+
+- `ImportResult` 欄位改為：`successAccounts`、`addedRecords`、`duplicateRecords`、`failedUids`（移除 `totalRecords`）。`_runImport` 三處 `ImportResult(...)` 建構（含兩處 unmount 提前返回與最終返回）一併改用新欄位；計數公式見段 2。
+- `progressDoneImportSummary` 由 2 個 placeholder（accounts、records）改為 3 個（successAccounts、addedRecords、duplicateRecords），文案如「已合併 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆」；`update_progress_dialog.dart`（約 235-238）呼叫點同步改。
+- **兩處 log 都要改**：`importAccountsAndFetchHoYoWiki`（約 608-611）與 `_runImport` 收尾（約 747-751）原本印 `records=$totalRecords`，改印 `added` / `duplicate`；含 UID 的 log 一律經 `sanitizeUid` 脫敏（對齊 CLAUDE.md log 規範）。
+
+### 5. 受影響檔案清單
+
+| 檔案 | 變更 |
+|------|------|
+| `lib/models/banner_storage.dart` | 新增 `mergeWith` + `static _mergeRecordsById` |
+| `lib/state/gacha_repository.dart` | `_runImport`：記錄合併、added/duplicate 計數、偏好只補空缺、`uidOrder` append、active 保留本機、log；`importAccountsAndFetchHoYoWiki` log 改欄位 |
+| `lib/state/update_progress.dart` | `ImportResult` 欄位改版 |
+| `lib/widgets/update_progress_dialog.dart` | 改用新 `ImportResult` 欄位與新 `progressDoneImportSummary` 簽名 |
+| `lib/pages/settings_page.dart` | `_import`：badge 改合併、改用 `showConfirmDialog`、內文改寫；`_clearGallery`／`_refetchAll` 改用抽取後的 `showConfirmDialog` |
+| `lib/widgets/dialogs/confirm_dialog.dart` | 新增 `showConfirmDialog`（無打字閘、`isDanger` 參數） |
+| `lib/widgets/dialogs/accounts_picker_dialog.dart` | `_PickerRow` badge 改中性 token |
+| `lib/l10n/app_*.arb`（已翻譯語系） | 見 i18n 段 |
+
+## 錯誤處理
+
+- 合併為純記憶體運算，唯一 I/O 風險在 `storage.save`，維持既有 `_atomicWrite`（寫 `.tmp` 後 rename 到目標；rename 失敗則該帳號磁碟資料不變、`.tmp` 殘留）與 per-account `try/catch`。
+- 本機檔案損毀的容錯維持現狀：合併以已載入記憶體的 `state.byUid` 為來源，不重讀磁碟。
+- `ref.mounted` 檢查與提前返回路徑全部保留，且提前返回也回傳正確的 `addedRecords` / `duplicateRecords` 累計值。
+
+## 測試計畫
+
+- **`BannerStorage.mergeWith` 單元測試**：union；id 去重；降序排序；banner key 聯集（其中一邊缺某 banner）；`lastUpdated` 取較新；同 id 的 lang 回填（本機空、備份非空）；空本機 / 空備份邊界；本機與備份完全不重疊。
+- **`_runImport`（`debugImportOnly`）測試**：
+  - 既有 UID **合併不覆蓋**：本機 `[A,B]` ＋ 備份 `[B,C]` → `[A,B,C]`，`addedRecords=1`、`duplicateRecords=1`。
+  - 本機獨有 UID 完全不動。
+  - 備份新 UID 加入，且 `uidOrder` append 在最後、本機既有順序不變。
+  - 別名只補空缺：本機已有別名不被備份覆蓋；備份空別名不清掉本機別名。
+  - active 三層 fallback：(1) 本機有效 → 保留本機；(2) 本機無效、備份有效 → 採用備份；(3) 兩者皆無、`newOrder` 非空 → `newOrder.first`。
+  - **更新**目前假設覆蓋語意的既有測試：`test/state/gacha_repository_test.dart`（別名 merge 測試與「overwritten」註解約 1108-1126；`uidOrder` 測試約 1189-1191）、`test/state/gacha_repository_import_with_hoyowiki_test.dart`（`totalRecords` 斷言 184、230 改驗新欄位）。
+- **Widget 測試**：
+  - `test/widgets/dialogs/confirm_dialog_test.dart`：新增 `showConfirmDialog`（不需打字即可確認、`isDanger` 配色）測試；既有 `showConfirmTypeDialog` 測試不動。
+  - `test/widgets/dialogs/accounts_picker_dialog_test.dart`：badge 文字斷言（約 26、166）改為「合併」文案。
+
+## i18n
+
+ARB key 異動（先寫 `lib/l10n/app_zh.arb`，再以中文為基準翻**已實際翻譯過**的語系；空殼 ARB 留給 Crowdin pipeline，不主動補）：
+
+- **新增**：
+  - `settingsImportMergeBadge` ＝「合併」
+  - `settingsImportConfirmMergeHeader` ＝「下列帳號將與本機資料合併，不會刪除既有記錄：」
+- **改寫**：
+  - `settingsImportConfirmIntro`：「即將匯入 {accounts} 個帳號（共 {records} 筆紀錄）」→ 合併語意（如「即將合併 {accounts} 個帳號（共 {records} 筆紀錄）」）
+  - `progressDoneImportSummary`：2 → 3 placeholder（successAccounts、addedRecords、duplicateRecords），如「已合併 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆」
+- **刪除**（全語系；刪前再全域 grep 確認無其他引用）：`settingsImportOverwriteBadge`、`settingsImportConfirmWarning`、`settingsImportConfirmOverwriteHeader`
+- **保留**：`settingsImportConfirmNoConflict`、`settingsImportConfirmPreserveFooter`
+- CJK 全形標點；結尾省略號一律半形 `...`。
+
+## 非目標（YAGNI）
+
+- 不提供「合併／覆蓋」切換（永遠合併）。
+- 不支援 UIGF / SRGF / Excel 等外部格式（維持自家 `AccountsBundle` JSON）。
+- 不重構 `fetchBannerWithMerge` 抓取流程。
+- 不改 `_clearGallery`／`_refetchAll` 的危險紅色語意（僅抽取共用 helper，傳 `isDanger: true` 維持現狀）。
+- 不為 picker badge 加 enum 樣式參數（唯一消費者直接改色即可）。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -210,14 +210,17 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{Imported 1 account ({records} records)} other{Imported {accounts} accounts ({records} records)}}",
+  "progressDoneImportSummary": "{accounts, plural, =1{Merged 1 account} other{Merged {accounts} accounts}}: {added} new, {duplicate} already present",
   "@progressDoneImportSummary": {
-    "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
+    "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts merged, plus new vs already-present record counts.",
     "placeholders": {
       "accounts": {
         "type": "int"
       },
-      "records": {
+      "added": {
+        "type": "int"
+      },
+      "duplicate": {
         "type": "int"
       }
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -585,7 +585,7 @@
     }
   },
   "settingsImportConfirmTitle": "Import confirmation",
-  "settingsImportConfirmIntro": "About to import {accounts} accounts ({records} records total):",
+  "settingsImportConfirmIntro": "About to merge {accounts} accounts ({records} records total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -596,7 +596,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "The following UIDs already have data and will be overwritten:",
+  "settingsImportConfirmMergeHeader": "The following accounts will be merged with local data; existing records won't be deleted:",
   "settingsImportConfirmNoConflict": "No data conflicts.",
   "settingsImportConfirmPreserveFooter": "Other existing accounts ({uids}) will be preserved.",
   "@settingsImportConfirmPreserveFooter": {
@@ -606,7 +606,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "This action cannot be undone. Type IMPORT to confirm.",
   "settingsImportSuccess": "Successfully imported {accounts} accounts ({records} records)",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -642,7 +641,7 @@
   },
   "settingsExportSelectTitle": "Select accounts to export",
   "settingsImportSelectTitle": "Select accounts to import",
-  "settingsImportOverwriteBadge": "Overwrite",
+  "settingsImportMergeBadge": "Merge",
   "accountsPickerSelectAll": "Select all",
   "accountRecordCount": "{n} records",
   "@accountRecordCount": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{Merged 1 account} other{Merged {accounts} accounts}}: {added} new, {duplicate} already present",
+  "progressDoneImportSummary": "{accounts, plural, =1{Imported 1 account} other{Imported {accounts} accounts}}: {added} new, {duplicate} already present",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts merged, plus new vs already-present record counts.",
     "placeholders": {
@@ -585,7 +585,7 @@
     }
   },
   "settingsImportConfirmTitle": "Import confirmation",
-  "settingsImportConfirmIntro": "About to merge {accounts} accounts ({records} records total):",
+  "settingsImportConfirmIntro": "About to import {accounts} accounts ({records} records total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{1 cuenta importada ({records} registros)} other{{accounts} cuentas importadas ({records} registros)}}",
+  "progressDoneImportSummary": "{accounts, plural, =1{Se combinó 1 cuenta} other{Se combinaron {accounts} cuentas}}: {added} nuevos, {duplicate} ya existentes",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmar importación",
-  "settingsImportConfirmIntro": "Se van a importar {accounts} cuenta(s) ({records} registro(s) en total):",
+  "settingsImportConfirmIntro": "A punto de combinar {accounts} cuentas ({records} registros en total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "Los siguientes UID ya tienen datos y serán sobreescritos:",
+  "settingsImportConfirmMergeHeader": "Las siguientes cuentas se combinarán con los datos locales; no se eliminarán los registros existentes:",
   "settingsImportConfirmNoConflict": "Sin conflictos de datos.",
   "settingsImportConfirmPreserveFooter": "Las demás cuentas existentes ({uids}) se conservarán.",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "Esta operación es irreversible. Escribe IMPORT para confirmar.",
   "settingsImportSuccess": "Se han importado correctamente {accounts} cuenta(s) ({records} registro(s))",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "Seleccionar cuentas a exportar",
   "settingsImportSelectTitle": "Seleccionar cuentas a importar",
-  "settingsImportOverwriteBadge": "Sobrescribir",
+  "settingsImportMergeBadge": "Combinar",
   "accountsPickerSelectAll": "Seleccionar todo",
   "accountRecordCount": "{n, plural, =1{1 registro} other{{n} registros}}",
   "@accountRecordCount": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{Se combinó 1 cuenta} other{Se combinaron {accounts} cuentas}}: {added} nuevos, {duplicate} ya existentes",
+  "progressDoneImportSummary": "{accounts, plural, =1{Se importó 1 cuenta} other{Se importaron {accounts} cuentas}}: {added} nuevos, {duplicate} ya existentes",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmar importación",
-  "settingsImportConfirmIntro": "A punto de combinar {accounts} cuentas ({records} registros en total):",
+  "settingsImportConfirmIntro": "Se van a importar {accounts} cuenta(s) ({records} registro(s) en total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{1 compte importé ({records} enregistrements)} other{{accounts} comptes importés ({records} enregistrements)}}",
+  "progressDoneImportSummary": "{accounts, plural, =1{1 compte fusionné} other{{accounts} comptes fusionnés}} : {added} nouveaux, {duplicate} déjà présents",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{1 compte fusionné} other{{accounts} comptes fusionnés}} : {added} nouveaux, {duplicate} déjà présents",
+  "progressDoneImportSummary": "{accounts, plural, =1{1 compte importé} other{{accounts} comptes importés}} : {added} nouveaux, {duplicate} déjà présents",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmation d'importation",
-  "settingsImportConfirmIntro": "Sur le point de fusionner {accounts} comptes ({records} enregistrements au total) :",
+  "settingsImportConfirmIntro": "Sur le point d'importer {accounts} compte(s) ({records} enregistrement(s) au total) :",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmation d'importation",
-  "settingsImportConfirmIntro": "Sur le point d'importer {accounts} compte(s) ({records} enregistrement(s) au total) :",
+  "settingsImportConfirmIntro": "Sur le point de fusionner {accounts} comptes ({records} enregistrements au total) :",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "Les UID suivants ont déjà des données et seront écrasés :",
+  "settingsImportConfirmMergeHeader": "Les comptes suivants seront fusionnés avec les données locales ; les enregistrements existants ne seront pas supprimés :",
   "settingsImportConfirmNoConflict": "Aucun conflit de données.",
   "settingsImportConfirmPreserveFooter": "Les autres comptes existants ({uids}) seront conservés.",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "Cette opération est irréversible. Saisissez IMPORT pour confirmer.",
   "settingsImportSuccess": "{accounts} compte(s) importé(s) avec succès ({records} enregistrement(s))",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "Sélectionner les comptes à exporter",
   "settingsImportSelectTitle": "Sélectionner les comptes à importer",
-  "settingsImportOverwriteBadge": "Écraser",
+  "settingsImportMergeBadge": "Fusionner",
   "accountsPickerSelectAll": "Tout sélectionner",
   "accountRecordCount": "{n, plural, =1{1 enregistrement} other{{n} enregistrements}}",
   "@accountRecordCount": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "インポートの確認",
-  "settingsImportConfirmIntro": "{accounts} 個のアカウントを結合します（合計 {records} 件の記録）：",
+  "settingsImportConfirmIntro": "{accounts} 個のアカウントを統合します（合計 {records} 件の記録）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmMergeHeader": "以下のアカウントはローカルデータと結合されます。既存の記録は削除されません：",
+  "settingsImportConfirmMergeHeader": "以下のアカウントはローカルデータと統合されます。既存の記録は削除されません：",
   "settingsImportConfirmNoConflict": "データの競合はありません。",
   "settingsImportConfirmPreserveFooter": "その他の既存アカウント（{uids}）は保持されます。",
   "@settingsImportConfirmPreserveFooter": {
@@ -638,7 +638,7 @@
   },
   "settingsExportSelectTitle": "エクスポートするアカウントを選択",
   "settingsImportSelectTitle": "インポートするアカウントを選択",
-  "settingsImportMergeBadge": "結合",
+  "settingsImportMergeBadge": "統合",
   "accountsPickerSelectAll": "すべて選択",
   "accountRecordCount": "{n} 件の記録",
   "@accountRecordCount": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "インポートの確認",
-  "settingsImportConfirmIntro": "{accounts} 個のアカウント（計 {records} 件の記録）をインポートします：",
+  "settingsImportConfirmIntro": "{accounts} 個のアカウントを結合します（合計 {records} 件の記録）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "次の UID には既存データがあり、上書きされます：",
+  "settingsImportConfirmMergeHeader": "以下のアカウントはローカルデータと結合されます。既存の記録は削除されません：",
   "settingsImportConfirmNoConflict": "データの競合はありません。",
   "settingsImportConfirmPreserveFooter": "その他の既存アカウント（{uids}）は保持されます。",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "この操作は元に戻せません。確認のため IMPORT と入力してください。",
   "settingsImportSuccess": "{accounts} 個のアカウント（{records} 件の記録）を正常にインポートしました",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "エクスポートするアカウントを選択",
   "settingsImportSelectTitle": "インポートするアカウントを選択",
-  "settingsImportOverwriteBadge": "上書き",
+  "settingsImportMergeBadge": "結合",
   "accountsPickerSelectAll": "すべて選択",
   "accountRecordCount": "{n} 件の記録",
   "@accountRecordCount": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts} 個のアカウントを結合しました：新規 {added} 件、既存 {duplicate} 件",
+  "progressDoneImportSummary": "{accounts} 個のアカウントをインポートしました：新規 {added} 件、既存 {duplicate} 件",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "インポートの確認",
-  "settingsImportConfirmIntro": "{accounts} 個のアカウントを統合します（合計 {records} 件の記録）：",
+  "settingsImportConfirmIntro": "{accounts} 個のアカウント（計 {records} 件の記録）をインポートします：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts} 件のアカウントをインポート（{records} 件の記録）",
+  "progressDoneImportSummary": "{accounts} 個のアカウントを結合しました：新規 {added} 件、既存 {duplicate} 件",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{1 conta importada ({records} registros)} other{{accounts} contas importadas ({records} registros)}}",
+  "progressDoneImportSummary": "{accounts, plural, =1{1 conta mesclada} other{{accounts} contas mescladas}}: {added} novos, {duplicate} já existentes",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmação de importação",
-  "settingsImportConfirmIntro": "Prestes a mesclar {accounts} contas ({records} registros no total):",
+  "settingsImportConfirmIntro": "Prestes a mesclar {accounts, plural, =1{1 conta} other{{accounts} contas}} ({records, plural, =1{1 registro} other{{records} registros}} no total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmação de importação",
-  "settingsImportConfirmIntro": "Prestes a importar {accounts, plural, =1{1 conta} other{{accounts} contas}} ({records, plural, =1{1 registro} other{{records} registros}} no total):",
+  "settingsImportConfirmIntro": "Prestes a mesclar {accounts} contas ({records} registros no total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "Os seguintes UIDs já possuem dados e serão sobrescritos:",
+  "settingsImportConfirmMergeHeader": "As seguintes contas serão mescladas com os dados locais; os registros existentes não serão excluídos:",
   "settingsImportConfirmNoConflict": "Sem conflitos de dados.",
   "settingsImportConfirmPreserveFooter": "Outras contas existentes ({uids}) serão mantidas.",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "Esta operação não pode ser desfeita. Digite IMPORT para confirmar.",
   "settingsImportSuccess": "{accounts, plural, =1{1 conta importada} other{{accounts} contas importadas}} com sucesso ({records, plural, =1{1 registro} other{{records} registros}})",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "Selecionar contas para exportar",
   "settingsImportSelectTitle": "Selecionar contas para importar",
-  "settingsImportOverwriteBadge": "Sobrescrever",
+  "settingsImportMergeBadge": "Mesclar",
   "accountsPickerSelectAll": "Selecionar tudo",
   "accountRecordCount": "{n, plural, =1{1 registro} other{{n} registros}}",
   "@accountRecordCount": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "{accounts, plural, =1{1 conta mesclada} other{{accounts} contas mescladas}}: {added} novos, {duplicate} já existentes",
+  "progressDoneImportSummary": "{accounts, plural, =1{1 conta importada} other{{accounts} contas importadas}}: {added} novos, {duplicate} já existentes",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Confirmação de importação",
-  "settingsImportConfirmIntro": "Prestes a mesclar {accounts, plural, =1{1 conta} other{{accounts} contas}} ({records, plural, =1{1 registro} other{{records} registros}} no total):",
+  "settingsImportConfirmIntro": "Prestes a importar {accounts, plural, =1{1 conta} other{{accounts} contas}} ({records, plural, =1{1 registro} other{{records} registros}} no total):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "นำเข้า {accounts} บัญชี ({records} รายการ)",
+  "progressDoneImportSummary": "ผสาน {accounts} บัญชีแล้ว: ใหม่ {added} รายการ, มีอยู่แล้ว {duplicate} รายการ",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "ผสาน {accounts} บัญชีแล้ว: ใหม่ {added} รายการ, มีอยู่แล้ว {duplicate} รายการ",
+  "progressDoneImportSummary": "นำเข้า {accounts} บัญชีแล้ว: ใหม่ {added} รายการ, มีอยู่แล้ว {duplicate} รายการ",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "ยืนยันการนำเข้า",
-  "settingsImportConfirmIntro": "กำลังจะผสาน {accounts} บัญชี (รวม {records} ระเบียน):",
+  "settingsImportConfirmIntro": "กำลังจะนำเข้า {accounts} บัญชี (รวม {records} รายการ):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "ยืนยันการนำเข้า",
-  "settingsImportConfirmIntro": "กำลังจะนำเข้า {accounts} บัญชี (รวม {records} รายการ):",
+  "settingsImportConfirmIntro": "กำลังจะผสาน {accounts} บัญชี (รวม {records} ระเบียน):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "UID ต่อไปนี้มีข้อมูลอยู่แล้ว และจะถูกเขียนทับ:",
+  "settingsImportConfirmMergeHeader": "บัญชีต่อไปนี้จะถูกผสานกับข้อมูลในเครื่อง โดยจะไม่ลบระเบียนที่มีอยู่:",
   "settingsImportConfirmNoConflict": "ไม่มีข้อมูลที่ขัดแย้ง",
   "settingsImportConfirmPreserveFooter": "บัญชีอื่นที่มีอยู่ ({uids}) จะถูกเก็บไว้",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "การดำเนินการนี้ไม่สามารถย้อนกลับได้ กรุณาพิมพ์ IMPORT เพื่อยืนยัน",
   "settingsImportSuccess": "นำเข้า {accounts} บัญชี ({records} รายการ) สำเร็จ",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "เลือกบัญชีที่จะส่งออก",
   "settingsImportSelectTitle": "เลือกบัญชีที่จะนำเข้า",
-  "settingsImportOverwriteBadge": "เขียนทับ",
+  "settingsImportMergeBadge": "ผสาน",
   "accountsPickerSelectAll": "เลือกทั้งหมด",
   "accountRecordCount": "{n} รายการ",
   "@accountRecordCount": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "Đã nhập {accounts} tài khoản ({records} bản ghi)",
+  "progressDoneImportSummary": "Đã hợp nhất {accounts} tài khoản: {added} mới, {duplicate} đã có",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -210,7 +210,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "Đã hợp nhất {accounts} tài khoản: {added} mới, {duplicate} đã có",
+  "progressDoneImportSummary": "Đã nhập {accounts} tài khoản: {added} mới, {duplicate} đã có",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Xác nhận nhập",
-  "settingsImportConfirmIntro": "Sắp hợp nhất {accounts} tài khoản (tổng {records} bản ghi):",
+  "settingsImportConfirmIntro": "Sắp nhập {accounts} tài khoản (tổng cộng {records} bản ghi):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -582,7 +582,7 @@
     }
   },
   "settingsImportConfirmTitle": "Xác nhận nhập",
-  "settingsImportConfirmIntro": "Sắp nhập {accounts} tài khoản (tổng cộng {records} bản ghi):",
+  "settingsImportConfirmIntro": "Sắp hợp nhất {accounts} tài khoản (tổng {records} bản ghi):",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -593,7 +593,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "Các UID sau đã có dữ liệu và sẽ bị ghi đè:",
+  "settingsImportConfirmMergeHeader": "Các tài khoản sau sẽ được hợp nhất với dữ liệu cục bộ; các bản ghi hiện có sẽ không bị xóa:",
   "settingsImportConfirmNoConflict": "Không có xung đột dữ liệu.",
   "settingsImportConfirmPreserveFooter": "Các tài khoản hiện có khác ({uids}) sẽ được giữ lại.",
   "@settingsImportConfirmPreserveFooter": {
@@ -603,7 +603,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "Thao tác này không thể hoàn tác. Vui lòng nhập IMPORT để xác nhận.",
   "settingsImportSuccess": "Đã nhập thành công {accounts} tài khoản ({records} bản ghi)",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -639,7 +638,7 @@
   },
   "settingsExportSelectTitle": "Chọn tài khoản để xuất",
   "settingsImportSelectTitle": "Chọn tài khoản để nhập",
-  "settingsImportOverwriteBadge": "Ghi đè",
+  "settingsImportMergeBadge": "Hợp nhất",
   "accountsPickerSelectAll": "Chọn tất cả",
   "accountRecordCount": "{n} bản ghi",
   "@accountRecordCount": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -161,9 +161,9 @@
   "@progressPartialFailed": {
     "placeholders": { "names": { "type": "String" } }
   },
-  "progressDoneImportSummary": "已合併 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆",
+  "progressDoneImportSummary": "已匯入 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆",
   "@progressDoneImportSummary": {
-    "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts merged, plus new vs already-present record counts.",
+    "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts imported, plus new vs already-present record counts.",
     "placeholders": {
       "accounts": { "type": "int" },
       "added": { "type": "int" },
@@ -437,7 +437,7 @@
     "placeholders": { "path": { "type": "String" } }
   },
   "settingsImportConfirmTitle": "匯入確認",
-  "settingsImportConfirmIntro": "即將合併 {accounts} 個帳號（共 {records} 筆紀錄）：",
+  "settingsImportConfirmIntro": "即將匯入 {accounts} 個帳號（共 {records} 筆紀錄）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": { "type": "int" },

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -437,20 +437,19 @@
     "placeholders": { "path": { "type": "String" } }
   },
   "settingsImportConfirmTitle": "匯入確認",
-  "settingsImportConfirmIntro": "即將匯入 {accounts} 個帳號（共 {records} 筆紀錄）：",
+  "settingsImportConfirmIntro": "即將合併 {accounts} 個帳號（共 {records} 筆紀錄）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": { "type": "int" },
       "records": { "type": "int" }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "下列 UID 已有資料，將被覆蓋：",
+  "settingsImportConfirmMergeHeader": "下列帳號將與本機資料合併，不會刪除既有記錄：",
   "settingsImportConfirmNoConflict": "無資料衝突。",
   "settingsImportConfirmPreserveFooter": "其他現有帳號（{uids}）將保留。",
   "@settingsImportConfirmPreserveFooter": {
     "placeholders": { "uids": { "type": "String" } }
   },
-  "settingsImportConfirmWarning": "此操作無法復原。請輸入 IMPORT 以確認。",
   "settingsImportSuccess": "已成功匯入 {accounts} 個帳號（{records} 筆紀錄）",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -473,7 +472,7 @@
 
   "settingsExportSelectTitle": "選擇要匯出的帳號",
   "settingsImportSelectTitle": "選擇要匯入的帳號",
-  "settingsImportOverwriteBadge": "覆蓋",
+  "settingsImportMergeBadge": "合併",
   "accountsPickerSelectAll": "全選",
   "accountRecordCount": "{n} 筆紀錄",
   "@accountRecordCount": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -161,12 +161,13 @@
   "@progressPartialFailed": {
     "placeholders": { "names": { "type": "String" } }
   },
-  "progressDoneImportSummary": "本次匯入 {accounts} 個帳號（共 {records} 筆紀錄）",
+  "progressDoneImportSummary": "已合併 {accounts} 個帳號：新增 {added} 筆、已存在 {duplicate} 筆",
   "@progressDoneImportSummary": {
-    "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
+    "description": "Completion dialog line shown when the import-then-fetch flow finishes: accounts merged, plus new vs already-present record counts.",
     "placeholders": {
       "accounts": { "type": "int" },
-      "records":  { "type": "int" }
+      "added": { "type": "int" },
+      "duplicate": { "type": "int" }
     }
   },
   "progressPartialImportFailed": "⚠ 部分匯入失敗：{uids}",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -206,7 +206,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "本次导入 {accounts} 个账号（共 {records} 条记录）",
+  "progressDoneImportSummary": "已合并 {accounts} 个账号：新增 {added} 条、已存在 {duplicate} 条",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -578,7 +578,7 @@
     }
   },
   "settingsImportConfirmTitle": "导入确认",
-  "settingsImportConfirmIntro": "即将导入 {accounts} 个账号（共 {records} 条记录）：",
+  "settingsImportConfirmIntro": "即将合并 {accounts} 个账号（共 {records} 条记录）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {
@@ -589,7 +589,7 @@
       }
     }
   },
-  "settingsImportConfirmOverwriteHeader": "下列 UID 已有数据，将被覆盖：",
+  "settingsImportConfirmMergeHeader": "以下账号将与本机数据合并，不会删除既有记录：",
   "settingsImportConfirmNoConflict": "无数据冲突。",
   "settingsImportConfirmPreserveFooter": "其他现有账号（{uids}）将保留。",
   "@settingsImportConfirmPreserveFooter": {
@@ -599,7 +599,6 @@
       }
     }
   },
-  "settingsImportConfirmWarning": "此操作无法撤销。请输入 IMPORT 以确认。",
   "settingsImportSuccess": "已成功导入 {accounts} 个账号（{records} 条记录）",
   "@settingsImportSuccess": {
     "placeholders": {
@@ -635,7 +634,7 @@
   },
   "settingsExportSelectTitle": "选择要导出的账号",
   "settingsImportSelectTitle": "选择要导入的账号",
-  "settingsImportOverwriteBadge": "覆盖",
+  "settingsImportMergeBadge": "合并",
   "accountsPickerSelectAll": "全选",
   "accountRecordCount": "{n} 条记录",
   "@accountRecordCount": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -206,7 +206,7 @@
       }
     }
   },
-  "progressDoneImportSummary": "已合并 {accounts} 个账号：新增 {added} 条、已存在 {duplicate} 条",
+  "progressDoneImportSummary": "已导入 {accounts} 个账号：新增 {added} 条、已存在 {duplicate} 条",
   "@progressDoneImportSummary": {
     "description": "Completion dialog line shown when the import-then-fetch flow finishes: how many accounts and total records were imported in this run.",
     "placeholders": {
@@ -578,7 +578,7 @@
     }
   },
   "settingsImportConfirmTitle": "导入确认",
-  "settingsImportConfirmIntro": "即将合并 {accounts} 个账号（共 {records} 条记录）：",
+  "settingsImportConfirmIntro": "即将导入 {accounts} 个账号（共 {records} 条记录）：",
   "@settingsImportConfirmIntro": {
     "placeholders": {
       "accounts": {

--- a/lib/models/banner_storage.dart
+++ b/lib/models/banner_storage.dart
@@ -57,6 +57,47 @@ class BannerStorage {
     banners: banners ?? this.banners,
   );
 
+  /// 將 [incoming]（同一 UID 的另一份存檔）合併進本份，回傳新的 [BannerStorage]。
+  ///
+  /// 逐 banner 依 [GachaRecord.id] union 去重後降序排序；本機既有記錄一律保留，
+  /// 同 id 時保留本機那筆（若本機 lang 為空、[incoming] 非空則回填 lang）。
+  /// [lastUpdated] 取兩者較新者。
+  BannerStorage mergeWith(BannerStorage incoming) {
+    final keys = {...banners.keys, ...incoming.banners.keys};
+    final mergedBanners = <String, List<GachaRecord>>{
+      for (final key in keys)
+        key: _mergeRecordsById(
+          banners[key] ?? const [],
+          incoming.banners[key] ?? const [],
+        ),
+    };
+    final newer = incoming.lastUpdated.isAfter(lastUpdated)
+        ? incoming.lastUpdated
+        : lastUpdated;
+    return BannerStorage(uid: uid, lastUpdated: newer, banners: mergedBanners);
+  }
+
+  /// 合併兩條同 banner 的記錄：依 id union 去重（同 id 保留 [local]，必要時以
+  /// [incoming] 的非空 lang 回填）→ 依 id 降序排序（id 等長 19 碼，字典序＝數值序）。
+  static List<GachaRecord> _mergeRecordsById(
+    List<GachaRecord> local,
+    List<GachaRecord> incoming,
+  ) {
+    final byId = <String, GachaRecord>{};
+    for (final r in local) {
+      byId[r.id] = r;
+    }
+    for (final r in incoming) {
+      final existing = byId[r.id];
+      if (existing == null) {
+        byId[r.id] = r;
+      } else if (existing.lang.isEmpty && r.lang.isNotEmpty) {
+        byId[r.id] = existing.copyWith(lang: r.lang);
+      }
+    }
+    return byId.values.toList()..sort((a, b) => b.id.compareTo(a.id));
+  }
+
   /// 全 banner 串成一條 list（OverviewPage 用）
   List<GachaRecord> get allRecords =>
       banners.values.expand((l) => l).toList(growable: false);

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -553,7 +553,7 @@ class _DataManagement extends ConsumerWidget {
           lastUpdated: a.data.lastUpdated,
           recordCount: a.data.allRecords.length,
           badge: existing.contains(a.data.uid)
-              ? l.settingsImportOverwriteBadge
+              ? l.settingsImportMergeBadge
               : null,
         ),
     ];
@@ -607,7 +607,7 @@ class _DataManagement extends ConsumerWidget {
     if (conflicts.isEmpty) {
       buf.writeln(l.settingsImportConfirmNoConflict);
     } else {
-      buf.writeln(l.settingsImportConfirmOverwriteHeader);
+      buf.writeln(l.settingsImportConfirmMergeHeader);
       for (final uid in conflicts) {
         buf.writeln('  • $uid');
       }
@@ -616,14 +616,11 @@ class _DataManagement extends ConsumerWidget {
       buf.writeln();
       buf.writeln(l.settingsImportConfirmPreserveFooter(preserved.join(', ')));
     }
-    buf.writeln();
-    buf.write(l.settingsImportConfirmWarning);
 
-    final ok = await showConfirmTypeDialog(
+    final ok = await showConfirmDialog(
       context: ctx,
       title: l.settingsImportConfirmTitle,
       body: buf.toString(),
-      expectedText: 'IMPORT',
       cancelLabel: l.actionCancel,
       confirmLabel: l.confirmImport,
       confirmIcon: Icons.check,

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -33,7 +33,6 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_link.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/account_management.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/section_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/accounts_picker_dialog.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/confirm_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/current_release_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/export_result_dialog.dart';
@@ -781,26 +780,13 @@ class _ImageCacheSectionState extends ConsumerState<_ImageCacheSection> {
     final l = AppLocalizations.of(ctx)!;
     final usage = ref.read(hoyowikiCacheUsageProvider).value;
     final sizeText = usage == null ? '' : formatBytes(usage.galleryBytes);
-    final ok = await showDialog<bool>(
+    final ok = await showConfirmDialog(
       context: ctx,
-      builder: (d) => AppDialog(
-        title: Text(l.confirmClearGalleryCacheTitle),
-        content: Text(l.confirmClearGalleryCacheBody(sizeText)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(d).pop(false),
-            child: Text(l.actionCancel),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(d).gacha.stateDanger,
-              foregroundColor: Colors.white,
-            ),
-            onPressed: () => Navigator.of(d).pop(true),
-            child: Text(l.confirmClearGalleryCacheConfirm),
-          ),
-        ],
-      ),
+      title: l.confirmClearGalleryCacheTitle,
+      body: l.confirmClearGalleryCacheBody(sizeText),
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmClearGalleryCacheConfirm,
+      isDanger: true,
     );
     if (ok != true) return;
     try {
@@ -822,26 +808,13 @@ class _ImageCacheSectionState extends ConsumerState<_ImageCacheSection> {
   /// 顯示確認 dialog，確認後呼叫 [GachaRepository.forceRefetchAllHoYoWikiImages]。
   Future<void> _refetchAll(BuildContext ctx) async {
     final l = AppLocalizations.of(ctx)!;
-    final ok = await showDialog<bool>(
+    final ok = await showConfirmDialog(
       context: ctx,
-      builder: (d) => AppDialog(
-        title: Text(l.confirmRefetchHoyoWikiTitle),
-        content: Text(l.confirmRefetchHoyoWikiBody),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(d).pop(false),
-            child: Text(l.actionCancel),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(d).gacha.stateDanger,
-              foregroundColor: Colors.white,
-            ),
-            onPressed: () => Navigator.of(d).pop(true),
-            child: Text(l.confirmRefetchHoyoWikiConfirm),
-          ),
-        ],
-      ),
+      title: l.confirmRefetchHoyoWikiTitle,
+      body: l.confirmRefetchHoyoWikiBody,
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmRefetchHoyoWikiConfirm,
+      isDanger: true,
     );
     if (ok != true) return;
     // 後端流程獨立於 dialog lifecycle；UpdateProgressDialog 由 app_shell.dart

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -608,7 +608,7 @@ class GachaRepository extends Notifier<GachaState> {
       _importLog.info(
         'import done: success=${result.successAccounts} '
         'failed=[${result.failedUids.map(sanitizeUid).join(",")}] '
-        'records=${result.totalRecords}',
+        'added=${result.addedRecords} duplicate=${result.duplicateRecords}',
       );
 
       var images = 0;
@@ -668,62 +668,68 @@ class GachaRepository extends Notifier<GachaState> {
 
     final newByUid = Map<String, BannerStorage>.from(state.byUid);
     final failed = <String>[];
-    var totalRecords = 0;
+    var addedRecords = 0;
+    var duplicateRecords = 0;
     var successCount = 0;
 
     for (final account in bundle.accounts) {
+      final incoming = account.data;
       try {
-        await storage.save(account.data);
+        final localBefore = newByUid[incoming.uid];
+        final toSave = localBefore == null
+            ? incoming
+            : localBefore.mergeWith(incoming);
+        await storage.save(toSave);
         if (!ref.mounted) {
           return ImportResult(
             successAccounts: successCount,
-            totalRecords: totalRecords,
+            addedRecords: addedRecords,
+            duplicateRecords: duplicateRecords,
             failedUids: failed,
           );
         }
-        newByUid[account.data.uid] = account.data;
+        final added =
+            toSave.allRecords.length - (localBefore?.allRecords.length ?? 0);
+        addedRecords += added;
+        duplicateRecords += incoming.allRecords.length - added;
+        newByUid[incoming.uid] = toSave;
         successCount++;
-        for (final list in account.data.banners.values) {
-          totalRecords += list.length;
-        }
       } catch (_) {
-        failed.add(account.data.uid);
+        failed.add(incoming.uid);
       }
     }
 
     final currentSettings = ref.read(settingsProvider);
     final mergedAliases = Map<String, String>.from(currentSettings.uidAliases);
     for (final account in bundle.accounts) {
-      if (failed.contains(account.data.uid)) continue;
+      final uid = account.data.uid;
+      if (failed.contains(uid)) continue;
+      if (mergedAliases.containsKey(uid)) continue; // 本機已有別名 → 保留
       final a = account.alias?.trim();
-      if (a == null || a.isEmpty) {
-        mergedAliases.remove(account.data.uid);
-      } else {
-        mergedAliases[account.data.uid] = a;
+      if (a != null && a.isNotEmpty) {
+        mergedAliases[uid] = a;
       }
     }
 
-    final exportedOrder = bundle.accounts
+    final localOrder = currentSettings.uidOrder;
+    final localSet = localOrder.toSet();
+    final appended = bundle.accounts
         .where((a) => !failed.contains(a.data.uid))
         .map((a) => a.data.uid)
-        .toList();
-    final exportedSet = exportedOrder.toSet();
-    final remaining = currentSettings.uidOrder
-        .where((u) => !exportedSet.contains(u))
-        .toList();
-    final newOrder = [...exportedOrder, ...remaining];
+        .where((uid) => !localSet.contains(uid))
+        .toList(growable: false);
+    final newOrder = [...localOrder, ...appended];
 
+    final localActive = state.activeUid;
     final desiredActive = bundle.lastActiveUid;
-    final fallback =
-        state.activeUid != null && newByUid.containsKey(state.activeUid)
-        ? state.activeUid
+    final newActive =
+        (localActive != null && newByUid.containsKey(localActive))
+        ? localActive
+        : (desiredActive != null && newByUid.containsKey(desiredActive))
+        ? desiredActive
         : (newByUid.isEmpty
               ? null
               : (newOrder.isEmpty ? newByUid.keys.first : newOrder.first));
-    final newActive =
-        (desiredActive != null && newByUid.containsKey(desiredActive))
-        ? desiredActive
-        : fallback;
 
     await settingsNotifier.applyImportedPreferences(
       aliases: mergedAliases,
@@ -733,7 +739,8 @@ class GachaRepository extends Notifier<GachaState> {
     if (!ref.mounted) {
       return ImportResult(
         successAccounts: successCount,
-        totalRecords: totalRecords,
+        addedRecords: addedRecords,
+        duplicateRecords: duplicateRecords,
         failedUids: failed,
       );
     }
@@ -746,12 +753,13 @@ class GachaRepository extends Notifier<GachaState> {
 
     _log.info(
       'import: success=$successCount '
-      'failed=[${failed.join(",")}] '
-      'records=$totalRecords',
+      'failed=[${failed.map(sanitizeUid).join(",")}] '
+      'added=$addedRecords duplicate=$duplicateRecords',
     );
     return ImportResult(
       successAccounts: successCount,
-      totalRecords: totalRecords,
+      addedRecords: addedRecords,
+      duplicateRecords: duplicateRecords,
       failedUids: failed,
     );
   }

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -722,8 +722,7 @@ class GachaRepository extends Notifier<GachaState> {
 
     final localActive = state.activeUid;
     final desiredActive = bundle.lastActiveUid;
-    final newActive =
-        (localActive != null && newByUid.containsKey(localActive))
+    final newActive = (localActive != null && newByUid.containsKey(localActive))
         ? localActive
         : (desiredActive != null && newByUid.containsKey(desiredActive))
         ? desiredActive

--- a/lib/state/update_progress.dart
+++ b/lib/state/update_progress.dart
@@ -50,15 +50,19 @@ class ImportResult {
   /// 建立 [ImportResult]。
   const ImportResult({
     required this.successAccounts,
-    required this.totalRecords,
+    required this.addedRecords,
+    required this.duplicateRecords,
     required this.failedUids,
   });
 
   /// 成功匯入的帳號數。
   final int successAccounts;
 
-  /// 成功匯入的總紀錄數。
-  final int totalRecords;
+  /// 合併後新增的記錄數（備份中 id 本機原本沒有的）。
+  final int addedRecords;
+
+  /// 合併時已存在而略過的記錄數（備份中 id 本機原本就有的）。
+  final int duplicateRecords;
 
   /// 匯入失敗的 UID 列表。
   final List<String> failedUids;

--- a/lib/widgets/dialogs/accounts_picker_dialog.dart
+++ b/lib/widgets/dialogs/accounts_picker_dialog.dart
@@ -28,7 +28,7 @@ class AccountPickerEntry {
   /// 該帳號的祈願紀錄總筆數。
   final int recordCount;
 
-  /// 可選的紅色警示徽章文字（如「有新資料」提示）。
+  /// 可選的徽章文字（如「合併」提示）。
   final String? badge;
 }
 
@@ -218,13 +218,13 @@ class _PickerRow extends StatelessWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
               decoration: BoxDecoration(
-                color: tokens.stateDanger.withValues(alpha: 0.18),
+                color: tokens.accentPrimary.withValues(alpha: 0.18),
                 borderRadius: BorderRadius.circular(99),
               ),
               child: Text(
                 badge,
                 style: TextStyle(
-                  color: tokens.stateDanger,
+                  color: tokens.accentPrimary,
                   fontSize: 11,
                   fontWeight: FontWeight.bold,
                 ),

--- a/lib/widgets/dialogs/confirm_dialog.dart
+++ b/lib/widgets/dialogs/confirm_dialog.dart
@@ -28,6 +28,56 @@ Future<bool?> showConfirmTypeDialog({
   );
 }
 
+/// 顯示一個一般確認 dialog（無打字閘）。
+/// 回傳值：true = 確認 / false = 取消 / null = 系統 dismiss。
+/// [isDanger] 為 true 時確認鍵用 danger 紅；false 時用預設（中性）配色。
+Future<bool?> showConfirmDialog({
+  required BuildContext context,
+  required String title,
+  required String body,
+  required String cancelLabel,
+  required String confirmLabel,
+  IconData? confirmIcon,
+  bool isDanger = false,
+}) {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) {
+      final tokens = Theme.of(ctx).gacha;
+      return AppDialog(
+        title: Text(title),
+        content: Text(body),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(cancelLabel),
+          ),
+          FilledButton(
+            style: isDanger
+                ? FilledButton.styleFrom(
+                    backgroundColor: tokens.stateDanger,
+                    foregroundColor: Colors.white,
+                  )
+                : null,
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: confirmIcon == null
+                ? Text(confirmLabel)
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(confirmIcon, size: 18),
+                      const SizedBox(width: 8),
+                      Text(confirmLabel),
+                    ],
+                  ),
+          ),
+        ],
+      );
+    },
+  );
+}
+
 /// 打字確認 dialog 的實作 widget。
 class _ConfirmDialog extends StatefulWidget {
   const _ConfirmDialog({

--- a/lib/widgets/update_progress_dialog.dart
+++ b/lib/widgets/update_progress_dialog.dart
@@ -234,7 +234,8 @@ class _Body extends StatelessWidget {
               Text(
                 l.progressDoneImportSummary(
                   importSummary.successAccounts,
-                  importSummary.totalRecords,
+                  importSummary.addedRecords,
+                  importSummary.duplicateRecords,
                 ),
               )
             else

--- a/test/models/banner_storage_test.dart
+++ b/test/models/banner_storage_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
+
+GachaRecord _r(String id, {String lang = 'zh-tw'}) => GachaRecord(
+  id: id,
+  uid: '100000001',
+  gachaType: '301',
+  name: 'x',
+  itemType: '武器',
+  rankType: 3,
+  time: DateTime.utc(2025, 1, 1),
+  lang: lang,
+);
+
+BannerStorage _s(
+  Map<String, List<GachaRecord>> banners, {
+  DateTime? lastUpdated,
+}) => BannerStorage(
+  uid: '100000001',
+  lastUpdated: lastUpdated ?? DateTime.utc(2026, 1, 1),
+  banners: banners,
+);
+
+void main() {
+  test('union by id, dedup, sorted desc', () {
+    final local = _s({
+      '301': [_r('3'), _r('1')],
+    });
+    final incoming = _s({
+      '301': [_r('2'), _r('1')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.map((r) => r.id).toList(), ['3', '2', '1']);
+  });
+
+  test('banner keys are unioned', () {
+    final local = _s({
+      '301': [_r('1')],
+    });
+    final incoming = _s({
+      '302': [_r('2')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners.keys.toSet(), {'301', '302'});
+    expect(merged.banners['301']!.single.id, '1');
+    expect(merged.banners['302']!.single.id, '2');
+  });
+
+  test('lastUpdated takes the newer of the two', () {
+    final local = _s({'301': []}, lastUpdated: DateTime.utc(2026, 1, 1));
+    final incoming = _s({'301': []}, lastUpdated: DateTime.utc(2026, 5, 12));
+    expect(local.mergeWith(incoming).lastUpdated, DateTime.utc(2026, 5, 12));
+    expect(incoming.mergeWith(local).lastUpdated, DateTime.utc(2026, 5, 12));
+  });
+
+  test('same id: keep local, but backfill empty local lang from incoming', () {
+    final local = _s({
+      '301': [_r('1', lang: '')],
+    });
+    final incoming = _s({
+      '301': [_r('1', lang: 'en-us')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.single.lang, 'en-us');
+  });
+
+  test('same id: non-empty local lang is NOT overwritten by incoming', () {
+    final local = _s({
+      '301': [_r('1', lang: 'zh-tw')],
+    });
+    final incoming = _s({
+      '301': [_r('1', lang: 'en-us')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.single.lang, 'zh-tw');
+  });
+
+  test('empty local merges to incoming content', () {
+    final local = _s({});
+    final incoming = _s({
+      '301': [_r('2'), _r('1')],
+    });
+    final merged = local.mergeWith(incoming);
+    expect(merged.banners['301']!.map((r) => r.id).toList(), ['2', '1']);
+  });
+}

--- a/test/state/gacha_repository_import_with_hoyowiki_test.dart
+++ b/test/state/gacha_repository_import_with_hoyowiki_test.dart
@@ -181,7 +181,8 @@ void main() {
     expect(completed.importSummary, isNotNull);
     expect(completed.importSummary!.successAccounts, 2);
     expect(completed.importSummary!.failedUids, isEmpty);
-    expect(completed.importSummary!.totalRecords, 2);
+    expect(completed.importSummary!.addedRecords, 2);
+    expect(completed.importSummary!.duplicateRecords, 0);
     expect(
       completed.hoYoWikiImagesDownloaded,
       2,
@@ -227,7 +228,8 @@ void main() {
     expect(completed.hoYoWikiImagesDownloaded, 0);
     expect(completed.importSummary, isNotNull);
     expect(completed.importSummary!.successAccounts, 0);
-    expect(completed.importSummary!.totalRecords, 0);
+    expect(completed.importSummary!.addedRecords, 0);
+    expect(completed.importSummary!.duplicateRecords, 0);
     expect(completed.importSummary!.failedUids, isEmpty);
   });
 

--- a/test/state/gacha_repository_test.dart
+++ b/test/state/gacha_repository_test.dart
@@ -1129,71 +1129,68 @@ void main() {
     },
   );
 
-  test(
-    'importAccounts: uidOrder keeps local order, appends new UIDs',
-    () async {
-      final storage = GachaStorage(tempDir);
-      for (final uid in ['100000001', '100000003', '100000004']) {
-        await storage.save(
-          BannerStorage(
-            uid: uid,
-            lastUpdated: DateTime.utc(2026, 1, 1),
+  test('importAccounts: uidOrder keeps local order, appends new UIDs', () async {
+    final storage = GachaStorage(tempDir);
+    for (final uid in ['100000001', '100000003', '100000004']) {
+      await storage.save(
+        BannerStorage(
+          uid: uid,
+          lastUpdated: DateTime.utc(2026, 1, 1),
+          banners: const {'301': []},
+        ),
+      );
+    }
+
+    SharedPreferences.setMockInitialValues({
+      'pref.uidOrder': jsonEncode(['100000004', '100000001', '100000003']),
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        gachaStorageProvider.overrideWithValue(storage),
+        gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+        cancellableHttpClientFactoryProvider.overrideWithValue(
+          () => CancellableHttpClient(
+            client: MockClient((_) async => http.Response('{}', 200)),
+            cancel: () {},
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(gachaRepositoryProvider);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    final bundle = AccountsBundle(
+      exportedAt: DateTime.utc(2026, 5, 12),
+      appVersion: 'x',
+      lastActiveUid: null,
+      accounts: [
+        ExportedAccount(
+          data: BannerStorage(
+            uid: '100000002',
+            lastUpdated: DateTime.utc(2026, 5, 12),
             banners: const {'301': []},
           ),
-        );
-      }
-
-      SharedPreferences.setMockInitialValues({
-        'pref.uidOrder': jsonEncode(['100000004', '100000001', '100000003']),
-      });
-
-      final container = ProviderContainer(
-        overrides: [
-          gachaStorageProvider.overrideWithValue(storage),
-          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
-          cancellableHttpClientFactoryProvider.overrideWithValue(
-            () => CancellableHttpClient(
-              client: MockClient((_) async => http.Response('{}', 200)),
-              cancel: () {},
-            ),
+        ),
+        ExportedAccount(
+          data: BannerStorage(
+            uid: '100000001',
+            lastUpdated: DateTime.utc(2026, 5, 12),
+            banners: const {'301': []},
           ),
-        ],
-      );
-      addTearDown(container.dispose);
-      container.read(gachaRepositoryProvider);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+        ),
+      ],
+    );
 
-      final bundle = AccountsBundle(
-        exportedAt: DateTime.utc(2026, 5, 12),
-        appVersion: 'x',
-        lastActiveUid: null,
-        accounts: [
-          ExportedAccount(
-            data: BannerStorage(
-              uid: '100000002',
-              lastUpdated: DateTime.utc(2026, 5, 12),
-              banners: const {'301': []},
-            ),
-          ),
-          ExportedAccount(
-            data: BannerStorage(
-              uid: '100000001',
-              lastUpdated: DateTime.utc(2026, 5, 12),
-              banners: const {'301': []},
-            ),
-          ),
-        ],
-      );
+    await container
+        .read(gachaRepositoryProvider.notifier)
+        .debugImportOnly(bundle);
 
-      await container
-          .read(gachaRepositoryProvider.notifier)
-          .debugImportOnly(bundle);
-
-      final order = container.read(settingsProvider).uidOrder;
-      // local order [100000004, 100000001, 100000003] unchanged; new 100000002 appended
-      expect(order, ['100000004', '100000001', '100000003', '100000002']);
-    },
-  );
+    final order = container.read(settingsProvider).uidOrder;
+    // local order [100000004, 100000001, 100000003] unchanged; new 100000002 appended
+    expect(order, ['100000004', '100000001', '100000003', '100000002']);
+  });
 
   test(
     'importAccounts: storage write failure marks UID failed and skips it',

--- a/test/state/gacha_repository_test.dart
+++ b/test/state/gacha_repository_test.dart
@@ -1129,6 +1129,62 @@ void main() {
     },
   );
 
+  test(
+    'importAccounts: keeps local alias on conflict, does not adopt bundle alias',
+    () async {
+      final storage = GachaStorage(tempDir);
+      await storage.save(
+        BannerStorage(
+          uid: '100000001',
+          lastUpdated: DateTime.utc(2026, 1, 1),
+          banners: const {'301': []},
+        ),
+      );
+      SharedPreferences.setMockInitialValues({
+        'pref.uidAliases': jsonEncode({'100000001': '本機暱稱'}),
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(
+              client: MockClient((_) async => http.Response('{}', 200)),
+              cancel: () {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(gachaRepositoryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final bundle = AccountsBundle(
+        exportedAt: DateTime.utc(2026, 5, 12),
+        appVersion: 'x',
+        lastActiveUid: null,
+        accounts: [
+          ExportedAccount(
+            data: BannerStorage(
+              uid: '100000001',
+              lastUpdated: DateTime.utc(2026, 5, 12),
+              banners: const {'301': []},
+            ),
+            alias: '主號',
+          ),
+        ],
+      );
+
+      await container
+          .read(gachaRepositoryProvider.notifier)
+          .debugImportOnly(bundle);
+
+      // 本機已有別名 → 匯入的 '主號' 不得覆蓋
+      expect(container.read(settingsProvider).uidAliases['100000001'], '本機暱稱');
+    },
+  );
+
   test('importAccounts: uidOrder keeps local order, appends new UIDs', () async {
     final storage = GachaStorage(tempDir);
     for (final uid in ['100000001', '100000003', '100000004']) {

--- a/test/state/gacha_repository_test.dart
+++ b/test/state/gacha_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/gacha_record.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/cancellable_http_client.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/settings_storage.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_fetcher.dart';
@@ -1045,7 +1046,7 @@ void main() {
   });
 
   test(
-    'importAccounts: per-UID overwrite preserves non-imported accounts',
+    'importAccounts: merges into existing UID, preserves non-imported',
     () async {
       final storage = GachaStorage(tempDir);
       // Existing: 100000001 (old data), 100000003 (untouched)
@@ -1065,6 +1066,8 @@ void main() {
       );
       SharedPreferences.setMockInitialValues({
         'pref.uidAliases': jsonEncode({'100000003': '另一支'}),
+        'pref.uidOrder': jsonEncode(['100000001', '100000003']),
+        'pref.lastActiveUid': '100000001',
       });
 
       final container = ProviderContainer(
@@ -1112,7 +1115,7 @@ void main() {
 
       final state = container.read(gachaRepositoryProvider);
       expect(state.byUid.keys.toSet(), {'100000001', '100000002', '100000003'});
-      // 100000001 overwritten
+      // 100000001 merged: lastUpdated takes newer
       expect(state.byUid['100000001']!.lastUpdated, DateTime.utc(2026, 5, 12));
       // 100000003 preserved
       expect(state.byUid['100000003']!.lastUpdated, DateTime.utc(2026, 1, 1));
@@ -1121,13 +1124,13 @@ void main() {
       // Settings: alias on 100000001 (from bundle), alias on 100000003 (pre-existing, preserved)
       final settings = container.read(settingsProvider);
       expect(settings.uidAliases, {'100000001': '主號', '100000003': '另一支'});
-      expect(settings.uidOrder.take(2).toList(), ['100000001', '100000002']);
+      expect(settings.uidOrder, ['100000001', '100000003', '100000002']);
       expect(settings.lastActiveUid, '100000001');
     },
   );
 
   test(
-    'importAccounts: uidOrder merges imported order first, then remaining',
+    'importAccounts: uidOrder keeps local order, appends new UIDs',
     () async {
       final storage = GachaStorage(tempDir);
       for (final uid in ['100000001', '100000003', '100000004']) {
@@ -1187,8 +1190,8 @@ void main() {
           .debugImportOnly(bundle);
 
       final order = container.read(settingsProvider).uidOrder;
-      // imported [100000002, 100000001] first, then remaining custom order minus imported = [100000004, 100000003]
-      expect(order, ['100000002', '100000001', '100000004', '100000003']);
+      // local order [100000004, 100000001, 100000003] unchanged; new 100000002 appended
+      expect(order, ['100000004', '100000001', '100000003', '100000002']);
     },
   );
 
@@ -1256,7 +1259,7 @@ void main() {
   );
 
   test(
-    'importAccounts: bundle lastActiveUid switches active to it when imported',
+    'importAccounts: keeps local active when local active is valid',
     () async {
       final storage = GachaStorage(tempDir);
       // Existing active = 200000001 (will remain after import)
@@ -1308,10 +1311,128 @@ void main() {
           .read(gachaRepositoryProvider.notifier)
           .debugImportOnly(bundle);
 
-      expect(container.read(gachaRepositoryProvider).activeUid, '200000002');
-      expect(container.read(settingsProvider).lastActiveUid, '200000002');
+      expect(container.read(gachaRepositoryProvider).activeUid, '200000001');
+      expect(container.read(settingsProvider).lastActiveUid, '200000001');
     },
   );
+
+  test(
+    'importAccounts: adopts bundle lastActiveUid when local has no active',
+    () async {
+      final storage = GachaStorage(tempDir);
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(
+              client: MockClient((_) async => http.Response('{}', 200)),
+              cancel: () {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(gachaRepositoryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final bundle = AccountsBundle(
+        exportedAt: DateTime.utc(2026, 5, 12),
+        appVersion: 'x',
+        lastActiveUid: '200000002',
+        accounts: [
+          ExportedAccount(
+            data: BannerStorage(
+              uid: '200000002',
+              lastUpdated: DateTime.utc(2026, 5, 12),
+              banners: const {'301': []},
+            ),
+          ),
+        ],
+      );
+
+      await container
+          .read(gachaRepositoryProvider.notifier)
+          .debugImportOnly(bundle);
+
+      expect(container.read(gachaRepositoryProvider).activeUid, '200000002');
+    },
+  );
+
+  test(
+    'importAccounts: merges records by id, never drops local, counts added/duplicate',
+    () async {
+      GachaRecord rec(String id) => GachaRecord(
+        id: id,
+        uid: '100000001',
+        gachaType: '301',
+        name: 'x',
+        itemType: '武器',
+        rankType: 3,
+        time: DateTime.utc(2025, 1, 1),
+        lang: 'zh-tw',
+      );
+
+      final storage = GachaStorage(tempDir);
+      await storage.save(
+        BannerStorage(
+          uid: '100000001',
+          lastUpdated: DateTime.utc(2026, 1, 1),
+          banners: {
+            '301': [rec('3'), rec('1')],
+          },
+        ),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          gachaCaptureProvider.overrideWithValue(_FakeCapture(null)),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(
+              client: MockClient((_) async => http.Response('{}', 200)),
+              cancel: () {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(gachaRepositoryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final bundle = AccountsBundle(
+        exportedAt: DateTime.utc(2026, 5, 12),
+        appVersion: 'x',
+        lastActiveUid: null,
+        accounts: [
+          ExportedAccount(
+            data: BannerStorage(
+              uid: '100000001',
+              lastUpdated: DateTime.utc(2026, 5, 12),
+              banners: {
+                '301': [rec('2'), rec('1')],
+              },
+            ),
+          ),
+        ],
+      );
+
+      final result = await container
+          .read(gachaRepositoryProvider.notifier)
+          .debugImportOnly(bundle);
+
+      expect(result.addedRecords, 1); // id 2 是新的
+      expect(result.duplicateRecords, 1); // id 1 已存在
+      final merged = container
+          .read(gachaRepositoryProvider)
+          .byUid['100000001']!
+          .banners['301']!
+          .map((r) => r.id)
+          .toList();
+      expect(merged, ['3', '2', '1']); // 本機 id 3 沒被丟、降序
+    },
+  );
+
   group('logging instrumentation', () {
     setUp(() {
       Logger.root.level = Level.ALL;

--- a/test/widgets/dialogs/accounts_picker_dialog_test.dart
+++ b/test/widgets/dialogs/accounts_picker_dialog_test.dart
@@ -23,7 +23,7 @@ final _entries = [
     alias: '小號',
     lastUpdated: DateTime.utc(2026, 5, 12, 9),
     recordCount: 0,
-    badge: '覆蓋',
+    badge: '合併',
   ),
 ];
 
@@ -159,11 +159,9 @@ void main() {
     expect(find.text('100000003 (小號)'), findsOneWidget);
   });
 
-  testWidgets('overwrite badge shown only when entry.badge != null', (
-    tester,
-  ) async {
+  testWidgets('badge shown only when entry.badge != null', (tester) async {
     await _open(tester);
-    expect(find.text('覆蓋'), findsOneWidget);
+    expect(find.text('合併'), findsOneWidget);
   });
 
   testWidgets('subtitle shows lastUpdated + recordCount per locale', (

--- a/test/widgets/dialogs/confirm_dialog_test.dart
+++ b/test/widgets/dialogs/confirm_dialog_test.dart
@@ -109,4 +109,76 @@ void main() {
     expect(find.byIcon(Icons.check), findsOneWidget);
     expect(find.byIcon(Icons.delete_outline), findsNothing);
   });
+
+  testWidgets('showConfirmDialog: confirm enabled immediately, returns true', (
+    tester,
+  ) async {
+    bool? confirmed;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  confirmed = await showConfirmDialog(
+                    context: ctx,
+                    title: 'Merge',
+                    body: 'About to merge',
+                    cancelLabel: 'Cancel',
+                    confirmLabel: 'Import',
+                    confirmIcon: Icons.check,
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNothing);
+    final confirmBtn = find.widgetWithText(FilledButton, 'Import');
+    expect(tester.widget<FilledButton>(confirmBtn).onPressed, isNotNull);
+
+    await tester.tap(confirmBtn);
+    await tester.pumpAndSettle();
+    expect(confirmed, isTrue);
+  });
+
+  testWidgets('showConfirmDialog: cancel returns false', (tester) async {
+    bool? confirmed;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  confirmed = await showConfirmDialog(
+                    context: ctx,
+                    title: 'Merge',
+                    body: 'About to merge',
+                    cancelLabel: 'Cancel',
+                    confirmLabel: 'Import',
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(confirmed, isFalse);
+  });
 }


### PR DESCRIPTION
## 摘要

把「匯入全部資料」從**整帳號覆蓋**改為**非破壞性合併**：匯入是純加法，本機既有的祈願記錄與偏好永不因匯入而消失。設計與實作計畫見 `docs/superpowers/specs/2026-06-09-import-merge-design.md` 與 `docs/superpowers/plans/2026-06-09-import-merge.md`。

## 主要變更

- **合併原語**：新增 `BannerStorage.mergeWith`，逐 banner 依 `GachaRecord.id` union 去重、降序排序；同 id 保留本機那筆（必要時以非空 `lang` 回填），`lastUpdated` 取兩者較新者。
- **`_runImport`**：本機沒有的 UID 直接寫入；已有的 UID 走 `mergeWith` 後寫入。回報「新增 / 已存在」筆數（`ImportResult` 由 `totalRecords` 改為 `addedRecords` / `duplicateRecords`）。
- **偏好只補空缺**：別名僅在本機無別名時採用備份值；帳號順序保持本機既有、新 UID 接在最後；目前選取帳號優先保留本機。
- **確認流程非破壞性**：抽取共用 `showConfirmDialog`（`_clearGallery` / `_refetchAll` 一併改用），匯入確認移除「輸入 IMPORT」打字閘，badge 由紅色「覆蓋」改中性「合併」，完成後回報合併結果。
- **i18n**：9 個已翻譯語系同步調整文案。「匯入」為整體動作；「合併」僅用於描述與本機資料衝突時的處理（衝突標頭、既有帳號 badge）。

## 測試與驗證

- 新增 `BannerStorage.mergeWith` 單元測試，以及 `_runImport` 的合併 / 偏好只補空缺 / active fallback / 計數測試；既有匯入測試更新為合併語意。
- `fvm flutter analyze` → `No issues found!`
- `fvm flutter test` → 899 passed
- `fvm dart format` 已套用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)