### PR TITLE
feat(import): detect and reject foreign-app backups on import

### DIFF
--- a/docs/superpowers/plans/2026-06-09-import-foreign-app-detection.md
+++ b/docs/superpowers/plans/2026-06-09-import-foreign-app-detection.md
@@ -1,0 +1,547 @@
+# 匯入時判別檔案是否由本軟體匯出 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 匯入時辨識並拒絕「非本軟體匯出」的備份檔（如姐妹專案鳴潮的檔），混合舊檔則只匯入可辨識的原神 banner。
+
+**Architecture:** 匯出端寫入 `app` 識別欄位（純加法、不 bump schema_version）。匯入端在 `importAccounts` 內、`AccountsBundle.fromJson` 之前判別：顯式 `app` 相符 → 完整信任、不過濾；`app` 不符 → 丟新例外 `ForeignBundleException`；無 `app` 的舊檔 → 依卡池代碼是否屬於 `gachaTypes` 已知集合判別並濾掉未知 banner（純外來則拋例外）。UI 依型別顯示在地化原因。
+
+**Tech Stack:** Flutter／Dart、FVM、ARB + `flutter gen-l10n`（template = `app_zh.arb`，輸出 `lib/l10n/generated/` 未進版控）。
+
+> 設計來源：`docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md`
+> 此分支已含前一支功能（匯入／匯出錯誤在地化）：`importAccounts` 已有 `on UnsupportedSchemaVersionException`／`on FormatException`，`settings_page` 已有對應 catch 臂，ARB 已有 `importReason*`／`exportReasonWriteFailed`。
+> 指令一律優先 `fvm flutter`／`fvm dart`；找不到 `fvm` 才退回 `flutter`／`dart`。Commit message 用英文 conventional commits；dartdoc／註解用繁中全形標點。不要 git push。
+
+---
+
+## 檔案結構
+
+| 檔案 | 動作 | 責任 |
+|------|------|------|
+| `lib/models/accounts_bundle.dart` | Modify | 新增 `accountsBundleAppId` 常數；`toJson` 加寫 `app` 欄位 |
+| `lib/services/accounts_import.dart` | Modify | 新增 `ForeignBundleException`；`importAccounts` 加身分判別兩條路 + `_screenLegacyBundle` helper |
+| `lib/pages/settings_page.dart` | Modify | 匯入 catch 加 `on ForeignBundleException` → 在地化原因 |
+| `lib/l10n/app_zh.arb` + 另 8 個已翻語系 | Modify | 新增 `importReasonForeignApp` |
+| `test/models/accounts_bundle_test.dart` | Modify | `toJson` 含 `app` |
+| `test/services/accounts_export_test.dart` | Modify | 匯出 JSON 含 `app` |
+| `test/services/accounts_import_test.dart` | Modify | 身分判別／過濾／順序測試 |
+
+已翻語系（要補 key 的 9 個）：`zh`（來源）、`en`、`fr`、`es`、`ja`、`vi`、`th`、`zh_Hans`、`pt_BR`。其餘約 22 個空殼 ARB **不要碰**。
+
+---
+
+## Task 1: 匯出端寫入 `app` 識別欄位
+
+**Files:**
+- Modify: `lib/models/accounts_bundle.dart`（檔頭加常數；`toJson` `:71-77`）
+- Test: `test/models/accounts_bundle_test.dart`、`test/services/accounts_export_test.dart`
+
+- [ ] **Step 1: 寫失敗測試（先紅）**
+
+在 `test/models/accounts_bundle_test.dart` 的 `main()` 內、最後一個 `test(...)` 之後（檔尾 `}` 之前）加入：
+
+```dart
+
+  test('toJson includes the app identifier', () {
+    final bundle = AccountsBundle(
+      exportedAt: DateTime.utc(2026, 6, 9),
+      appVersion: '1.0.0',
+      lastActiveUid: null,
+      accounts: const [],
+    );
+    expect(bundle.toJson()['app'], accountsBundleAppId);
+  });
+```
+
+在 `test/services/accounts_export_test.dart` 第一個 test 的 `expect(decoded['schema_version'], 1);`（約 `:33`）下一行加入：
+
+```dart
+    expect(decoded['app'], accountsBundleAppId);
+```
+
+並在該檔 import 區塊（`:5` `accounts_export.dart` 那行之後）補上 model import 讓常數可見：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/models/accounts_bundle_test.dart test/services/accounts_export_test.dart`
+Expected: FAIL — `Undefined name 'accountsBundleAppId'`（常數還沒建立）。
+
+- [ ] **Step 3: 新增常數並寫入 toJson**
+
+在 `lib/models/accounts_bundle.dart` 第 1 行 import 之後、`UnsupportedSchemaVersionException` 之前插入：
+
+```dart
+
+/// 本軟體的匯出識別字串，寫入備份檔的 `app` 欄位供匯入端辨識來源。
+///
+/// 值對齊 pubspec 套件名；姐妹專案（鳴潮）為 `wuthering_waves_convene_gacha_analyzer`，天生相異。
+const String accountsBundleAppId = 'genshin_impact_wish_gacha_analyzer';
+```
+
+把 `AccountsBundle.toJson`（`:71-77`）改為（在 `schema_version` 後加 `app`）：
+
+```dart
+  Map<String, dynamic> toJson() => {
+    'schema_version': schemaVersion,
+    'app': accountsBundleAppId,
+    'exported_at': exportedAt.toUtc().toIso8601String(),
+    'app_version': appVersion,
+    'last_active_uid': lastActiveUid,
+    'accounts': accounts.map((a) => a.toJson()).toList(growable: false),
+  };
+```
+
+`fromJson` 不需改（忽略未知欄位）。schema_version 維持 `1`。
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/models/accounts_bundle_test.dart test/services/accounts_export_test.dart`
+Expected: PASS（既有 round-trip／export 測試仍綠）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+git add lib/models/accounts_bundle.dart test/models/accounts_bundle_test.dart test/services/accounts_export_test.dart
+git commit -m "feat(export): tag exported bundles with app identifier"
+```
+
+---
+
+## Task 2: `ForeignBundleException` + 身分判別與過濾（importAccounts）
+
+**Files:**
+- Modify: `lib/services/accounts_import.dart`
+- Test: `test/services/accounts_import_test.dart`
+
+- [ ] **Step 1: 寫失敗測試（先紅）**
+
+在 `test/services/accounts_import_test.dart` 檔頭加入 `dart:convert` import（若尚無），確認已 import `accounts_bundle.dart`（前一支功能已加；若無則補）。在檔頭 import 區塊後、`void main()` 之前加入測試輔助：
+
+```dart
+Map<String, dynamic> _account(String uid, List<String> codes) => {
+  'uid': uid,
+  'last_updated': '2026-05-12T07:55:00.000Z',
+  'banners': {for (final c in codes) c: <dynamic>[]},
+};
+
+Map<String, dynamic> _bundle({
+  String? app,
+  int schema = 1,
+  required List<Map<String, dynamic>> accounts,
+}) => {
+  'schema_version': schema,
+  if (app != null) 'app': app,
+  'exported_at': '2026-05-12T08:30:00.000Z',
+  'app_version': '1.0.0',
+  'last_active_uid': null,
+  'accounts': accounts,
+};
+```
+
+在 `main()` 內、最後一個 `test(...)` 之後加入：
+
+```dart
+
+  test('explicit app mismatch → ForeignBundleException', () {
+    final text = jsonEncode(
+      _bundle(
+        app: 'wuthering_waves_convene_gacha_analyzer',
+        accounts: [_account('A', ['301'])],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
+  });
+
+  test('explicit app match → no filtering, unknown codes kept', () {
+    final text = jsonEncode(
+      _bundle(
+        app: accountsBundleAppId,
+        accounts: [
+          _account('A', ['301', '600']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301', '600'});
+  });
+
+  test('legacy pure Genshin codes → all banners kept', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301', '302']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301', '302'});
+  });
+
+  test('legacy pure Wuthering Waves codes → ForeignBundleException', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['1', '2', '7']),
+        ],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
+  });
+
+  test('legacy mixed codes → unknown banners filtered, known kept', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301', '1']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301'});
+  });
+
+  test('legacy mixed → account left with only foreign codes is dropped', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301']),
+          _account('B', ['1', '2']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.map((a) => a.data.uid).toList(), ['A']);
+  });
+
+  test('legacy empty accounts → not foreign, empty bundle', () {
+    final text = jsonEncode(_bundle(accounts: []));
+    final bundle = importAccounts(text);
+    expect(bundle.accounts, isEmpty);
+  });
+
+  test('pure foreign with schema_version 999 → ForeignBundleException '
+      '(precedes version check)', () {
+    final text = jsonEncode(
+      _bundle(
+        schema: 999,
+        accounts: [
+          _account('A', ['1']),
+        ],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/services/accounts_import_test.dart`
+Expected: FAIL — `Undefined name 'ForeignBundleException'`（型別還沒建立）。
+
+- [ ] **Step 3: 實作例外、判別與過濾**
+
+在 `lib/services/accounts_import.dart` 的 import 區塊（`:5` `accounts_bundle.dart` 之後）加上：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+```
+
+在 `_log` 定義之後、`importAccounts` 之前新增例外型別：
+
+```dart
+/// 匯入檔不是由本軟體匯出（`app` 識別碼不符，或舊檔卡池代碼非原神已知集合）時拋出。
+class ForeignBundleException implements Exception {
+  /// 建立 [ForeignBundleException]。
+  const ForeignBundleException();
+
+  @override
+  String toString() => 'ForeignBundleException';
+}
+```
+
+把 `importAccounts` 的 body 改為（在既有 `try { return AccountsBundle.fromJson(...) }` 之前插入身分判別，並把傳入改為 `prepared`）：
+
+```dart
+AccountsBundle importAccounts(String text) {
+  Object? raw;
+  try {
+    raw = jsonDecode(text);
+  } catch (e) {
+    _log.warning('import failed: invalid JSON ($e)');
+    throw const FormatException('Invalid JSON');
+  }
+  if (raw is! Map<String, dynamic>) {
+    _log.warning('import failed: top-level not an object');
+    throw const FormatException('Top-level value must be an object');
+  }
+
+  final app = raw['app'];
+  final Map<String, dynamic> prepared;
+  if (app is String) {
+    if (app != accountsBundleAppId) {
+      _log.warning('import failed: foreign bundle (app=$app)');
+      throw const ForeignBundleException();
+    }
+    prepared = raw; // 本軟體自己的檔，完整信任、不過濾
+  } else {
+    prepared = _screenLegacyBundle(raw);
+  }
+
+  try {
+    return AccountsBundle.fromJson(prepared);
+  } on UnsupportedSchemaVersionException catch (e) {
+    _log.warning('import failed: unsupported schema version ${e.version}');
+    rethrow;
+  } on FormatException catch (e) {
+    _log.warning('import failed: ${e.message}');
+    rethrow;
+  } catch (e, st) {
+    _log.warning('import failed: parse error', e, st);
+    throw FormatException('Failed to parse: $e');
+  }
+}
+```
+
+在 `importAccounts` 之後新增 helper：
+
+```dart
+/// 處理無 `app` 欄位的舊備份：依卡池代碼判別是否為本軟體（原神）檔，並濾掉非原神 banner。
+///
+/// 蒐集 `accounts[*].banners` 的 key 與 [gachaTypes] 已知集合比對：確有卡池資料但無一是
+/// 原神代碼 → 丟 [ForeignBundleException]（純外來，如鳴潮檔）；否則回傳濾除未知 banner 後的
+/// raw（未知代碼的 banner 整條跳過、不解析其記錄，濾空的帳號一併移除），只留可辨識的原神 banner。
+/// 讀不出任何卡池資料（空檔／結構模糊）→ 原樣交回，由 [AccountsBundle.fromJson] 後續處理。
+Map<String, dynamic> _screenLegacyBundle(Map<String, dynamic> raw) {
+  final known = {for (final t in gachaTypes) t.gachaType};
+  final accountsRaw = raw['accounts'];
+  if (accountsRaw is! List) return raw;
+
+  var sawAnyCode = false;
+  var keptAnyKnown = false;
+  final filteredAccounts = <dynamic>[];
+  for (final entry in accountsRaw) {
+    if (entry is! Map<String, dynamic>) {
+      filteredAccounts.add(entry);
+      continue;
+    }
+    final bannersRaw = entry['banners'];
+    if (bannersRaw is! Map<String, dynamic>) {
+      filteredAccounts.add(entry);
+      continue;
+    }
+    final keptBanners = <String, dynamic>{};
+    for (final code in bannersRaw.keys) {
+      sawAnyCode = true;
+      if (known.contains(code)) {
+        keptBanners[code] = bannersRaw[code];
+        keptAnyKnown = true;
+      }
+    }
+    if (keptBanners.isNotEmpty) {
+      filteredAccounts.add({...entry, 'banners': keptBanners});
+    }
+  }
+
+  if (sawAnyCode && !keptAnyKnown) {
+    _log.warning('import failed: foreign bundle (no Genshin pools)');
+    throw const ForeignBundleException();
+  }
+  return {...raw, 'accounts': filteredAccounts};
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/services/accounts_import_test.dart`
+Expected: PASS（含既有 Invalid JSON／top-level array／`schema_version > 1 → UnsupportedSchemaVersionException` 三條——注意該條用空 `accounts`，會通過 `_screenLegacyBundle`（無代碼、不判外來）再撞版本檢查，仍綠）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+git add lib/services/accounts_import.dart test/services/accounts_import_test.dart
+git commit -m "feat(import): reject foreign-app bundles and filter unknown banners"
+```
+
+---
+
+## Task 3: 新增 `importReasonForeignApp`（9 語系）+ gen-l10n
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`、`app_en.arb`、`app_fr.arb`、`app_es.arb`、`app_ja.arb`、`app_vi.arb`、`app_th.arb`、`app_zh_Hans.arb`、`app_pt_BR.arb`
+
+> 每個檔案：找到 `exportReasonWriteFailed` 那行，在其後緊接插入該語系的 `importReasonForeignApp` 行（同 2 空格縮排、行尾保留逗號——後面還有其他 key）。無 `@key` 區塊（比照同組 reason key）。**只改這 9 個檔案。**
+
+- [ ] **Step 1: 9 檔各插入一行**
+
+`app_zh.arb`（template）：
+```json
+  "importReasonForeignApp": "此檔案不是由本軟體匯出的備份",
+```
+
+`app_en.arb`：
+```json
+  "importReasonForeignApp": "This file was not exported by the app",
+```
+
+`app_fr.arb`：
+```json
+  "importReasonForeignApp": "Ce fichier n'a pas été exporté par cette application",
+```
+
+`app_es.arb`：
+```json
+  "importReasonForeignApp": "Este archivo no es una copia de seguridad exportada por la aplicación",
+```
+
+`app_ja.arb`：
+```json
+  "importReasonForeignApp": "このファイルは本ツールでエクスポートされたバックアップではありません",
+```
+
+`app_vi.arb`：
+```json
+  "importReasonForeignApp": "Tệp này không phải bản sao lưu được xuất từ ứng dụng này",
+```
+
+`app_th.arb`：
+```json
+  "importReasonForeignApp": "ไฟล์นี้ไม่ใช่ข้อมูลสำรองที่ส่งออกจากแอปนี้",
+```
+
+`app_zh_Hans.arb`：
+```json
+  "importReasonForeignApp": "此文件不是由本软件导出的备份",
+```
+
+`app_pt_BR.arb`：
+```json
+  "importReasonForeignApp": "Este arquivo de backup não foi exportado por este aplicativo",
+```
+
+- [ ] **Step 2: 重新產生 l10n**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 重新產生（未進版控、不 commit）。
+
+- [ ] **Step 3: 驗證 getter 與 ARB 合法**
+
+確認 `lib/l10n/generated/app_localizations.dart` 出現 `String get importReasonForeignApp;`（grep）。
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 4: 眼睛複查多位元組字串**
+
+開 `app_zh.arb`、`app_ja.arb`、`app_th.arb` 確認三條多位元組字串完整、JSON 逗號正確、未加 `@` 區塊、未動其他 key。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add foreign-app import failure reason string"
+```
+
+---
+
+## Task 4: UI —— `settings_page` 加 `on ForeignBundleException` 臂
+
+**Files:**
+- Modify: `lib/pages/settings_page.dart`（`importAccounts` catch，約 `:538-559`）
+
+> `settings_page.dart` 已 import `services/accounts_import.dart`（`ForeignBundleException` 可見）與 `models/accounts_bundle.dart`，不需補 import。
+
+- [ ] **Step 1: 在 importAccounts 的 try 後加第一個 catch 臂**
+
+把：
+
+```dart
+    try {
+      bundle = importAccounts(text);
+    } on UnsupportedSchemaVersionException {
+```
+
+改為（在 `on UnsupportedSchemaVersionException` 之前插入 `on ForeignBundleException`）：
+
+```dart
+    try {
+      bundle = importAccounts(text);
+    } on ForeignBundleException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonForeignApp)),
+        ),
+      );
+      return;
+    } on UnsupportedSchemaVersionException {
+```
+
+（其餘 `on UnsupportedSchemaVersionException`／`on FormatException` 兩臂維持原樣。英文細節已於 `importAccounts` 內 `_log.warning`，UI 不重複 log。）
+
+- [ ] **Step 2: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 無錯誤。
+
+- [ ] **Step 3: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 4: 全套測試**
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pages/settings_page.dart
+git commit -m "fix(import): show localized reason for foreign-app backup files"
+```
+
+---
+
+## Task 5: 最終驗收
+
+- [ ] **Step 1: 全套品質檢查**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+```
+
+Expected：format 無變動、analyze `No issues found!`、test `All tests passed!`。
+
+- [ ] **Step 2: 手動驗收**
+
+匯入一個鳴潮備份檔（或把 `app` 改成別的字串／把 banner key 換成 `1`,`2` 的舊格式檔）確認顯示「此檔案不是由本軟體匯出的備份」（非英文、非「請更新 App」）；匯入正常原神檔仍成功。
+
+> 不要主動 git push。
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 匯出 `app` 識別欄位、不 bump schema_version → Task 1。✓
+- 顯式 `app` 不符 → 拒絕；相符 → 不過濾 → Task 2 Step 3（`app is String` 分支）+ 測試。✓
+- 舊檔 lenient + 過濾未知 banner、純外來拋例外、濾空帳號移除 → Task 2 `_screenLegacyBundle` + 測試。✓
+- 判別在版本檢查之前（順序）→ Task 2（身分判別在 `fromJson` 之前）+ 「schema 999 純外來 → ForeignBundleException」測試。✓
+- `ForeignBundleException` 型別 → Task 2。✓
+- UI 在地化原因 → Task 4 + Task 3（`importReasonForeignApp` 9 語系）。✓
+- analyze + test 全綠 → Task 4 Step 3-4、Task 5。✓
+
+**Placeholder 掃描：** 無 TBD／TODO；每步含完整程式碼與實際譯文。✓
+
+**型別一致性：** `accountsBundleAppId`（Task 1 定義 → Task 2 引用、測試引用）、`ForeignBundleException`（Task 2 定義 → Task 4 catch → Task 2 測試）、`_screenLegacyBundle`、`importReasonForeignApp`（Task 3 定義 → Task 4 引用）全程一致。✓
+
+**不在範圍：** 姐妹專案（鳴潮 repo）加對應 `app` 欄位；既有 `UnsupportedSchemaVersionException`／其餘 reason key（前一支已處理）。

--- a/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
+++ b/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
@@ -163,7 +163,7 @@ Map<String, dynamic> _screenLegacyBundle(Map<String, dynamic> raw) { ... }
 繁中（`app_zh.arb`，來源）初稿：
 
 ```json
-  "importReasonForeignApp": "此檔案不是由本軟體匯出的備份（可能來自其他遊戲的版本）",
+  "importReasonForeignApp": "此檔案不是由本軟體匯出的備份",
 ```
 
 其餘 8 語系譯文於實作前透過翻譯＋對抗式校驗 workflow 產出，沿用各檔既有語氣與用詞。寫入後跑 `fvm flutter gen-l10n`（產物 `lib/l10n/generated/` 未進版控、不 commit）。

--- a/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
+++ b/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
@@ -1,0 +1,165 @@
+# 匯入時判別檔案是否由本軟體匯出設計
+
+## 背景與目標
+
+姐妹專案 [wuthering-waves-convene-gacha-analyzer](https://github.com/GoneTone/wuthering-waves-convene-gacha-analyzer)（鳴潮 Convene 抽卡分析器，同作者、同架構）與本專案（原神）使用**完全相同的匯出 JSON 形狀**：`AccountsBundle.toJson` 兩邊都寫 `schema_version`／`exported_at`／`app_version`／`last_active_uid`／`accounts`，且**都沒有任何 app／game 識別欄位**。因此目前匯入端無法分辨一個備份檔到底來自哪個遊戲——鳴潮的備份檔丟進原神 App 會被當成合法檔嘗試匯入。
+
+兩個事實讓現況更糟：
+
+- `app_version` 只是版本號（如 `1.0.0`），不識別 App。
+- `currentSchemaVersion` 鳴潮是 `2`、本專案是 `1`。鳴潮 schema-2 檔目前會撞上版本檢查、顯示**錯誤訊息「請更新 App」**（其實是別款遊戲的檔）；而舊的鳴潮 schema-1 檔則完全擋不掉。
+
+關鍵可靠依據：**祈願代碼空間不重疊**。本專案 `gachaTypes` 的代碼集合為 `{301, 302, 500, 200, 100, 2000, 1000}`；鳴潮用 `cardPoolType` `{1,2,3,4,5,6,8,9,10,11}`。在匯出 JSON 中，代碼是 `accounts[i].banners` map 的 key。
+
+本設計用**兩者並用（hybrid）**的方式在匯入時判別「是否由本軟體匯出」，並在偵測到外來檔時以正確訊息拒絕。
+
+**成功條件**
+
+- 匯入鳴潮備份檔（含現有舊檔與未來檔、任何 schema 版本）一律被拒，並顯示「非本軟體匯出」的在地化訊息，而非誤導的「請更新 App」。
+- 較新版**原神**檔仍正確顯示「請更新 App」（不被身分判別誤殺）。
+- 本軟體自己的既有舊備份（無識別欄位、含原神代碼）仍可正常匯入。
+- 新匯出的檔帶有明確的 app 識別欄位；加欄位不破壞舊版 App 讀取既有檔。
+- `fvm flutter analyze` 全綠、`fvm flutter test` 全綠。
+
+## 決策摘要
+
+| 面向 | 決策 |
+|------|------|
+| 判別機制 | 兩者並用：顯式識別碼（新檔權威）+ 內容嗅探（舊檔 fallback） |
+| 識別碼欄位 | `app`，值為套件名字串 `genshin_impact_wish_gacha_analyzer` |
+| schema_version | **不** bump（`app` 為純加法欄位，舊版 App 忽略未知欄位即可） |
+| 內容判據 | `accounts[*].banners` 的 key 是否屬於 `gachaTypes` 代碼集合（重用單一真實來源，不另建表） |
+| 判別時機 | 在 `importAccounts` 內、`AccountsBundle.fromJson` **之前**（在版本檢查之前，確保訊息正確） |
+| 偵測動作 | 硬性拒絕（外來遊戲資料無法有意義地匯入），顯示在地化原因 |
+| 新例外 | `ForeignBundleException`（此備份非本軟體匯出） |
+| 新 ARB key | `importReasonForeignApp`，9 個已翻語系（譯文經 workflow 翻譯＋校驗） |
+
+## 設計
+
+### 1. 識別碼常數與匯出（`lib/models/accounts_bundle.dart`、`lib/services/accounts_export.dart`）
+
+在 `accounts_bundle.dart` 新增 top-level 常數（附 dartdoc）：
+
+```dart
+/// 本軟體的匯出識別字串，寫入備份檔的 `app` 欄位供匯入端辨識來源。
+/// 值對齊 pubspec 套件名；姐妹專案（鳴潮）為 `wuthering_waves_convene_gacha_analyzer`，天生相異。
+const String accountsBundleAppId = 'genshin_impact_wish_gacha_analyzer';
+```
+
+`AccountsBundle.toJson` 加寫 `app` 欄位（置於 `schema_version` 後）：
+
+```dart
+  Map<String, dynamic> toJson() => {
+    'schema_version': schemaVersion,
+    'app': accountsBundleAppId,
+    'exported_at': exportedAt.toUtc().toIso8601String(),
+    'app_version': appVersion,
+    'last_active_uid': lastActiveUid,
+    'accounts': accounts.map((a) => a.toJson()).toList(growable: false),
+  };
+```
+
+`AccountsBundle.fromJson` **不需**讀 `app`（身分判別在 service 層讀 raw 完成）；既有 `fromJson` 本就忽略未知欄位，無須改動。`exportAccounts` 不需改（透過 `toJson` 自動帶上）。
+
+> schema_version 維持 `1`：`app` 是純加法欄位，舊版本 App 讀新檔時忽略它即可，不觸發版本不相容。
+
+### 2. 身分判別與 `ForeignBundleException`（`lib/services/accounts_import.dart`）
+
+新增例外型別（附 dartdoc 與 `toString()`，對齊 [UnsupportedSchemaVersionException] 既有風格）：
+
+```dart
+/// 匯入檔不是由本軟體匯出（app 識別碼不符，或舊檔卡池代碼非原神已知集合）時拋出。
+class ForeignBundleException implements Exception {
+  /// 建立 [ForeignBundleException]。
+  const ForeignBundleException();
+
+  @override
+  String toString() => 'ForeignBundleException';
+}
+```
+
+新增判別函式（top-level、可單測；附 dartdoc）：
+
+```dart
+/// 判斷 raw 備份 JSON 是否**不是**本軟體匯出的。
+///
+/// 先看顯式 `app` 欄位（新檔權威依據）；無 `app` 的舊檔退而檢查
+/// `accounts[*].banners` 的卡池代碼是否屬於 [gachaTypes] 已知集合。
+/// 蒐集到代碼但無一屬於原神 → 外來；其餘（含原神代碼、空檔、結構讀不出）→ 視為非外來，交後續流程。
+bool isForeignBundle(Map<String, dynamic> raw) { ... }
+```
+
+判別邏輯：
+
+1. `final app = raw['app'];` 若 `app is String` → 回傳 `app != accountsBundleAppId`。
+2. 否則蒐集卡池代碼：`raw['accounts']` 若為 `List`，逐一取 `entry['banners']`（若為 `Map`）的 keys，聯集成 `Set<String>`。
+3. 已知集合：`final known = {for (final t in gachaTypes) t.gachaType};`
+4. 若蒐集到的代碼集合非空且 `codes.intersection(known).isEmpty` → 回傳 `true`（外來）；否則 `false`。
+
+> 容錯：任何讀取 raw 巢狀結構的步驟以型別檢查保護（非預期型別就略過該層）；讀不出任何代碼時回傳 `false`，把判斷讓給既有的 `FormatException`／版本檢查流程。
+
+`importAccounts` 在確認 raw 是 `Map` 之後、呼叫 `AccountsBundle.fromJson` 之前插入：
+
+```dart
+  if (isForeignBundle(raw)) {
+    _log.warning('import failed: foreign bundle (not from this app)');
+    throw const ForeignBundleException();
+  }
+```
+
+最終 `importAccounts` 的檢查順序：
+
+1. `jsonDecode` 失敗 → `FormatException('Invalid JSON')`〔既有〕
+2. 非 Map → `FormatException('Top-level value must be an object')`〔既有〕
+3. **`isForeignBundle` → `ForeignBundleException`**〔新增，在版本檢查之前〕
+4. `AccountsBundle.fromJson` → `UnsupportedSchemaVersionException`（版本過新）／`FormatException`（結構）〔既有〕
+
+`gachaTypes` 來自 `lib/data/gacha_types.dart`（`accounts_import.dart` 需 import 之）。`gachaTypes` 為 const list，取 `.gachaType` 不會觸發 `resolveName`（不需 `AppLocalizations`），純 Dart 單測可直接使用。
+
+### 3. UI（`lib/pages/settings_page.dart`）
+
+`importAccounts` 的 try/catch 加 `on ForeignBundleException` 一臂（與既有 `on UnsupportedSchemaVersionException`／`on FormatException` 並列，順序不拘——三型別互斥）：
+
+```dart
+    } on ForeignBundleException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonForeignApp)),
+        ),
+      );
+      return;
+    }
+```
+
+英文細節已於 `importAccounts` 內 `_log.warning`，UI 不重複 log。
+
+### 4. i18n（ARB）
+
+新增 1 個 key `importReasonForeignApp`，比照既有 reason key（無 placeholder、無 `@` 區塊），加進 9 個已翻語系（`zh`／`en`／`fr`／`es`／`ja`／`vi`／`th`／`zh_Hans`／`pt_BR`），空殼語系留給 Crowdin。
+
+繁中（`app_zh.arb`，來源）初稿：
+
+```json
+  "importReasonForeignApp": "此檔案不是由本軟體匯出的備份（可能來自其他遊戲的版本）",
+```
+
+其餘 8 語系譯文於實作前透過翻譯＋對抗式校驗 workflow 產出，沿用各檔既有語氣與用詞。寫入後跑 `fvm flutter gen-l10n`（產物 `lib/l10n/generated/` 未進版控、不 commit）。
+
+### 5. 測試
+
+- `test/services/accounts_import_test.dart`（或新測試檔）：`isForeignBundle` 單測——
+  - `app` 符合 → false；`app` 不符（如 `wuthering_waves_convene_gacha_analyzer`）→ true。
+  - 無 `app` + banners key 全為原神代碼（如 `301`/`302`）→ false。
+  - 無 `app` + banners key 全為鳴潮代碼（如 `1`/`2`/`7`）→ true。
+  - 無 `app` + 空 `accounts`／無 banners／結構模糊 → false。
+  - `importAccounts`：外來 raw（含 `app` 不符、或鳴潮代碼）→ 丟 `ForeignBundleException`。
+  - **順序驗證**：外來檔即使 `schema_version: 999` 也應丟 `ForeignBundleException`（而非 `UnsupportedSchemaVersionException`）。
+- `test/models/accounts_bundle_test.dart`：`toJson` 輸出含 `'app': accountsBundleAppId`；既有 round-trip 測試仍綠（`fromJson` 忽略 `app`）。
+- `settings_page` 的型別→l10n 映射比照既有 reason key 不寫 widget test（純呈現映射，理由同前一支 spec）。
+
+## 範圍外
+
+- **姐妹專案（鳴潮 repo）加上對應 `app` 欄位**——那是另一個 repo，本次不做；列為建議後續，雙向就能對稱互拒。
+- 不調整既有 `UnsupportedSchemaVersionException`／其餘 reason key（前一支 spec 已處理）。
+- 不偵測「同為原神但更舊／更新格式」以外的細粒度差異——交由既有 schema_version 機制。

--- a/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
+++ b/docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md
@@ -18,6 +18,7 @@
 - 匯入鳴潮備份檔（含現有舊檔與未來檔、任何 schema 版本）一律被拒，並顯示「非本軟體匯出」的在地化訊息，而非誤導的「請更新 App」。
 - 較新版**原神**檔仍正確顯示「請更新 App」（不被身分判別誤殺）。
 - 本軟體自己的既有舊備份（無識別欄位、含原神代碼）仍可正常匯入。
+- 無 `app` 欄位的舊檔若混入非原神 banner，只要含至少一個原神代碼即接受該檔，並只匯入可辨識的原神 banner、跳過未知 banner（不因未知記錄結構而整檔解析失敗）。
 - 新匯出的檔帶有明確的 app 識別欄位；加欄位不破壞舊版 App 讀取既有檔。
 - `fvm flutter analyze` 全綠、`fvm flutter test` 全綠。
 
@@ -30,7 +31,9 @@
 | schema_version | **不** bump（`app` 為純加法欄位，舊版 App 忽略未知欄位即可） |
 | 內容判據 | `accounts[*].banners` 的 key 是否屬於 `gachaTypes` 代碼集合（重用單一真實來源，不另建表） |
 | 判別時機 | 在 `importAccounts` 內、`AccountsBundle.fromJson` **之前**（在版本檢查之前，確保訊息正確） |
-| 偵測動作 | 硬性拒絕（外來遊戲資料無法有意義地匯入），顯示在地化原因 |
+| 舊檔判別嚴格度 | **lenient + 過濾**：只要有任一原神代碼即接受該檔，但濾掉非原神 banner（整條跳過、不解析其記錄）；完全沒有原神代碼才整檔拒絕 |
+| 偵測動作 | 純外來檔（顯式 `app` 不符，或舊檔無任何原神代碼）→ 硬性拒絕並顯示在地化原因；混合舊檔 → 接受並只匯入可辨識的原神 banner |
+| 信任邊界 | 顯式 `app` **相符**的檔完整信任、不過濾（避免誤刪較新版本本軟體尚未認得的代碼，那情況交由 schema_version 機制） |
 | 新例外 | `ForeignBundleException`（此備份非本軟體匯出） |
 | 新 ARB key | `importReasonForeignApp`，9 個已翻語系（譯文經 workflow 翻譯＋校驗） |
 
@@ -78,41 +81,60 @@ class ForeignBundleException implements Exception {
 }
 ```
 
-新增判別函式（top-level、可單測；附 dartdoc）：
+`importAccounts` 在確認 raw 是 `Map` 之後、呼叫 `AccountsBundle.fromJson` 之前，依 `app` 欄位走兩條路：
 
 ```dart
-/// 判斷 raw 備份 JSON 是否**不是**本軟體匯出的。
-///
-/// 先看顯式 `app` 欄位（新檔權威依據）；無 `app` 的舊檔退而檢查
-/// `accounts[*].banners` 的卡池代碼是否屬於 [gachaTypes] 已知集合。
-/// 蒐集到代碼但無一屬於原神 → 外來；其餘（含原神代碼、空檔、結構讀不出）→ 視為非外來，交後續流程。
-bool isForeignBundle(Map<String, dynamic> raw) { ... }
-```
-
-判別邏輯：
-
-1. `final app = raw['app'];` 若 `app is String` → 回傳 `app != accountsBundleAppId`。
-2. 否則蒐集卡池代碼：`raw['accounts']` 若為 `List`，逐一取 `entry['banners']`（若為 `Map`）的 keys，聯集成 `Set<String>`。
-3. 已知集合：`final known = {for (final t in gachaTypes) t.gachaType};`
-4. 若蒐集到的代碼集合非空且 `codes.intersection(known).isEmpty` → 回傳 `true`（外來）；否則 `false`。
-
-> 容錯：任何讀取 raw 巢狀結構的步驟以型別檢查保護（非預期型別就略過該層）；讀不出任何代碼時回傳 `false`，把判斷讓給既有的 `FormatException`／版本檢查流程。
-
-`importAccounts` 在確認 raw 是 `Map` 之後、呼叫 `AccountsBundle.fromJson` 之前插入：
-
-```dart
-  if (isForeignBundle(raw)) {
-    _log.warning('import failed: foreign bundle (not from this app)');
-    throw const ForeignBundleException();
+  final app = raw['app'];
+  final Map<String, dynamic> prepared;
+  if (app is String) {
+    if (app != accountsBundleAppId) {
+      _log.warning('import failed: foreign bundle (app=$app)');
+      throw const ForeignBundleException();
+    }
+    prepared = raw; // 本軟體自己的檔，完整信任、不過濾
+  } else {
+    prepared = _screenLegacyBundle(raw); // 無 app 的舊檔：判別 + 過濾未知 banner
   }
+  // 既有版本／結構檢查（沿用目前的 try/catch）
+  try {
+    return AccountsBundle.fromJson(prepared);
+  } on UnsupportedSchemaVersionException catch (e) { ... }
+    on FormatException catch (e) { ... }
+    catch (e, st) { ... }
 ```
+
+> 信任邊界：顯式 `app` **相符**的檔不過濾。若未來版本新增了本版本還不認得的代碼，過濾會誤刪資料；那情況本就由 `AccountsBundle.fromJson` 的 schema_version 檢查（→ `UnsupportedSchemaVersionException`「請更新 App」）把關。
+
+無 `app` 欄位的舊檔交由下列 helper 判別並過濾（附 dartdoc）：
+
+```dart
+/// 處理無 `app` 欄位的舊備份：依卡池代碼判別是否為本軟體（原神）檔，並濾掉非原神 banner。
+///
+/// 蒐集 `accounts[*].banners` 的 key 與 [gachaTypes] 已知集合比對：
+/// - 確有卡池資料、但無一是原神代碼 → 丟 [ForeignBundleException]（純外來，如鳴潮檔）。
+/// - 否則回傳濾除未知 banner 後的 raw：未知代碼的 banner 整條跳過（不解析其記錄），
+///   濾空的帳號一併移除，只保留可辨識的原神 banner。
+/// - 讀不出任何卡池資料（空檔／結構模糊）→ 原樣交回，由 [AccountsBundle.fromJson] 後續處理。
+Map<String, dynamic> _screenLegacyBundle(Map<String, dynamic> raw) { ... }
+```
+
+`_screenLegacyBundle` 邏輯：
+
+1. `final known = {for (final t in gachaTypes) t.gachaType};`（已知集合 `{301,302,500,200,100,2000,1000}`）。
+2. `raw['accounts']` 非 `List` → 原樣回傳（結構錯誤交 `fromJson` 報）。
+3. 逐一帳號：`entry` 或 `entry['banners']` 非 `Map` → 原樣保留該 entry（交 `fromJson` 處理）；否則逐一 banner key，只保留 `known.contains(key)` 的；同時記錄「是否見過任何代碼」`sawAnyCode` 與「是否保留了任何原神 banner」`keptAnyKnown`。
+4. 帳號濾後 banners 非空 → 以濾後 banners 重建該 entry 加入；濾空（原本就有 banner 但全非原神）→ 丟棄該帳號。
+5. `sawAnyCode && !keptAnyKnown` → 丟 `ForeignBundleException`（純外來）。
+6. 否則回傳 `{...raw, 'accounts': 濾後清單}`。
+
+> 容錯：讀取 raw 巢狀結構每層都以型別檢查保護，非預期型別就原樣保留交 `fromJson`；讀不出任何代碼（空檔）時不判外來、原樣交回。過濾在解析記錄**之前**完成，故未知 banner 內若是別款遊戲的記錄結構也不會觸發解析錯誤。
 
 最終 `importAccounts` 的檢查順序：
 
 1. `jsonDecode` 失敗 → `FormatException('Invalid JSON')`〔既有〕
 2. 非 Map → `FormatException('Top-level value must be an object')`〔既有〕
-3. **`isForeignBundle` → `ForeignBundleException`**〔新增，在版本檢查之前〕
-4. `AccountsBundle.fromJson` → `UnsupportedSchemaVersionException`（版本過新）／`FormatException`（結構）〔既有〕
+3. **身分判別**〔新增，在版本檢查之前〕：顯式 `app` 不符 → `ForeignBundleException`；無 `app` 的舊檔經 `_screenLegacyBundle` →（純外來）`ForeignBundleException`／（其餘）濾後 raw。
+4. `AccountsBundle.fromJson(prepared)` → `UnsupportedSchemaVersionException`（版本過新）／`FormatException`（結構）〔既有〕
 
 `gachaTypes` 來自 `lib/data/gacha_types.dart`（`accounts_import.dart` 需 import 之）。`gachaTypes` 為 const list，取 `.gachaType` 不會觸發 `resolveName`（不需 `AppLocalizations`），純 Dart 單測可直接使用。
 
@@ -148,13 +170,14 @@ bool isForeignBundle(Map<String, dynamic> raw) { ... }
 
 ### 5. 測試
 
-- `test/services/accounts_import_test.dart`（或新測試檔）：`isForeignBundle` 單測——
-  - `app` 符合 → false；`app` 不符（如 `wuthering_waves_convene_gacha_analyzer`）→ true。
-  - 無 `app` + banners key 全為原神代碼（如 `301`/`302`）→ false。
-  - 無 `app` + banners key 全為鳴潮代碼（如 `1`/`2`/`7`）→ true。
-  - 無 `app` + 空 `accounts`／無 banners／結構模糊 → false。
-  - `importAccounts`：外來 raw（含 `app` 不符、或鳴潮代碼）→ 丟 `ForeignBundleException`。
-  - **順序驗證**：外來檔即使 `schema_version: 999` 也應丟 `ForeignBundleException`（而非 `UnsupportedSchemaVersionException`）。
+- `test/services/accounts_import_test.dart`：以 `importAccounts` 為入口驗證可觀察行為——
+  - **顯式 `app` 不符**（如 `wuthering_waves_convene_gacha_analyzer`）→ 丟 `ForeignBundleException`。
+  - **顯式 `app` 相符** → 正常回傳，且不過濾（即使含本版本未知代碼也保留）。
+  - **無 `app` + 純原神代碼**（`301`/`302`…）→ 正常回傳，banner 全數保留。
+  - **無 `app` + 純鳴潮代碼**（`1`/`2`/`7`）→ 丟 `ForeignBundleException`。
+  - **無 `app` + 混合**（`301` + `1`）→ 正常回傳，且回傳的 bundle **只含 `301` banner、不含 `1`**（驗證未知 banner 被濾掉）；若某帳號只剩未知代碼則該帳號被移除。
+  - **無 `app` + 空 `accounts`／無 banners** → 不判外來，正常回傳（空 bundle）。
+  - **順序驗證**：純外來檔（無 `app`、純鳴潮代碼）即使 `schema_version: 999` 也應丟 `ForeignBundleException`（而非 `UnsupportedSchemaVersionException`）。
 - `test/models/accounts_bundle_test.dart`：`toJson` 輸出含 `'app': accountsBundleAppId`；既有 round-trip 測試仍綠（`fromJson` 忽略 `app`）。
 - `settings_page` 的型別→l10n 映射比照既有 reason key 不寫 widget test（純呈現映射，理由同前一支 spec）。
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -643,6 +643,7 @@
   "importReasonUnsupportedVersion": "This file was exported by a newer version of the app. Please update the app before importing.",
   "importReasonUnreadable": "Unable to read the file",
   "exportReasonWriteFailed": "Unable to write the file, please check the save location and permissions",
+  "importReasonForeignApp": "This file was not exported by the app",
   "settingsExportSelectTitle": "Select accounts to export",
   "settingsImportSelectTitle": "Select accounts to import",
   "settingsImportMergeBadge": "Merge",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "Este archivo se exportó con una versión más reciente de la aplicación, actualízala antes de importar",
   "importReasonUnreadable": "No se puede leer el archivo",
   "exportReasonWriteFailed": "No se puede escribir el archivo, comprueba la ubicación de guardado y los permisos",
+  "importReasonForeignApp": "Este archivo no es una copia de seguridad exportada por la aplicación",
   "settingsExportSelectTitle": "Seleccionar cuentas a exportar",
   "settingsImportSelectTitle": "Seleccionar cuentas a importar",
   "settingsImportMergeBadge": "Combinar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "Ce fichier a été exporté par une version plus récente de l'application, veuillez la mettre à jour avant de l'importer",
   "importReasonUnreadable": "Impossible de lire le fichier",
   "exportReasonWriteFailed": "Impossible d'écrire le fichier, veuillez vérifier l'emplacement d'enregistrement et les autorisations",
+  "importReasonForeignApp": "Ce fichier n'a pas été exporté par cette application",
   "settingsExportSelectTitle": "Sélectionner les comptes à exporter",
   "settingsImportSelectTitle": "Sélectionner les comptes à importer",
   "settingsImportMergeBadge": "Fusionner",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "このファイルは、より新しいバージョンのツールでエクスポートされています。ツールを更新してからインポートしてください",
   "importReasonUnreadable": "ファイルを読み込めません",
   "exportReasonWriteFailed": "ファイルを書き込めません。保存先と権限を確認してください",
+  "importReasonForeignApp": "このファイルは本ツールでエクスポートされたバックアップではありません",
   "settingsExportSelectTitle": "エクスポートするアカウントを選択",
   "settingsImportSelectTitle": "インポートするアカウントを選択",
   "settingsImportMergeBadge": "統合",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "Este arquivo foi exportado por uma versão mais recente do aplicativo. Atualize o aplicativo antes de importar",
   "importReasonUnreadable": "Não foi possível ler o arquivo",
   "exportReasonWriteFailed": "Não foi possível gravar o arquivo. Verifique o local de salvamento e as permissões",
+  "importReasonForeignApp": "Este arquivo de backup não foi exportado por este aplicativo",
   "settingsExportSelectTitle": "Selecionar contas para exportar",
   "settingsImportSelectTitle": "Selecionar contas para importar",
   "settingsImportMergeBadge": "Mesclar",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "ไฟล์นี้ถูกส่งออกจากแอปเวอร์ชันที่ใหม่กว่า กรุณาอัปเดตแอปก่อนนำเข้า",
   "importReasonUnreadable": "ไม่สามารถอ่านไฟล์ได้",
   "exportReasonWriteFailed": "ไม่สามารถเขียนไฟล์ได้ กรุณาตรวจสอบตำแหน่งที่บันทึกและสิทธิ์การเข้าถึง",
+  "importReasonForeignApp": "ไฟล์นี้ไม่ใช่ข้อมูลสำรองที่ส่งออกจากแอปนี้",
   "settingsExportSelectTitle": "เลือกบัญชีที่จะส่งออก",
   "settingsImportSelectTitle": "เลือกบัญชีที่จะนำเข้า",
   "settingsImportMergeBadge": "ผสาน",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -640,6 +640,7 @@
   "importReasonUnsupportedVersion": "Tệp này được xuất từ phiên bản ứng dụng mới hơn, vui lòng cập nhật ứng dụng trước khi nhập",
   "importReasonUnreadable": "Không thể đọc tệp",
   "exportReasonWriteFailed": "Không thể ghi tệp, vui lòng kiểm tra vị trí lưu và quyền truy cập",
+  "importReasonForeignApp": "Tệp này không phải bản sao lưu được xuất từ ứng dụng này",
   "settingsExportSelectTitle": "Chọn tài khoản để xuất",
   "settingsImportSelectTitle": "Chọn tài khoản để nhập",
   "settingsImportMergeBadge": "Hợp nhất",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -473,6 +473,7 @@
   "importReasonUnsupportedVersion": "此檔案由較新版本的 App 匯出，請先更新 App 後再匯入",
   "importReasonUnreadable": "無法讀取檔案",
   "exportReasonWriteFailed": "無法寫入檔案，請確認儲存位置與權限",
+  "importReasonForeignApp": "此檔案不是由本軟體匯出的備份",
 
   "settingsExportSelectTitle": "選擇要匯出的帳號",
   "settingsImportSelectTitle": "選擇要匯入的帳號",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -636,6 +636,7 @@
   "importReasonUnsupportedVersion": "此文件由较新版本的软件导出，请先更新软件后再导入",
   "importReasonUnreadable": "无法读取文件",
   "exportReasonWriteFailed": "无法写入文件，请确认保存位置与权限",
+  "importReasonForeignApp": "此文件不是由本软件导出的备份",
   "settingsExportSelectTitle": "选择要导出的账号",
   "settingsImportSelectTitle": "选择要导入的账号",
   "settingsImportMergeBadge": "合并",

--- a/lib/models/accounts_bundle.dart
+++ b/lib/models/accounts_bundle.dart
@@ -1,5 +1,10 @@
 import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
 
+/// 本軟體的匯出識別字串，寫入備份檔的 `app` 欄位供匯入端辨識來源。
+///
+/// 值對齊 pubspec 套件名；姐妹專案（鳴潮）為 `wuthering_waves_convene_gacha_analyzer`，天生相異。
+const String accountsBundleAppId = 'genshin_impact_wish_gacha_analyzer';
+
 /// 匯入檔的 schema 版本高於目前 App 支援版本時拋出，供 UI 給出「請更新 App」指引。
 class UnsupportedSchemaVersionException implements Exception {
   /// 建立 [UnsupportedSchemaVersionException]。
@@ -70,6 +75,7 @@ class AccountsBundle {
   /// 序列化為 JSON。
   Map<String, dynamic> toJson() => {
     'schema_version': schemaVersion,
+    'app': accountsBundleAppId,
     'exported_at': exportedAt.toUtc().toIso8601String(),
     'app_version': appVersion,
     'last_active_uid': lastActiveUid,

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -538,6 +538,14 @@ class _DataManagement extends ConsumerWidget {
     final AccountsBundle bundle;
     try {
       bundle = importAccounts(text);
+    } on ForeignBundleException {
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        SnackBar(
+          content: Text(l.settingsImportFailed(l.importReasonForeignApp)),
+        ),
+      );
+      return;
     } on UnsupportedSchemaVersionException {
       if (!ctx.mounted) return;
       ScaffoldMessenger.of(ctx).showSnackBar(

--- a/lib/services/accounts_import.dart
+++ b/lib/services/accounts_import.dart
@@ -2,13 +2,24 @@ import 'dart:convert';
 
 import 'package:logging/logging.dart';
 
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 
 /// Logger 實例（帳號匯入/匯出）。
 final _log = Logger('accounts.io');
 
+/// 匯入檔不是由本軟體匯出（`app` 識別碼不符，或舊檔卡池代碼非原神已知集合）時拋出。
+class ForeignBundleException implements Exception {
+  /// 建立 [ForeignBundleException]。
+  const ForeignBundleException();
+
+  @override
+  String toString() => 'ForeignBundleException';
+}
+
 /// 把 JSON 文字解析回 [AccountsBundle]。
 /// 版本號過新時拋出 [UnsupportedSchemaVersionException]；
+/// 非本軟體產生的備份時拋出 [ForeignBundleException]；
 /// 其餘結構／型別不符時統一拋出 [FormatException]，給 UI 顯示用。
 AccountsBundle importAccounts(String text) {
   Object? raw;
@@ -22,8 +33,21 @@ AccountsBundle importAccounts(String text) {
     _log.warning('import failed: top-level not an object');
     throw const FormatException('Top-level value must be an object');
   }
+
+  final app = raw['app'];
+  final Map<String, dynamic> prepared;
+  if (app is String) {
+    if (app != accountsBundleAppId) {
+      _log.warning('import failed: foreign bundle (app=$app)');
+      throw const ForeignBundleException();
+    }
+    prepared = raw; // 本軟體自己的檔，完整信任、不過濾
+  } else {
+    prepared = _screenLegacyBundle(raw);
+  }
+
   try {
-    return AccountsBundle.fromJson(raw);
+    return AccountsBundle.fromJson(prepared);
   } on UnsupportedSchemaVersionException catch (e) {
     _log.warning('import failed: unsupported schema version ${e.version}');
     rethrow;
@@ -34,4 +58,48 @@ AccountsBundle importAccounts(String text) {
     _log.warning('import failed: parse error', e, st);
     throw FormatException('Failed to parse: $e');
   }
+}
+
+/// 處理無 `app` 欄位的舊備份：依卡池代碼判別是否為本軟體（原神）檔，並濾掉非原神 banner。
+///
+/// 蒐集 `accounts[*].banners` 的 key 與 [gachaTypes] 已知集合比對：確有卡池資料但無一是
+/// 原神代碼 → 丟 [ForeignBundleException]（純外來，如鳴潮檔）；否則回傳濾除未知 banner 後的
+/// raw（未知代碼的 banner 整條跳過、不解析其記錄，濾空的帳號一併移除），只留可辨識的原神 banner。
+/// 讀不出任何卡池資料（空檔／結構模糊）→ 原樣交回，由 [AccountsBundle.fromJson] 後續處理。
+Map<String, dynamic> _screenLegacyBundle(Map<String, dynamic> raw) {
+  final known = {for (final t in gachaTypes) t.gachaType};
+  final accountsRaw = raw['accounts'];
+  if (accountsRaw is! List) return raw;
+
+  var sawAnyCode = false;
+  var keptAnyKnown = false;
+  final filteredAccounts = <dynamic>[];
+  for (final entry in accountsRaw) {
+    if (entry is! Map<String, dynamic>) {
+      filteredAccounts.add(entry);
+      continue;
+    }
+    final bannersRaw = entry['banners'];
+    if (bannersRaw is! Map<String, dynamic>) {
+      filteredAccounts.add(entry);
+      continue;
+    }
+    final keptBanners = <String, dynamic>{};
+    for (final code in bannersRaw.keys) {
+      sawAnyCode = true;
+      if (known.contains(code)) {
+        keptBanners[code] = bannersRaw[code];
+        keptAnyKnown = true;
+      }
+    }
+    if (keptBanners.isNotEmpty) {
+      filteredAccounts.add({...entry, 'banners': keptBanners});
+    }
+  }
+
+  if (sawAnyCode && !keptAnyKnown) {
+    _log.warning('import failed: foreign bundle (no Genshin pools)');
+    throw const ForeignBundleException();
+  }
+  return {...raw, 'accounts': filteredAccounts};
 }

--- a/lib/services/accounts_import.dart
+++ b/lib/services/accounts_import.dart
@@ -73,6 +73,7 @@ Map<String, dynamic> _screenLegacyBundle(Map<String, dynamic> raw) {
 
   var sawAnyCode = false;
   var keptAnyKnown = false;
+  // 非預期型別的 entry 原樣保留，讓 AccountsBundle.fromJson 拋出帶位置的結構錯誤。
   final filteredAccounts = <dynamic>[];
   for (final entry in accountsRaw) {
     if (entry is! Map<String, dynamic>) {

--- a/test/models/accounts_bundle_test.dart
+++ b/test/models/accounts_bundle_test.dart
@@ -133,4 +133,14 @@ void main() {
     });
     expect(bundle.accounts.single.alias, isNull);
   });
+
+  test('toJson includes the app identifier', () {
+    final bundle = AccountsBundle(
+      exportedAt: DateTime.utc(2026, 6, 9),
+      appVersion: '1.0.0',
+      lastActiveUid: null,
+      accounts: const [],
+    );
+    expect(bundle.toJson()['app'], accountsBundleAppId);
+  });
 }

--- a/test/services/accounts_export_test.dart
+++ b/test/services/accounts_export_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/banner_storage.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/accounts_export.dart';
 
@@ -31,6 +32,7 @@ void main() {
 
     final decoded = jsonDecode(out) as Map<String, dynamic>;
     expect(decoded['schema_version'], 1);
+    expect(decoded['app'], accountsBundleAppId);
     expect(decoded['app_version'], '9.9.9');
     expect(decoded['last_active_uid'], 'A');
     expect(decoded['exported_at'], '2026-05-12T08:30:00.000Z');

--- a/test/services/accounts_import_test.dart
+++ b/test/services/accounts_import_test.dart
@@ -1,6 +1,27 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/models/accounts_bundle.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/accounts_import.dart';
+
+Map<String, dynamic> _account(String uid, List<String> codes) => {
+  'uid': uid,
+  'last_updated': '2026-05-12T07:55:00.000Z',
+  'banners': {for (final c in codes) c: <dynamic>[]},
+};
+
+Map<String, dynamic> _bundle({
+  String? app,
+  int schema = 1,
+  required List<Map<String, dynamic>> accounts,
+}) => {
+  'schema_version': schema,
+  'app': ?app,
+  'exported_at': '2026-05-12T08:30:00.000Z',
+  'app_version': '1.0.0',
+  'last_active_uid': null,
+  'accounts': accounts,
+};
 
 void main() {
   test('parses a minimal valid bundle', () {
@@ -64,5 +85,97 @@ void main() {
         ),
       ),
     );
+  });
+
+  test('explicit app mismatch → ForeignBundleException', () {
+    final text = jsonEncode(
+      _bundle(
+        app: 'wuthering_waves_convene_gacha_analyzer',
+        accounts: [
+          _account('A', ['301']),
+        ],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
+  });
+
+  test('explicit app match → no filtering, unknown codes kept', () {
+    final text = jsonEncode(
+      _bundle(
+        app: accountsBundleAppId,
+        accounts: [
+          _account('A', ['301', '600']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301', '600'});
+  });
+
+  test('legacy pure Genshin codes → all banners kept', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301', '302']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301', '302'});
+  });
+
+  test('legacy pure Wuthering Waves codes → ForeignBundleException', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['1', '2', '7']),
+        ],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
+  });
+
+  test('legacy mixed codes → unknown banners filtered, known kept', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301', '1']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.single.data.banners.keys.toSet(), {'301'});
+  });
+
+  test('legacy mixed → account left with only foreign codes is dropped', () {
+    final text = jsonEncode(
+      _bundle(
+        accounts: [
+          _account('A', ['301']),
+          _account('B', ['1', '2']),
+        ],
+      ),
+    );
+    final bundle = importAccounts(text);
+    expect(bundle.accounts.map((a) => a.data.uid).toList(), ['A']);
+  });
+
+  test('legacy empty accounts → not foreign, empty bundle', () {
+    final text = jsonEncode(_bundle(accounts: []));
+    final bundle = importAccounts(text);
+    expect(bundle.accounts, isEmpty);
+  });
+
+  test('pure foreign with schema_version 999 → ForeignBundleException '
+      '(precedes version check)', () {
+    final text = jsonEncode(
+      _bundle(
+        schema: 999,
+        accounts: [
+          _account('A', ['1']),
+        ],
+      ),
+    );
+    expect(() => importAccounts(text), throwsA(isA<ForeignBundleException>()));
   });
 }


### PR DESCRIPTION
@
## 摘要

> 本 PR 疊在 #110 之上（base 為 `feat/import-error-l10n`）；待 #110 合併後可改 base 為 `master`。

姐妹專案（[鳴潮 Convene 抽卡分析器](https://github.com/GoneTone/wuthering-waves-convene-gacha-analyzer)，同作者、同 JSON 架構）的備份檔目前無法與本專案（原神）的檔區分——丟進來會被當合法檔嘗試匯入。本 PR 在匯入時判別並拒絕「非本軟體匯出」的檔，採兩者並用：

- **匯出端**寫入 `app` 識別欄位（值為套件名，純加法、不 bump schema_version，舊版 App 忽略未知欄位）。
- **匯入端**在版本檢查之前判別：
  - 顯式 `app` 不符 → 拒絕；相符 → 完整信任、不過濾（避免誤刪較新版本尚未認得的代碼）。
  - 無 `app` 的舊檔 → 依卡池代碼是否屬於原神已知集合（`{301,302,500,200,100,2000,1000}`，重用 `gachaTypes`）判別：純外來則拒，混合則只留可辨識的原神 banner（濾掉未知 banner、移除濾空帳號、且不解析未知記錄避免整檔失敗）。
- 新增 `ForeignBundleException`，UI 顯示在地化原因 `importReasonForeignApp`（9 語系）。

判別跑在 schema_version 檢查之前，因此鳴潮檔得到「非本軟體匯出」的正確訊息，較新版原神檔才顯示「請更新 App」。

設計：`docs/superpowers/specs/2026-06-09-import-foreign-app-detection-design.md`
計畫：`docs/superpowers/plans/2026-06-09-import-foreign-app-detection.md`

## 已知限制／後續

- 姐妹專案（鳴潮 repo）尚未寫入對應 `app` 欄位，互拒目前是單向；待該 repo 補上即對稱（設計已列為範圍外）。
- 舊檔（無 `app`）若帳號濾後只剩外來代碼會被移除；若被丟棄的帳號剛好與另一帳號 UID 重複，重複 UID 檢查會被略過（良性、僅影響手動拼接的舊檔）。
- 產生的 l10n（`lib/l10n/generated/`）未進版控，審查 UI 字串請本地跑 `fvm flutter gen-l10n`。

## 測試

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — 全綠（+909）
- 涵蓋 8 個判別／過濾情境，含順序驗證（外來檔即使 `schema_version: 999` 也判 `ForeignBundleException` 而非版本過新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@