### PR TITLE
feat(item-detail): pass ?lang to HoYoWiki entry button

### DIFF
--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -718,9 +718,9 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
           onPressed: id == null
               ? null
               : () {
-                  _log.info('open wiki id=$id');
+                  _log.info('open wiki id=$id lang=${record.lang}');
                   openExternalUrl(
-                    Uri.parse('https://wiki.hoyolab.com/pc/genshin/entry/$id'),
+                    buildHoYoWikiEntryUrl(id: id, lang: record.lang),
                   );
                 },
         ),
@@ -771,6 +771,12 @@ class _GalleryChipEntry {
   /// chip 類別 — icon 永遠 ready（已由 hasHoYoWikiContent 把關），gallery 走 lazy。
   final _ChipKind kind;
 }
+
+/// 組出 HoYoWiki 詞條頁網址，帶上 [lang] 讓落地頁語言對齊 Dialog 顯示的資料語言。
+Uri buildHoYoWikiEntryUrl({required String id, required String lang}) =>
+    Uri.parse(
+      'https://wiki.hoyolab.com/pc/genshin/entry/$id',
+    ).replace(queryParameters: {'lang': lang});
 
 /// 顯示 [GachaItemDetailDialog]。
 Future<void> showGachaItemDetailDialog(

--- a/test/widgets/dialogs/gacha_item_detail_dialog_test.dart
+++ b/test/widgets/dialogs/gacha_item_detail_dialog_test.dart
@@ -1046,4 +1046,23 @@ void main() {
       );
     });
   });
+
+  group('buildHoYoWikiEntryUrl', () {
+    test('帶上 lang query 參數並對齊資料語言', () {
+      final uri = buildHoYoWikiEntryUrl(id: 'x1', lang: 'zh-tw');
+      expect(uri.path, '/pc/genshin/entry/x1');
+      expect(uri.queryParameters['lang'], 'zh-tw');
+      expect(
+        uri.toString(),
+        'https://wiki.hoyolab.com/pc/genshin/entry/x1?lang=zh-tw',
+      );
+    });
+
+    test('不同資料語言反映在 lang 參數', () {
+      expect(
+        buildHoYoWikiEntryUrl(id: 'a2', lang: 'ja-jp').queryParameters['lang'],
+        'ja-jp',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 摘要

物品詳情 Dialog 的「前往 HoYoWiki」按鈕原本開啟 `https://wiki.hoyolab.com/pc/genshin/entry/$id`，不帶語言參數，落地頁語言由瀏覽器／HoYoLab 帳號決定，可能與 Dialog 內顯示的資料語言不一致。

本 PR 讓 URL 帶上 `?lang=${record.lang}`，使 wiki 頁面語言對齊 Dialog 內容。

## 為什麼用 `record.lang`（資料語言）

這顆按鈕對應的 `id` 本來就是用 `index.lookupId(name, lang: record.lang)` 查出來的，Dialog 內的 gallery／desc／tags 也全部來自 `entry.pageByLang[record.lang]`。整個 Dialog 的內容都釘在 `record.lang`，落地頁自然應該對齊同一個語言，使用者才不會「點開後語言突然變了」。`record.lang` 用的就是 HoYoLab 對齊代碼（`zh-tw` / `en-us` / `ja-jp` …），與 wiki web 的 `?lang=` 格式相同，免轉換。

## 變更內容

- 新增小型純函式 `buildHoYoWikiEntryUrl({id, lang})` 組出帶 `?lang=` 的詞條頁網址。
- 「前往 HoYoWiki」按鈕改用此函式。
- open-wiki log 補上 `lang` context。
- 補上 `buildHoYoWikiEntryUrl` 單元測試。

## 測試

- `fvm dart format` ✅
- `fvm flutter analyze` → `No issues found!` ✅
- `fvm flutter test`（全套）→ `All tests passed!` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)