### PR TITLE
feat(import): localize import/export failure reasons

### DIFF
--- a/docs/superpowers/plans/2026-06-09-import-export-error-l10n.md
+++ b/docs/superpowers/plans/2026-06-09-import-export-error-l10n.md
@@ -1,0 +1,477 @@
+# 匯入／匯出失敗原因在地化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓匯入／匯出失敗時顯示的原因改為使用者語言（目前是硬編碼英文），採分桶策略。
+
+**Architecture:** 底層 `FormatException` 的英文訊息保留（從此只供 log／測試），改在 UI 層依「捕捉到的例外型別」挑在地化文案；只為「版本過新」這個可行動特例新增專屬例外 `UnsupportedSchemaVersionException`，其餘解析錯誤全歸「格式不正確」一桶。重用既有 `settingsImportFailed`／`settingsExportFailed` wrapper，只替換帶入的原因字串。
+
+**Tech Stack:** Flutter／Dart、FVM 釘住 SDK、ARB + `flutter gen-l10n`（template = `app_zh.arb`，輸出 `lib/l10n/generated/`，未進版控）。
+
+> 設計來源：`docs/superpowers/specs/2026-06-09-import-export-error-l10n-design.md`
+> 指令一律優先用 `fvm`（`fvm flutter` / `fvm dart`）；找不到 `fvm` 才退回直接 `flutter` / `dart`。
+
+---
+
+## 檔案結構
+
+| 檔案 | 動作 | 責任 |
+|------|------|------|
+| `lib/models/accounts_bundle.dart` | Modify | 新增 `UnsupportedSchemaVersionException`；版本過新改丟此例外 |
+| `lib/services/accounts_import.dart` | Modify | 讓 `UnsupportedSchemaVersionException` 原樣上拋（先 log），不被泛用 catch 吞 |
+| `lib/pages/settings_page.dart` | Modify | 三個失敗點停止把英文丟進 UI，改帶在地化 reason key；匯入讀檔失敗補 log |
+| `lib/l10n/app_zh.arb`（template）+ 另 8 個已翻語系 | Modify | 新增 4 個 reason key（含譯文） |
+| `test/models/accounts_bundle_test.dart` | Modify | 版本過新測試改斷言 `UnsupportedSchemaVersionException` |
+| `test/services/accounts_import_test.dart` | Modify | 新增版本過新傳播測試 |
+
+已翻語系（有實體翻譯、要補 key 的 9 個）：`zh`（來源）、`en`、`fr`、`es`、`ja`、`vi`、`th`、`zh_Hans`、`pt_BR`。其餘約 22 個空殼 ARB **不要碰**（留給 Crowdin pipeline）。
+
+---
+
+## Task 1: 新增 `UnsupportedSchemaVersionException`（model 層）
+
+**Files:**
+- Modify: `lib/models/accounts_bundle.dart`（新增 class；改 `AccountsBundle.fromJson` 內版本檢查，約 `:73-77`）
+- Test: `test/models/accounts_bundle_test.dart:58-76`
+
+- [ ] **Step 1: 改寫版本過新的失敗測試（先紅）**
+
+把 `test/models/accounts_bundle_test.dart` 第 58–76 行整個 `test('schema_version > 1 throws with "update the app" hint', ...)` 區塊替換為：
+
+```dart
+  test('schema_version > currentSchemaVersion throws '
+      'UnsupportedSchemaVersionException', () {
+    final json = {
+      'schema_version': 999,
+      'exported_at': '2026-05-12T00:00:00.000Z',
+      'app_version': '1.0.0',
+      'last_active_uid': null,
+      'accounts': <Map<String, dynamic>>[],
+    };
+    expect(
+      () => AccountsBundle.fromJson(json),
+      throwsA(
+        isA<UnsupportedSchemaVersionException>().having(
+          (e) => e.version,
+          'version',
+          999,
+        ),
+      ),
+    );
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/models/accounts_bundle_test.dart`
+Expected: FAIL — 編譯錯誤 `Undefined name 'UnsupportedSchemaVersionException'`（型別還沒建立）。
+
+- [ ] **Step 3: 新增例外型別並改丟它**
+
+在 `lib/models/accounts_bundle.dart` 檔案最上方（`ExportedAccount` class 之前、`import` 之後）新增：
+
+```dart
+/// 匯入檔的 schema 版本高於目前 App 支援版本時拋出，供 UI 給出「請更新 App」指引。
+class UnsupportedSchemaVersionException implements Exception {
+  /// 建立 [UnsupportedSchemaVersionException]。
+  const UnsupportedSchemaVersionException(this.version);
+
+  /// 匯入檔宣告的 schema 版本（高於 [AccountsBundle.currentSchemaVersion]）。
+  final int version;
+}
+```
+
+在 `AccountsBundle.fromJson` 內，把原本的版本過新分支：
+
+```dart
+    if (version > currentSchemaVersion) {
+      throw FormatException(
+        'Unsupported schema version: $version. Please update the app.',
+      );
+    }
+```
+
+替換為：
+
+```dart
+    if (version > currentSchemaVersion) {
+      throw UnsupportedSchemaVersionException(version);
+    }
+```
+
+其餘所有 `FormatException`（`schema_version` 缺漏、`accounts` 非陣列、`accounts[$i]`、`Duplicate UID` 等）**保持不變**。
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/models/accounts_bundle_test.dart`
+Expected: PASS（All tests passed!）。其餘 `FormatException` 測試（missing schema_version、accounts must be an array、duplicate UID）仍應綠。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/models/accounts_bundle.dart test/models/accounts_bundle_test.dart
+git commit -m "feat(import): add UnsupportedSchemaVersionException for newer-than-supported backups"
+```
+
+---
+
+## Task 2: 讓 `importAccounts` 原樣上拋版本例外（service 層）
+
+**Files:**
+- Modify: `lib/services/accounts_import.dart:24-32`（包住 `AccountsBundle.fromJson` 的 try/catch）
+- Test: `test/services/accounts_import_test.dart`
+
+- [ ] **Step 1: 新增版本過新傳播測試（先紅）**
+
+在 `test/services/accounts_import_test.dart` 的 `main()` 內、最後一個 `test(...)` 之後（第 44 行 `});` 之後、`}` 之前）插入：
+
+```dart
+
+  test('schema_version > 1 → UnsupportedSchemaVersionException', () {
+    const text = '''
+{
+  "schema_version": 999,
+  "exported_at": "2026-05-12T08:30:00.000Z",
+  "app_version": "1.0.0",
+  "last_active_uid": null,
+  "accounts": []
+}
+''';
+    expect(
+      () => importAccounts(text),
+      throwsA(
+        isA<UnsupportedSchemaVersionException>().having(
+          (e) => e.version,
+          'version',
+          999,
+        ),
+      ),
+    );
+  });
+```
+
+並在檔案頂端的 import 區塊（第 2 行 `import '.../services/accounts_import.dart';` 之後）補上 model 的 import，讓測試看得到例外型別：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/services/accounts_import_test.dart`
+Expected: FAIL — 目前 `importAccounts` 的泛用 `catch (e, st)` 會把版本例外包成 `FormatException('Failed to parse: ...')`，故拋出的型別不是 `UnsupportedSchemaVersionException`。
+
+- [ ] **Step 3: 加一條 `on UnsupportedSchemaVersionException` 讓它原樣上拋**
+
+把 `lib/services/accounts_import.dart` 內第 24–32 行的：
+
+```dart
+  try {
+    return AccountsBundle.fromJson(raw);
+  } on FormatException catch (e) {
+    _log.warning('import failed: ${e.message}');
+    rethrow;
+  } catch (e, st) {
+    _log.warning('import failed: parse error', e, st);
+    throw FormatException('Failed to parse: $e');
+  }
+```
+
+替換為（在 `on FormatException` 之前先攔版本例外）：
+
+```dart
+  try {
+    return AccountsBundle.fromJson(raw);
+  } on UnsupportedSchemaVersionException catch (e) {
+    _log.warning('import failed: unsupported schema version ${e.version}');
+    rethrow;
+  } on FormatException catch (e) {
+    _log.warning('import failed: ${e.message}');
+    rethrow;
+  } catch (e, st) {
+    _log.warning('import failed: parse error', e, st);
+    throw FormatException('Failed to parse: $e');
+  }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/services/accounts_import_test.dart`
+Expected: PASS（含既有的 Invalid JSON、top-level array → FormatException 兩條仍綠）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/accounts_import.dart test/services/accounts_import_test.dart
+git commit -m "feat(import): propagate UnsupportedSchemaVersionException from importAccounts"
+```
+
+---
+
+## Task 3: 新增 4 個在地化 reason key（9 語系）+ 重新產生 l10n
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（template）、`app_en.arb`、`app_fr.arb`、`app_es.arb`、`app_ja.arb`、`app_vi.arb`、`app_th.arb`、`app_zh_Hans.arb`、`app_pt_BR.arb`
+
+> 每個檔案：找到 `settingsImportFailed` 條目及其 `@settingsImportFailed` metadata 區塊，在該 `@settingsImportFailed` 區塊的結尾 `},` 之後，插入該語系對應的 4 行（頂層 2 空格縮排，第 4 行尾端保留逗號——後面還有其他 key）。這 4 個 key **不需** `@key` 區塊（比照同層 `settingsImportSelectTitle` / `settingsImportMergeBadge` 等無 placeholder 的簡單字串）。**只改下列 9 個檔案**，其餘 ARB 不動。
+
+- [ ] **Step 1: `app_zh.arb`（template，來源）**
+
+```json
+  "importReasonInvalidFormat": "檔案格式不正確或已損毀",
+  "importReasonUnsupportedVersion": "此檔案由較新版本的 App 匯出，請先更新 App 後再匯入",
+  "importReasonUnreadable": "無法讀取檔案",
+  "exportReasonWriteFailed": "無法寫入檔案，請確認儲存位置與權限",
+```
+
+- [ ] **Step 2: `app_en.arb`**
+
+```json
+  "importReasonInvalidFormat": "The file format is invalid or the file is corrupted",
+  "importReasonUnsupportedVersion": "This file was exported by a newer version of the app. Please update the app before importing.",
+  "importReasonUnreadable": "Unable to read the file",
+  "exportReasonWriteFailed": "Unable to write the file, please check the save location and permissions",
+```
+
+- [ ] **Step 3: `app_fr.arb`**
+
+```json
+  "importReasonInvalidFormat": "Le format du fichier est incorrect ou le fichier est corrompu",
+  "importReasonUnsupportedVersion": "Ce fichier a été exporté par une version plus récente de l'application, veuillez la mettre à jour avant de l'importer",
+  "importReasonUnreadable": "Impossible de lire le fichier",
+  "exportReasonWriteFailed": "Impossible d'écrire le fichier, veuillez vérifier l'emplacement d'enregistrement et les autorisations",
+```
+
+- [ ] **Step 4: `app_es.arb`**
+
+```json
+  "importReasonInvalidFormat": "El formato del archivo no es válido o está dañado",
+  "importReasonUnsupportedVersion": "Este archivo se exportó con una versión más reciente de la aplicación, actualízala antes de importar",
+  "importReasonUnreadable": "No se puede leer el archivo",
+  "exportReasonWriteFailed": "No se puede escribir el archivo, comprueba la ubicación de guardado y los permisos",
+```
+
+- [ ] **Step 5: `app_ja.arb`**
+
+```json
+  "importReasonInvalidFormat": "ファイル形式が正しくないか、ファイルが破損しています",
+  "importReasonUnsupportedVersion": "このファイルは、より新しいバージョンのツールでエクスポートされています。ツールを更新してからインポートしてください",
+  "importReasonUnreadable": "ファイルを読み込めません",
+  "exportReasonWriteFailed": "ファイルを書き込めません。保存先と権限を確認してください",
+```
+
+- [ ] **Step 6: `app_vi.arb`**
+
+```json
+  "importReasonInvalidFormat": "Định dạng tệp không hợp lệ hoặc đã bị hỏng",
+  "importReasonUnsupportedVersion": "Tệp này được xuất từ phiên bản ứng dụng mới hơn, vui lòng cập nhật ứng dụng trước khi nhập",
+  "importReasonUnreadable": "Không thể đọc tệp",
+  "exportReasonWriteFailed": "Không thể ghi tệp, vui lòng kiểm tra vị trí lưu và quyền truy cập",
+```
+
+- [ ] **Step 7: `app_th.arb`**
+
+```json
+  "importReasonInvalidFormat": "รูปแบบไฟล์ไม่ถูกต้องหรือไฟล์เสียหาย",
+  "importReasonUnsupportedVersion": "ไฟล์นี้ถูกส่งออกจากแอปเวอร์ชันที่ใหม่กว่า กรุณาอัปเดตแอปก่อนนำเข้า",
+  "importReasonUnreadable": "ไม่สามารถอ่านไฟล์ได้",
+  "exportReasonWriteFailed": "ไม่สามารถเขียนไฟล์ได้ กรุณาตรวจสอบตำแหน่งที่บันทึกและสิทธิ์การเข้าถึง",
+```
+
+- [ ] **Step 8: `app_zh_Hans.arb`**
+
+```json
+  "importReasonInvalidFormat": "文件格式不正确或已损坏",
+  "importReasonUnsupportedVersion": "此文件由较新版本的软件导出，请先更新软件后再导入",
+  "importReasonUnreadable": "无法读取文件",
+  "exportReasonWriteFailed": "无法写入文件，请确认保存位置与权限",
+```
+
+- [ ] **Step 9: `app_pt_BR.arb`**
+
+```json
+  "importReasonInvalidFormat": "O formato do arquivo é inválido ou o arquivo está corrompido",
+  "importReasonUnsupportedVersion": "Este arquivo foi exportado por uma versão mais recente do aplicativo. Atualize o aplicativo antes de importar",
+  "importReasonUnreadable": "Não foi possível ler o arquivo",
+  "exportReasonWriteFailed": "Não foi possível gravar o arquivo. Verifique o local de salvamento e as permissões",
+```
+
+- [ ] **Step 10: 重新產生 l10n 並驗證 ARB 合法**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤輸出；`lib/l10n/generated/app_localizations.dart` 重新產生（此目錄未進版控，不需 commit）。
+
+驗證 getter 已生成：
+Run: `fvm flutter analyze`
+Expected: `No issues found!`（ARB JSON 合法、key 一致；此時程式還沒用到新 key，但不應因 ARB 出錯）。
+
+- [ ] **Step 11: Commit**
+
+> `lib/l10n/generated/` 未進版控，`git add lib/l10n/` 只會納入 `.arb`。
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add localized import/export failure reason strings"
+```
+
+---
+
+## Task 4: 接上 UI —— `settings_page.dart` 三個失敗點改用在地化 reason
+
+**Files:**
+- Modify: `lib/pages/settings_page.dart`（匯出失敗 `:497`、匯入讀檔失敗 `:527-532`、`importAccounts` catch `:536-544`）
+
+> `settings_page.dart` 已 import `models/accounts_bundle.dart`（`:15`）與 `package:logging/logging.dart`（`:7`），不需補 import。
+
+- [ ] **Step 1: 匯出失敗改用 `exportReasonWriteFailed`**
+
+把第 497 行：
+
+```dart
+        message: l.settingsExportFailed(e.toString()),
+```
+
+改為：
+
+```dart
+        message: l.settingsExportFailed(l.exportReasonWriteFailed),
+```
+
+（此區塊上方第 490–492 行已有 `Logger('accounts.io').severe('export failed ...', e, st)`，英文細節仍進 log，不需再動。）
+
+- [ ] **Step 2: 匯入讀檔失敗——補 log + 改用 `importReasonUnreadable`**
+
+把第 527–532 行：
+
+```dart
+    } catch (e) {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(content: Text(l.settingsImportFailed(e.toString()))),
+      );
+      return;
+    }
+```
+
+替換為：
+
+```dart
+    } catch (e, st) {
+      Logger('accounts.io').warning('import: read file failed', e, st);
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(content: Text(l.settingsImportFailed(l.importReasonUnreadable))),
+      );
+      return;
+    }
+```
+
+- [ ] **Step 3: `importAccounts` catch——依型別分桶**
+
+把第 536–544 行：
+
+```dart
+    try {
+      bundle = importAccounts(text);
+    } on FormatException catch (e) {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(content: Text(l.settingsImportFailed(e.message))),
+      );
+      return;
+    }
+```
+
+替換為：
+
+```dart
+    try {
+      bundle = importAccounts(text);
+    } on UnsupportedSchemaVersionException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonUnsupportedVersion)),
+        ),
+      );
+      return;
+    } on FormatException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonInvalidFormat)),
+        ),
+      );
+      return;
+    }
+```
+
+> 註：英文細節已在 `importAccounts` 內 `_log.warning`，UI 不重複 log。`on FormatException` / `on UnsupportedSchemaVersionException` 不綁變數，避免 unused-variable 警告。
+
+> 不在此加 widget 測試：此改動是「例外型別 → l10n key」的純呈現映射，要測得跑完整 widget pump + mock file picker，成本遠高於價值（既有測試也未覆蓋 settings_page UI）。靠 analyze + 全套 test 綠 + 手動驗收即可。
+
+- [ ] **Step 4: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 顯示已格式化的檔案數，無錯誤。
+
+- [ ] **Step 5: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 6: 全套測試**
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/pages/settings_page.dart
+git commit -m "fix(import): localize import/export failure reasons in settings"
+```
+
+---
+
+## Task 5: 最終驗收
+
+- [ ] **Step 1: 全套品質檢查（對齊 CLAUDE.md 提交前流程）**
+
+依序執行，三項全綠才算完成：
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+```
+
+Expected:
+- format：無錯誤
+- analyze：`No issues found!`
+- test：`All tests passed!`
+
+- [ ] **Step 2: 手動驗收（擇一語言切到非英文）**
+
+在非英文語系下，於設定頁觸發匯入一個壞掉／非 JSON 的檔案，確認 SnackBar 顯示的失敗原因為該語言（無英文殘留）；若手邊有「schema_version 較新」的測試檔，確認顯示「請更新 App」那條在地化訊息。
+
+> 不要主動 `git push`。
+
+---
+
+## Self-Review
+
+**Spec coverage（逐項對照 spec）：**
+- 匯入解析錯誤英文 → Task 3 `importReasonInvalidFormat` + Task 4 Step 3 `on FormatException`。✓
+- 版本過新可行動訊息 → Task 1（例外）+ Task 2（傳播）+ Task 3 `importReasonUnsupportedVersion` + Task 4 Step 3 `on UnsupportedSchemaVersionException`。✓
+- 匯入讀檔 IO 失敗 → Task 3 `importReasonUnreadable` + Task 4 Step 2（含補 log）。✓
+- 匯出 IO 失敗 → Task 3 `exportReasonWriteFailed` + Task 4 Step 1。✓
+- 英文細節保留在 log → model/service 既有 `_log.warning`／export 既有 `.severe` 不動；匯入讀檔失敗新增 `.warning`。✓
+- 只翻已翻語系、空殼留給 Crowdin → Task 3 限定 9 檔。✓
+- analyze + test 全綠 → Task 4 Step 5–6、Task 5。✓
+
+**Placeholder 掃描：** 無 TBD／TODO；每個改動步驟都附完整程式碼與實際譯文。✓
+
+**型別一致性：** `UnsupportedSchemaVersionException`（Task 1 定義 → Task 2 攔截 → Task 4 catch）、`.version` 欄位（Task 1 定義 → Task 1/2 測試斷言）、4 個 ARB key 名（Task 3 定義 → Task 4 引用）全程一致。✓
+
+**不在範圍：** `Text('Developed by ')`、中文 `semanticLabel`、純符號、只進 log 的技術性錯誤、`progressPartialImportFailed`／`settingsImportPartial`。

--- a/docs/superpowers/specs/2026-06-09-import-export-error-l10n-design.md
+++ b/docs/superpowers/specs/2026-06-09-import-export-error-l10n-design.md
@@ -1,0 +1,160 @@
+# 匯入／匯出失敗原因在地化設計
+
+## 背景與目標
+
+使用者回報「匯入資料失敗」時跳出的訊息是英文。追根究柢：外層「匯入失敗：{reason}」（`settingsImportFailed`）本身有在地化，但 `{reason}` 是由底層硬編碼英文 `FormatException` 的 `.message`／平台 IO 例外的 `.toString()` 直接帶入的，所以前綴是使用者語言、原因卻是英文。匯出失敗（`settingsExportFailed(e.toString())`）同樣中招。
+
+涉及的英文來源：
+
+- `lib/services/accounts_import.dart`：`'Invalid JSON'`、`'Top-level value must be an object'`、`'Failed to parse: $e'`
+- `lib/models/accounts_bundle.dart`：`'Missing or invalid "schema_version"'`、`'Unsupported schema version: $version...'`、`'Missing or invalid "accounts" array'`、`'accounts[$i] must be an object'`、`'accounts[$i]: $e'`、`'Duplicate UID in accounts: ...'`
+- `lib/pages/settings_page.dart`：匯入檔案讀取失敗與匯出失敗時直接把平台例外的 `toString()` 當原因顯示（英文 `FileSystemException` 等）
+
+本設計把這些**會顯示給使用者的失敗原因**改為在地化，採**分桶**策略。
+
+**成功條件**
+
+- 匯入／匯出失敗時，SnackBar／結果 dialog 顯示的原因為使用者語言，無殘留英文。
+- 可行動的特例（檔案由較新版本匯出）給出明確指引（請更新 App），與「格式不正確」一般失敗區隔。
+- 英文技術細節不丟失：保留在 log（既有 `_log.warning`／`Logger.severe`，並補上目前缺漏的匯入讀檔失敗那條 log）。
+- `fvm flutter analyze` 全綠、`fvm flutter test` 全綠。
+
+## 決策摘要
+
+| 面向 | 決策 |
+|------|------|
+| 呈現策略 | 分桶：可行動原因獨立成有意義訊息，其餘解析錯誤收斂成一桶「格式不正確或已損毀」，IO 讀／寫失敗各一桶 |
+| 在地化層級 | 在 **UI 層**依「捕捉到的例外型別」挑在地化文案；底層 `FormatException` 的英文訊息保留，從此**只供 log 與測試**，不再進 UI |
+| 特例辨識 | 只為「版本過新」加一個專屬例外型別 `UnsupportedSchemaVersionException`，讓 UI 能與一般 malformed 區隔；不引入錯誤分類 enum（YAGNI） |
+| wrapper 重用 | 重用既有 `settingsImportFailed(reason)`／`settingsExportFailed(error)`，只替換帶入的原因字串；不新造外層 key |
+| 版本訊息 | 版本過新訊息**不帶版本號 placeholder**（可行動指引不需數字，少一個翻譯欄位） |
+| 新增 ARB key | 4 個 reason key（見下表） |
+| 翻譯範圍 | 先寫 `app_zh.arb`（來源），翻 `app_en.arb` 及已有實體翻譯的語系；空殼 ARB 留給 Crowdin pipeline；用詞對齊 `docs/術語表.md` |
+
+## 設計
+
+### 1. `lib/models/accounts_bundle.dart`：新增可辨識的版本例外
+
+新增 top-level 例外型別（附一行 `///` dartdoc）：
+
+```dart
+/// 匯入檔的 schema 版本高於目前 App 支援版本時拋出，供 UI 給出「請更新 App」指引。
+class UnsupportedSchemaVersionException implements Exception {
+  /// 建立 [UnsupportedSchemaVersionException]。
+  const UnsupportedSchemaVersionException(this.version);
+
+  /// 匯入檔宣告的 schema 版本（高於 [AccountsBundle.currentSchemaVersion]）。
+  final int version;
+}
+```
+
+把原本的「版本過新」分支：
+
+```dart
+if (version > currentSchemaVersion) {
+  throw FormatException('Unsupported schema version: $version. Please update the app.');
+}
+```
+
+換成：
+
+```dart
+if (version > currentSchemaVersion) {
+  throw UnsupportedSchemaVersionException(version);
+}
+```
+
+其餘 `FormatException`（schema_version 缺漏、accounts 非陣列、accounts[i] 非物件、Duplicate UID 等）**全部不動**——它們歸到「格式不正確」這一桶，英文訊息續供 log／測試。
+
+### 2. `lib/services/accounts_import.dart`：讓版本例外原樣上拋
+
+`importAccounts` 內包住 `AccountsBundle.fromJson` 的 try/catch（現為 `on FormatException { rethrow }` + 泛用 `catch (e, st)` 包成 `FormatException('Failed to parse: $e')`）要先攔 `UnsupportedSchemaVersionException` 原樣 rethrow（先 log），避免被泛用 catch 吞成 `FormatException`：
+
+```dart
+try {
+  return AccountsBundle.fromJson(raw);
+} on UnsupportedSchemaVersionException catch (e) {
+  _log.warning('import failed: unsupported schema version ${e.version}');
+  rethrow;
+} on FormatException catch (e) {
+  _log.warning('import failed: ${e.message}');
+  rethrow;
+} catch (e, st) {
+  _log.warning('import failed: parse error', e, st);
+  throw FormatException('Failed to parse: $e');
+}
+```
+
+`importAccounts` 對外契約變為：可能拋 `UnsupportedSchemaVersionException`（版本過新）或 `FormatException`（其餘 malformed）。
+
+### 3. `lib/pages/settings_page.dart`：三個失敗點停止把英文丟進 UI
+
+三處都不再把 `e.message`／`e.toString()` 當原因，改帶在地化字串：
+
+**(a) 匯入檔案讀取失敗**（現 `catch (e)` → `l.settingsImportFailed(e.toString())`，且**目前無 log**）：
+
+```dart
+} catch (e, st) {
+  Logger('accounts.io').warning('import: read file failed', e, st);
+  if (!ctx.mounted) return;
+  ScaffoldMessenger.of(ctx).showSnackBar(
+    SnackBar(content: Text(l.settingsImportFailed(l.importReasonUnreadable))),
+  );
+  return;
+}
+```
+
+**(b) `importAccounts` 失敗**（現單一 `on FormatException` → `l.settingsImportFailed(e.message)`）改為依型別分桶：
+
+```dart
+final AccountsBundle bundle;
+try {
+  bundle = importAccounts(text);
+} on UnsupportedSchemaVersionException {
+  if (!ctx.mounted) return;
+  ScaffoldMessenger.of(ctx).showSnackBar(
+    SnackBar(content: Text(l.settingsImportFailed(l.importReasonUnsupportedVersion))),
+  );
+  return;
+} on FormatException {
+  if (!ctx.mounted) return;
+  ScaffoldMessenger.of(ctx).showSnackBar(
+    SnackBar(content: Text(l.settingsImportFailed(l.importReasonInvalidFormat))),
+  );
+  return;
+}
+```
+
+（底層英文細節已於 `importAccounts` 內 `_log.warning`，不需在 UI 重複 log。）
+
+**(c) 匯出失敗**（現 `l.settingsExportFailed(e.toString())`，已有 `Logger.severe`）：
+
+```dart
+message: l.settingsExportFailed(l.exportReasonWriteFailed),
+```
+
+### 4. ARB：4 個新 reason key（分桶）
+
+| key | 繁中（`app_zh.arb`，來源） | 用途 |
+|---|---|---|
+| `importReasonInvalidFormat` | 檔案格式不正確或已損毀 | 所有解析／格式錯誤（含缺欄位、結構錯誤、重複 UID） |
+| `importReasonUnsupportedVersion` | 此檔案由較新版本的 App 匯出，請先更新 App 後再匯入 | 版本過新（可行動） |
+| `importReasonUnreadable` | 無法讀取檔案 | 匯入時讀檔 IO 失敗 |
+| `exportReasonWriteFailed` | 無法寫入檔案，請確認儲存位置與權限 | 匯出 IO 失敗 |
+
+- 每個 key 附 `@key` 的 `description`，說明使用情境（供翻譯者理解）。
+- 先寫 `app_zh.arb`，再以中文為基準翻 `app_en.arb` 及其餘**已有實體翻譯**的語系；空殼 ARB 不碰（留給 Crowdin pipeline）。
+- 用詞對齊 `docs/術語表.md`（匯入／匯出等）。
+
+### 5. 測試
+
+- `test/models/accounts_bundle_test.dart`：把「版本過新」那條從斷言 `FormatException`（含 `'Unsupported schema version'` 訊息）改為斷言 `UnsupportedSchemaVersionException`，並驗 `.version`。其餘 `FormatException` 案例不動。
+- `test/services/accounts_import_test.dart`：若有版本相關案例，同步改為斷言 `UnsupportedSchemaVersionException`；malformed 案例維持斷言 `FormatException`（契約不變）。
+- 新增涵蓋：`importAccounts` 對版本過新檔案拋 `UnsupportedSchemaVersionException(version)`（型別 + version 值）。
+
+## 不在範圍
+
+- `lib/pages/settings_page.dart` 的 `Text('Developed by ')`（英文）與 `semanticLabel: '旋風之音 GoneTone'`（中文）——使用者本次只要修匯入／匯出原因。
+- 分頁 `/`、分隔符 `·`／`・`、括號等純符號。
+- 只進 log 的技術性錯誤（`StateError('toByteData returned null')`、FFI `Exception('unexpected arr length...')`）——不該也不需在地化。
+- 匯入部分成功的回報（`progressPartialImportFailed`、`settingsImportPartial`）——前綴已在地化，帶出的只有 UID 數字，不含英文。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -639,6 +639,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "The file format is invalid or the file is corrupted",
+  "importReasonUnsupportedVersion": "This file was exported by a newer version of the app. Please update the app before importing.",
+  "importReasonUnreadable": "Unable to read the file",
+  "exportReasonWriteFailed": "Unable to write the file, please check the save location and permissions",
   "settingsExportSelectTitle": "Select accounts to export",
   "settingsImportSelectTitle": "Select accounts to import",
   "settingsImportMergeBadge": "Merge",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "El formato del archivo no es válido o está dañado",
+  "importReasonUnsupportedVersion": "Este archivo se exportó con una versión más reciente de la aplicación, actualízala antes de importar",
+  "importReasonUnreadable": "No se puede leer el archivo",
+  "exportReasonWriteFailed": "No se puede escribir el archivo, comprueba la ubicación de guardado y los permisos",
   "settingsExportSelectTitle": "Seleccionar cuentas a exportar",
   "settingsImportSelectTitle": "Seleccionar cuentas a importar",
   "settingsImportMergeBadge": "Combinar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "Le format du fichier est incorrect ou le fichier est corrompu",
+  "importReasonUnsupportedVersion": "Ce fichier a été exporté par une version plus récente de l'application, veuillez la mettre à jour avant de l'importer",
+  "importReasonUnreadable": "Impossible de lire le fichier",
+  "exportReasonWriteFailed": "Impossible d'écrire le fichier, veuillez vérifier l'emplacement d'enregistrement et les autorisations",
   "settingsExportSelectTitle": "Sélectionner les comptes à exporter",
   "settingsImportSelectTitle": "Sélectionner les comptes à importer",
   "settingsImportMergeBadge": "Fusionner",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "ファイル形式が正しくないか、ファイルが破損しています",
+  "importReasonUnsupportedVersion": "このファイルは、より新しいバージョンのツールでエクスポートされています。ツールを更新してからインポートしてください",
+  "importReasonUnreadable": "ファイルを読み込めません",
+  "exportReasonWriteFailed": "ファイルを書き込めません。保存先と権限を確認してください",
   "settingsExportSelectTitle": "エクスポートするアカウントを選択",
   "settingsImportSelectTitle": "インポートするアカウントを選択",
   "settingsImportMergeBadge": "統合",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "O formato do arquivo é inválido ou o arquivo está corrompido",
+  "importReasonUnsupportedVersion": "Este arquivo foi exportado por uma versão mais recente do aplicativo. Atualize o aplicativo antes de importar",
+  "importReasonUnreadable": "Não foi possível ler o arquivo",
+  "exportReasonWriteFailed": "Não foi possível gravar o arquivo. Verifique o local de salvamento e as permissões",
   "settingsExportSelectTitle": "Selecionar contas para exportar",
   "settingsImportSelectTitle": "Selecionar contas para importar",
   "settingsImportMergeBadge": "Mesclar",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "รูปแบบไฟล์ไม่ถูกต้องหรือไฟล์เสียหาย",
+  "importReasonUnsupportedVersion": "ไฟล์นี้ถูกส่งออกจากแอปเวอร์ชันที่ใหม่กว่า กรุณาอัปเดตแอปก่อนนำเข้า",
+  "importReasonUnreadable": "ไม่สามารถอ่านไฟล์ได้",
+  "exportReasonWriteFailed": "ไม่สามารถเขียนไฟล์ได้ กรุณาตรวจสอบตำแหน่งที่บันทึกและสิทธิ์การเข้าถึง",
   "settingsExportSelectTitle": "เลือกบัญชีที่จะส่งออก",
   "settingsImportSelectTitle": "เลือกบัญชีที่จะนำเข้า",
   "settingsImportMergeBadge": "ผสาน",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -636,6 +636,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "Định dạng tệp không hợp lệ hoặc đã bị hỏng",
+  "importReasonUnsupportedVersion": "Tệp này được xuất từ phiên bản ứng dụng mới hơn, vui lòng cập nhật ứng dụng trước khi nhập",
+  "importReasonUnreadable": "Không thể đọc tệp",
+  "exportReasonWriteFailed": "Không thể ghi tệp, vui lòng kiểm tra vị trí lưu và quyền truy cập",
   "settingsExportSelectTitle": "Chọn tài khoản để xuất",
   "settingsImportSelectTitle": "Chọn tài khoản để nhập",
   "settingsImportMergeBadge": "Hợp nhất",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -469,6 +469,10 @@
   "@settingsImportFailed": {
     "placeholders": { "reason": { "type": "String" } }
   },
+  "importReasonInvalidFormat": "檔案格式不正確或已損毀",
+  "importReasonUnsupportedVersion": "此檔案由較新版本的 App 匯出，請先更新 App 後再匯入",
+  "importReasonUnreadable": "無法讀取檔案",
+  "exportReasonWriteFailed": "無法寫入檔案，請確認儲存位置與權限",
 
   "settingsExportSelectTitle": "選擇要匯出的帳號",
   "settingsImportSelectTitle": "選擇要匯入的帳號",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -632,6 +632,10 @@
       }
     }
   },
+  "importReasonInvalidFormat": "文件格式不正确或已损坏",
+  "importReasonUnsupportedVersion": "此文件由较新版本的软件导出，请先更新软件后再导入",
+  "importReasonUnreadable": "无法读取文件",
+  "exportReasonWriteFailed": "无法写入文件，请确认保存位置与权限",
   "settingsExportSelectTitle": "选择要导出的账号",
   "settingsImportSelectTitle": "选择要导入的账号",
   "settingsImportMergeBadge": "合并",

--- a/lib/models/accounts_bundle.dart
+++ b/lib/models/accounts_bundle.dart
@@ -7,6 +7,9 @@ class UnsupportedSchemaVersionException implements Exception {
 
   /// 匯入檔宣告的 schema 版本（高於 [AccountsBundle.currentSchemaVersion]）。
   final int version;
+
+  @override
+  String toString() => 'UnsupportedSchemaVersionException(version: $version)';
 }
 
 /// 單一匯出帳號：包含祈願資料與選填別名。
@@ -73,7 +76,9 @@ class AccountsBundle {
     'accounts': accounts.map((a) => a.toJson()).toList(growable: false),
   };
 
-  /// 從 JSON 還原 [AccountsBundle]，schema 版本不相容時丟 [FormatException]。
+  /// 從 JSON 還原 [AccountsBundle]。
+  ///
+  /// schema 版本高於支援版本時丟 [UnsupportedSchemaVersionException]；其餘格式錯誤丟 [FormatException]。
   factory AccountsBundle.fromJson(Map<String, dynamic> json) {
     final version = json['schema_version'];
     if (version is! int) {

--- a/lib/models/accounts_bundle.dart
+++ b/lib/models/accounts_bundle.dart
@@ -1,5 +1,14 @@
 import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
 
+/// 匯入檔的 schema 版本高於目前 App 支援版本時拋出，供 UI 給出「請更新 App」指引。
+class UnsupportedSchemaVersionException implements Exception {
+  /// 建立 [UnsupportedSchemaVersionException]。
+  const UnsupportedSchemaVersionException(this.version);
+
+  /// 匯入檔宣告的 schema 版本（高於 [AccountsBundle.currentSchemaVersion]）。
+  final int version;
+}
+
 /// 單一匯出帳號：包含祈願資料與選填別名。
 class ExportedAccount {
   /// 建立 [ExportedAccount]。
@@ -71,9 +80,7 @@ class AccountsBundle {
       throw const FormatException('Missing or invalid "schema_version"');
     }
     if (version > currentSchemaVersion) {
-      throw FormatException(
-        'Unsupported schema version: $version. Please update the app.',
-      );
+      throw UnsupportedSchemaVersionException(version);
     }
 
     final rawAccounts = json['accounts'];

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -494,7 +494,7 @@ class _DataManagement extends ConsumerWidget {
       await showExportResultDialog(
         ctx,
         success: false,
-        message: l.settingsExportFailed(e.toString()),
+        message: l.settingsExportFailed(l.exportReasonWriteFailed),
       );
       return;
     }
@@ -524,10 +524,13 @@ class _DataManagement extends ConsumerWidget {
     final String text;
     try {
       text = await file.readAsString();
-    } catch (e) {
+    } catch (e, st) {
+      Logger('accounts.io').warning('import: read file failed', e, st);
       if (!ctx.mounted) return;
       ScaffoldMessenger.of(ctx).showSnackBar(
-        SnackBar(content: Text(l.settingsImportFailed(e.toString()))),
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonUnreadable)),
+        ),
       );
       return;
     }
@@ -535,10 +538,22 @@ class _DataManagement extends ConsumerWidget {
     final AccountsBundle bundle;
     try {
       bundle = importAccounts(text);
-    } on FormatException catch (e) {
+    } on UnsupportedSchemaVersionException {
       if (!ctx.mounted) return;
       ScaffoldMessenger.of(ctx).showSnackBar(
-        SnackBar(content: Text(l.settingsImportFailed(e.message))),
+        SnackBar(
+          content: Text(
+            l.settingsImportFailed(l.importReasonUnsupportedVersion),
+          ),
+        ),
+      );
+      return;
+    } on FormatException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonInvalidFormat)),
+        ),
       );
       return;
     }

--- a/lib/services/accounts_import.dart
+++ b/lib/services/accounts_import.dart
@@ -7,8 +7,9 @@ import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 /// Logger 實例（帳號匯入/匯出）。
 final _log = Logger('accounts.io');
 
-/// 把 JSON 文字解析回 [AccountsBundle]。任何結構或型別不符都會
-/// 統一拋出 [FormatException]，給 UI 顯示用。
+/// 把 JSON 文字解析回 [AccountsBundle]。
+/// 版本號過新時拋出 [UnsupportedSchemaVersionException]；
+/// 其餘結構／型別不符時統一拋出 [FormatException]，給 UI 顯示用。
 AccountsBundle importAccounts(String text) {
   Object? raw;
   try {
@@ -23,6 +24,9 @@ AccountsBundle importAccounts(String text) {
   }
   try {
     return AccountsBundle.fromJson(raw);
+  } on UnsupportedSchemaVersionException catch (e) {
+    _log.warning('import failed: unsupported schema version ${e.version}');
+    rethrow;
   } on FormatException catch (e) {
     _log.warning('import failed: ${e.message}');
     rethrow;

--- a/test/models/accounts_bundle_test.dart
+++ b/test/models/accounts_bundle_test.dart
@@ -55,7 +55,8 @@ void main() {
     },
   );
 
-  test('schema_version > 1 throws with "update the app" hint', () {
+  test('schema_version > currentSchemaVersion throws '
+      'UnsupportedSchemaVersionException', () {
     final json = {
       'schema_version': 999,
       'exported_at': '2026-05-12T00:00:00.000Z',
@@ -66,10 +67,10 @@ void main() {
     expect(
       () => AccountsBundle.fromJson(json),
       throwsA(
-        isA<FormatException>().having(
-          (e) => e.message,
-          'message',
-          contains('update the app'),
+        isA<UnsupportedSchemaVersionException>().having(
+          (e) => e.version,
+          'version',
+          999,
         ),
       ),
     );

--- a/test/services/accounts_import_test.dart
+++ b/test/services/accounts_import_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/accounts_import.dart';
 
 void main() {
@@ -38,6 +39,28 @@ void main() {
           (e) => e.message,
           'message',
           contains('object'),
+        ),
+      ),
+    );
+  });
+
+  test('schema_version > 1 → UnsupportedSchemaVersionException', () {
+    const text = '''
+{
+  "schema_version": 999,
+  "exported_at": "2026-05-12T08:30:00.000Z",
+  "app_version": "1.0.0",
+  "last_active_uid": null,
+  "accounts": []
+}
+''';
+    expect(
+      () => importAccounts(text),
+      throwsA(
+        isA<UnsupportedSchemaVersionException>().having(
+          (e) => e.version,
+          'version',
+          999,
         ),
       ),
     );


### PR DESCRIPTION
@
## 摘要

匯入／匯出失敗時顯示的原因原本是硬編碼英文（底層例外的 `.message`／`.toString()` 直接帶進「匯入失敗：{reason}」外層），導致前綴是使用者語言、原因卻是英文。本 PR 改為在地化，採分桶策略：

- 新增 `UnsupportedSchemaVersionException`（版本過新專屬例外），讓可行動的「請更新 App」與一般 malformed 區隔。
- `importAccounts` 讓該例外原樣上拋，不被泛用 catch 吞成 `FormatException`。
- UI 三個失敗點（匯入讀檔、匯入解析、匯出寫檔）改用在地化 reason；底層英文細節仍進 log。
- 新增 4 個 reason key（`importReasonInvalidFormat`／`importReasonUnsupportedVersion`／`importReasonUnreadable`／`exportReasonWriteFailed`），翻進 9 個已翻語系；空殼語系留給 Crowdin pipeline。

設計：`docs/superpowers/specs/2026-06-09-import-export-error-l10n-design.md`
計畫：`docs/superpowers/plans/2026-06-09-import-export-error-l10n.md`

## 測試

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — 全綠
- 手動：非英文語系下匯入壞檔，失敗原因顯示為該語言

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@