### PR TITLE
feat(settings): add non-destructive "update item data" action

### DIFF
--- a/docs/superpowers/plans/2026-06-18-manual-refresh-item-metadata.md
+++ b/docs/superpowers/plans/2026-06-18-manual-refresh-item-metadata.md
@@ -675,3 +675,28 @@ git commit -m "chore: finalize manual item metadata refresh"
 **Placeholder scan：** 無 TBD／TODO；每個 code step 含完整程式碼與 ARB JSON。
 
 **Type consistency：** `_fetchHoYoWiki(client, {bool forceEntryRefetch})`、`debugRunHoYoWikiOnly({bool forceEntryRefetch})`、`refreshAllHoYoWikiMetadata()`、`_ItemDataSection`、`l.settingsItemData` 等命名跨 Task 一致。`UpdateCompleted` 具名參數（`totalNewRecords`/`failedBanners`/`updatedAt`/`hoYoWikiImagesDownloaded`）沿用 `forceRefetchAllHoYoWikiImages` 既有用法。
+
+---
+
+## 實作後演進（驗收階段追加）
+
+> 本計畫的 Task 1-5 是原始範圍。實機驗收時依使用者回饋追加了下列任務；**最終出貨的完整設計以更新後的設計文件為準**（`docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md`，已涵蓋以下全部）。此處僅記錄演進脈絡，方便對照 commit 歷史。
+
+- **完成訊息語意化**：原計畫直接沿用 `UpdateCompleted`，但其內容是祈願記錄語意（「新增 N 筆紀錄」），對 metadata 刷新不適當。改為：`_fetchHoYoWiki` 回傳型別由 `Future<int>` 改為 record `({int imagesDownloaded, int itemsRefreshed, int staleLangItemsPruned})`；`UpdateCompleted` 新增 `hoyoWikiEntriesRefreshed`（int?，metadata 流程判別）與 `hoyoWikiStaleItemsPruned`（int）；`UpdateProgressDialog._Body` 的 `UpdateCompleted` 分支改三路，metadata 分支顯示「已更新 M 個物品的資料」+ 條件式「補下載 N 張」+ 條件式「已清理 K 個物品的殘留語言資料」。
+- **殘留語言清理**：`_fetchHoYoWiki` 新增 `pruneStaleLangs` 旗標（`refreshAllHoYoWikiMetadata` 傳 true）；新增 `HoYoWikiIndexNotifier.pruneLanguages(Set<String> keepLangs) → Future<int>`，移除 index 中 `lang ∉ keepLangs` 的 `pageByLang`（保留 icon／searchMap／menuIds），空 keepLangs 與呼叫端 `allLangs.isNotEmpty` 雙重防呆，回傳清理到的相異物品數。
+- **新增 i18n key**：`progressDoneItemDataSummary`、`progressDoneItemDataImagesSummary`、`progressDoneItemDataPrunedSummary`（皆帶 `{count}` int placeholder），補進 zh template + 9 個已翻譯語系。
+
+**最終關鍵簽名（覆蓋上方原始 Task 描述）：**
+
+```dart
+// lib/state/gacha_repository.dart
+Future<({int imagesDownloaded, int itemsRefreshed, int staleLangItemsPruned})>
+    _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false, bool pruneStaleLangs = false});
+
+// lib/state/hoyowiki_index.dart
+Future<int> pruneLanguages(Set<String> keepLangs); // 空集合回 0；回傳清理物品數
+
+// lib/state/update_progress.dart — UpdateCompleted 新增
+final int? hoyoWikiEntriesRefreshed; // 非 null = 更新物品資料流程；值為刷新物品數
+final int hoyoWikiStaleItemsPruned;  // 預設 0；清理殘留語言的物品數
+```

--- a/docs/superpowers/plans/2026-06-18-manual-refresh-item-metadata.md
+++ b/docs/superpowers/plans/2026-06-18-manual-refresh-item-metadata.md
@@ -1,0 +1,677 @@
+# 手動更新物品詳細資料 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在設定頁新增一顆非破壞性的「更新物品資料」按鈕，重抓所有物品的 HoYoWiki metadata（強制重抓已解析條目的 entry 階段），保留既有快取圖、新 gallery 圖維持 lazy。
+
+**Architecture:** 重用既有 `_fetchHoYoWiki` 三階段管線，加一個 `forceEntryRefetch` 開關讓 entry 階段強制重抓已解析條目；外層包一個不呼叫 `resetAll()` 的 `refreshAllHoYoWikiMetadata()`；設定頁新增獨立「物品資料」區與輕量確認 dialog。詳情頁零改動（既有 lazy backfill 已涵蓋）。
+
+**Tech Stack:** Flutter、Riverpod（`NotifierProvider`）、`http`/`MockClient`、flutter gen-l10n（ARB）、flutter_test。
+
+## Global Constraints
+
+- 指令一律優先透過 `fvm` 執行（`fvm flutter analyze` / `fvm flutter test` / `fvm flutter gen-l10n` / `fvm dart format lib/ test/`）；找不到 `fvm` 才退回 `flutter` / `dart`。
+- 提交前依序通過：`fvm dart format lib/ test/`、`fvm flutter analyze`（須 `No issues found!`）、`fvm flutter test`（須 `All tests passed!`）。不得用 `--no-verify`。
+- 不要 `git push`（功能分支 `feat/manual-refresh-item-metadata` 已建立，所有 commit 落在此分支）。
+- 所有新宣告（method、field、class）寫一行 `///` dartdoc；Flutter override 不寫。
+- 關鍵節點埋 `Logger` log，命名對齊既有樹（`gacha.hoyowiki.*`）；敏感資料經 `sanitizeUrl`/`sanitizeUid`。
+- 註解節制：只在 WHY 不顯而易見或段落導引時寫。
+- CJK 文案（含 ARB、dartdoc、註解）用全形標點；commit message 用英文半形、conventional commits；省略號一律半形 `...`（ARB 內既有用全形 `…`，新字串沿用既有檔案慣例以保持一致——見 Task 3 說明）。
+- i18n 從 `app_zh.arb`（template）起手；只在已有實體翻譯的 ARB 補字串，空殼 ARB 留給 Crowdin pipeline。
+- Dialog 一律用既有 `showConfirmDialog`，不手寫 `AlertDialog`。
+- 嚴禁重複造輪子：重用 `_fetchHoYoWiki`、`showConfirmDialog`、`SectionCard`、`app_shell` 既有進度 listener。
+
+---
+
+### Task 1: `_fetchHoYoWiki` 加 `forceEntryRefetch` 開關
+
+**Files:**
+- Modify: `lib/state/gacha_repository.dart`（`_fetchHoYoWiki` 簽名與 entryTodo 建構；`debugRunHoYoWikiOnly` 加參數）
+- Test: `test/state/gacha_repository_hoyowiki_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `Future<int> _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false})`
+  - `Future<void> debugRunHoYoWikiOnly({bool forceEntryRefetch = false})`（測試 hook，`@visibleForTesting`）
+
+**背景：** 目前 `_fetchHoYoWiki`（`lib/state/gacha_repository.dart:979`）的 entryTodo 由 `needRefetchEntry` 判定——entry 已存在且該 lang page 已抓就跳過。force 模式要讓**所有已解析的 (id, lang)** 都進 entry worklist。search 階段不需改（newly-searched id 的 entry 為 null，`needRefetchEntry` 本就回 true）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `test/state/gacha_repository_hoyowiki_test.dart` 的 `main()` 內、最後一個 top-level `test(...)`（cancel 那筆，約 1072 行的 `});` 之後、`main` 收尾的 `}` 之前）插入。此測試用可變的 gallery 長度模擬「HoYoWiki 後來新增了一張 gallery 圖」，驗證 force 模式會重抓已存在的 entry 並更新 gallery：
+
+```dart
+  test('forceEntryRefetch=true：已解析的 entry 仍重抓並更新 gallery', () async {
+    var entryCallCount = 0;
+    var galleryListLen = 1;
+    final apiClient = MockClient((req) async {
+      if (req.url.path.endsWith('/search')) {
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'list': [
+                {
+                  'name': 'Hu Tao',
+                  'entry_page_id': '111',
+                  'menu': {
+                    'sub_menus': [
+                      {'id': 2},
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+          200,
+        );
+      }
+      if (req.url.path.endsWith('/entry_page')) {
+        entryCallCount++;
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'page': {
+                'icon_url': 'https://x/icon.png',
+                'modules': [
+                  {
+                    'components': [
+                      {
+                        'component_id': 'gallery_character',
+                        'data': jsonEncode({
+                          'pic': '',
+                          'list': [
+                            for (var i = 0; i < galleryListLen; i++)
+                              {
+                                'id': 'g$i',
+                                'key': 'k$i',
+                                'img': 'https://x/g$i.png',
+                                'imgDesc': '',
+                              },
+                          ],
+                        }),
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+          200,
+        );
+      }
+      return http.Response.bytes([1, 2, 3], 200);
+    });
+    final container = await setupContainer(apiClient: apiClient);
+    final notifier = container.read(gachaRepositoryProvider.notifier);
+
+    // 第一次增量抓取：entry 抓 1 次，gallery 1 張
+    await notifier.debugRunHoYoWikiOnly();
+    expect(entryCallCount, 1);
+    expect(
+      container.read(hoyowikiIndexProvider).lookupEntry('111')!
+          .pageByLang['en-us']!.gallery!.list.length,
+      1,
+    );
+
+    // HoYoWiki 端新增一張 gallery 圖
+    galleryListLen = 2;
+
+    // 非 force：已抓過 → 不重抓，gallery 仍是舊的 1 張
+    await notifier.debugRunHoYoWikiOnly();
+    expect(entryCallCount, 1, reason: '非 force 模式不重抓已解析 entry');
+
+    // force：強制重抓 entry → gallery 更新為 2 張
+    await notifier.debugRunHoYoWikiOnly(forceEntryRefetch: true);
+    expect(entryCallCount, 2, reason: 'force 模式重抓已解析 entry');
+    expect(
+      container.read(hoyowikiIndexProvider).lookupEntry('111')!
+          .pageByLang['en-us']!.gallery!.list.length,
+      2,
+      reason: 'force 重抓後 mergeEntry 覆蓋 gallery，新圖出現',
+    );
+
+    // gallery 大圖不應被 eager 下載（維持 lazy）
+    final galleryFiles = tempDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => RegExp(r'111_gallery_').hasMatch(f.path))
+        .toList();
+    expect(galleryFiles, isEmpty, reason: 'gallery 維持 lazy，不在更新流程下載');
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/state/gacha_repository_hoyowiki_test.dart --plain-name "forceEntryRefetch"`
+Expected: 編譯失敗或 FAIL —— `debugRunHoYoWikiOnly` 尚無具名參數 `forceEntryRefetch`。
+
+- [ ] **Step 3: 實作 `_fetchHoYoWiki` 簽名與 entryTodo 強制納入**
+
+在 `lib/state/gacha_repository.dart` 修改 `_fetchHoYoWiki` 簽名（約 979 行）：
+
+```dart
+  Future<int> _fetchHoYoWiki(
+    http.Client client, {
+    bool forceEntryRefetch = false,
+  }) async {
+```
+
+把初始 entryTodo 建構（約 1023-1036 行）的判定改為「force 時無條件納入」：
+
+```dart
+    final entryTodo = <({String id, String lang})>{};
+    for (final lang in allLangs) {
+      for (final name in namesByLang[lang] ?? const <String>{}) {
+        final id = index.lookupId(name: name, lang: lang);
+        if (id == null) continue;
+        if (forceEntryRefetch ||
+            needRefetchEntry(
+              index.lookupEntry(id),
+              index.lookupMenuId(id),
+              lang,
+            )) {
+          entryTodo.add((id: id, lang: lang));
+        }
+      }
+    }
+```
+
+更新 `_fetchHoYoWiki` 的 dartdoc，在流程說明補一句：「`forceEntryRefetch` 為 true 時，entry 階段強制納入所有已解析的 (id, lang)，用於設定頁手動更新物品資料。」
+
+- [ ] **Step 4: 實作 `debugRunHoYoWikiOnly` 透傳參數**
+
+修改 `debugRunHoYoWikiOnly`（約 1204 行）：
+
+```dart
+  /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）。
+  @visibleForTesting
+  Future<void> debugRunHoYoWikiOnly({bool forceEntryRefetch = false}) async {
+    _cancelTriggered = false;
+    final cancellable = ref.read(cancellableHttpClientFactoryProvider)();
+    try {
+      await _fetchHoYoWiki(cancellable.client, forceEntryRefetch: forceEntryRefetch);
+    } finally {
+      cancellable.client.close();
+    }
+  }
+```
+
+- [ ] **Step 5: 跑測試確認通過**
+
+Run: `fvm flutter test test/state/gacha_repository_hoyowiki_test.dart`
+Expected: PASS（新測試與既有 11 筆全綠）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+fvm dart format lib/ test/
+git add lib/state/gacha_repository.dart test/state/gacha_repository_hoyowiki_test.dart
+git commit -m "feat(hoyowiki): add forceEntryRefetch flag to metadata fetch pipeline"
+```
+
+---
+
+### Task 2: 新增 `refreshAllHoYoWikiMetadata()` 非破壞性入口
+
+**Files:**
+- Modify: `lib/state/gacha_repository.dart`（新增 logger field + public method）
+- Test: `test/state/gacha_repository_hoyowiki_test.dart`
+
+**Interfaces:**
+- Consumes: `_fetchHoYoWiki(client, forceEntryRefetch: true)`（Task 1）
+- Produces: `Future<void> refreshAllHoYoWikiMetadata()`（public，供設定頁呼叫）
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `test/state/gacha_repository_hoyowiki_test.dart` 接續 Task 1 的測試之後插入。驗證 `refreshAllHoYoWikiMetadata` 會重抓已解析 entry、保留既有 icon 快取檔、且結束 emit `UpdateCompleted`：
+
+```dart
+  test('refreshAllHoYoWikiMetadata：非破壞性重抓，保留 icon、emit UpdateCompleted', () async {
+    var entryCallCount = 0;
+    var imageDownloadCount = 0;
+    final apiClient = MockClient((req) async {
+      if (req.url.path.endsWith('/search')) {
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'list': [
+                {
+                  'name': 'Hu Tao',
+                  'entry_page_id': '111',
+                  'menu': {
+                    'sub_menus': [
+                      {'id': 2},
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+          200,
+        );
+      }
+      if (req.url.path.endsWith('/entry_page')) {
+        entryCallCount++;
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'page': {'icon_url': 'https://x/icon.png', 'header_img_url': ''},
+            },
+          }),
+          200,
+        );
+      }
+      imageDownloadCount++;
+      return http.Response.bytes([1, 2, 3], 200);
+    });
+    final container = await setupContainer(apiClient: apiClient);
+    final notifier = container.read(gachaRepositoryProvider.notifier);
+
+    // 先增量抓一次：建立 index + icon 快取檔
+    await notifier.debugRunHoYoWikiOnly();
+    expect(entryCallCount, 1);
+    expect(imageDownloadCount, 1, reason: '第一次下 icon');
+    final iconFile = File('${tempDir.path}/111_icon.png');
+    expect(iconFile.existsSync(), isTrue);
+
+    // 非破壞性更新
+    await notifier.refreshAllHoYoWikiMetadata();
+
+    // entry 被強制重抓；icon 已在快取 → 不重下；icon 檔仍在（未被 wipe）
+    expect(entryCallCount, 2, reason: 'force 重抓 entry');
+    expect(imageDownloadCount, 1, reason: 'icon 已快取，缺才下 → 不重下');
+    expect(iconFile.existsSync(), isTrue, reason: '非破壞性：既有快取保留');
+
+    // 結束狀態為 UpdateCompleted
+    expect(container.read(gachaRepositoryProvider).progress, isA<UpdateCompleted>());
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/state/gacha_repository_hoyowiki_test.dart --plain-name "refreshAllHoYoWikiMetadata"`
+Expected: 編譯失敗 —— `refreshAllHoYoWikiMetadata` 未定義。
+
+- [ ] **Step 3: 新增 logger field**
+
+在 `lib/state/gacha_repository.dart` 既有 logger 宣告（111-117 行）之後新增：
+
+```dart
+  static final _refreshMetaLog = Logger('gacha.hoyowiki.refreshMetadata');
+```
+
+- [ ] **Step 4: 實作 `refreshAllHoYoWikiMetadata`**
+
+緊接在 `forceRefetchAllHoYoWikiImages`（約 604 行的 `}` 之後）新增。骨架比照 `forceRefetchAllHoYoWikiImages`，但**不呼叫 `resetAll()`**、無 wipe 失敗路徑：
+
+```dart
+  /// 非破壞性更新所有物品的 HoYoWiki metadata（強制重抓已解析條目的 entry 階段）。
+  ///
+  /// 與 [forceRefetchAllHoYoWikiImages] 不同：**不** `resetAll()`，保留既有 index
+  /// 與快取圖。重抓後 [HoYoWikiIndexNotifier.mergeEntry] 覆蓋各 lang page，新增的
+  /// gallery 圖只更新 index、不在此下載（維持 lazy，由詳情頁開啟時補）；icon 僅在
+  /// 本地缺檔時才下載。
+  ///
+  /// 流程：互斥檢查 → emit `Preparing` → `_fetchHoYoWiki(forceEntryRefetch: true)`
+  /// → 依取消狀態 emit `UpdateCompleted` 或 `clearProgress`。
+  Future<void> refreshAllHoYoWikiMetadata() async {
+    if (state.progress != null) {
+      _refreshMetaLog.info('skip: another progress in-flight');
+      return;
+    }
+    if (_isUpdating) return;
+    _isUpdating = true;
+    _cancelTriggered = false;
+    _refreshMetaLog.info('start, totalUids=${state.byUid.length}');
+
+    final cancellable = ref.read(cancellableHttpClientFactoryProvider)();
+    _activeCancellable = cancellable;
+    state = state.copyWith(progress: const Preparing());
+
+    try {
+      var images = 0;
+      try {
+        images = await _fetchHoYoWiki(
+          cancellable.client,
+          forceEntryRefetch: true,
+        );
+      } catch (e, st) {
+        _refreshMetaLog.warning('hoyowiki stage threw (ignored)', e, st);
+      }
+      if (!ref.mounted) return;
+
+      if (_cancelTriggered) {
+        _refreshMetaLog.warning('cancelled');
+        state = state.copyWith(clearProgress: true);
+        return;
+      }
+
+      _refreshMetaLog.info('done, images=$images');
+      state = state.copyWith(
+        progress: UpdateCompleted(
+          totalNewRecords: 0,
+          failedBanners: const [],
+          updatedAt: DateTime.now().toUtc(),
+          hoYoWikiImagesDownloaded: images,
+        ),
+      );
+    } finally {
+      _activeCancellable?.client.close();
+      _activeCancellable = null;
+      _cancelTriggered = false;
+      _isUpdating = false;
+    }
+  }
+```
+
+- [ ] **Step 5: 跑測試確認通過**
+
+Run: `fvm flutter test test/state/gacha_repository_hoyowiki_test.dart`
+Expected: PASS（全部綠）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+fvm dart format lib/ test/
+git add lib/state/gacha_repository.dart test/state/gacha_repository_hoyowiki_test.dart
+git commit -m "feat(hoyowiki): add non-destructive refreshAllHoYoWikiMetadata entry point"
+```
+
+---
+
+### Task 3: 新增 i18n 字串（ARB）
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（template，必填）
+- Modify: `lib/l10n/app_en.arb` 及其他**已含** `settingsRefetchHoyoWikiImagesTitle` 的 `app_*.arb`
+- Generated: `lib/l10n/generated/*`（由 gen-l10n 產生，隨後一併提交）
+
+**Interfaces:**
+- Produces（供 Task 4 使用的 getter）：`l.settingsItemData`、`l.settingsRefreshItemDataDesc`、`l.settingsRefreshItemDataTitle`、`l.settingsRefreshItemDataEmpty`、`l.confirmRefreshItemDataTitle`、`l.confirmRefreshItemDataBody`、`l.confirmRefreshItemDataConfirm`
+
+**說明：** template 為 `app_zh.arb`。其他 locale 若缺 key 會在執行期 fallback 到 template，故 gen-l10n 不會因非 template ARB 缺 key 而失敗。依專案慣例只在「已有實體翻譯」的 ARB 補字串——判準：該檔已含 `settingsRefetchHoyoWikiImagesTitle`（用 Grep 確認），有則補、空殼則跳過。省略號沿用本檔既有寫法（`app_zh.arb` 內既有 `計算中…` 用全形，新字串若含省略號比照同檔慣例；本批字串草案不含省略號）。
+
+- [ ] **Step 1: 在 `app_zh.arb` 新增字串**
+
+在 `lib/l10n/app_zh.arb` 的 `confirmRefetchHoyoWikiConfirm` 區塊（366-369 行）之後、`settingsImageCache`（371 行）之前插入：
+
+```json
+  "settingsItemData": "物品資料",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "從 HoYoWiki 重新抓取所有物品的最新詳細資料（描述、圖片清單等），保留已下載的圖片；新增的圖片會在你開啟該物品詳情時才下載。",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "更新物品資料",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "尚無卡池記錄，無法更新物品資料",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "更新物品資料？",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "將連線 HoYoWiki 重新抓取所有物品的詳細資料，依物品數量可能需要一段時間。已下載的圖片會保留，不會被清除。",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "開始更新",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
+```
+
+- [ ] **Step 2: 在 `app_en.arb` 新增對應英文字串**
+
+在 `lib/l10n/app_en.arb` 對應位置（`confirmRefetchHoyoWikiConfirm` 之後）插入。英文無 `@` metadata 區塊（template 已帶 description），只需 key-value：
+
+```json
+  "settingsItemData": "Item Data",
+  "settingsRefreshItemDataDesc": "Re-fetch the latest item details (descriptions, image lists, etc.) from HoYoWiki, keeping already-downloaded images. New images are downloaded when you open the item's details.",
+  "settingsRefreshItemDataTitle": "Update Item Data",
+  "settingsRefreshItemDataEmpty": "No gacha records yet — nothing to update",
+  "confirmRefreshItemDataTitle": "Update item data?",
+  "confirmRefreshItemDataBody": "This will contact HoYoWiki to re-fetch every item's details, which may take a while depending on how many items you have. Already-downloaded images are kept and will not be cleared.",
+  "confirmRefreshItemDataConfirm": "Start update",
+```
+
+> 若 `app_en.arb` 既有條目帶 `@` metadata，則比照同檔慣例補上；以實際檔案格式為準。
+
+- [ ] **Step 3: 補其他已翻譯的 ARB**
+
+Run（找出已翻譯的 locale 檔）：`grep -l "settingsRefetchHoyoWikiImagesTitle" lib/l10n/app_*.arb`
+對結果中**除 `app_zh.arb`/`app_en.arb` 外**的每個檔，比照 Step 2 形式新增上述 7 個 key，文案以繁中（Step 1）為基準翻成該語言；未出現在清單的 ARB（空殼）不動。
+
+- [ ] **Step 4: 重新產生 localizations**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 新增上述 getter。
+
+- [ ] **Step 5: analyze 驗證 getter 可用**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add item data refresh strings"
+```
+
+---
+
+### Task 4: 設定頁新增「物品資料」區與按鈕
+
+**Files:**
+- Modify: `lib/pages/settings_page.dart`（新增 `SectionCard` 與 `_ItemDataSection`）
+- Test: `test/pages/settings_item_data_section_test.dart`（新建）
+
+**Interfaces:**
+- Consumes: `refreshAllHoYoWikiMetadata()`（Task 2）、Task 3 的 `l.*` getter、既有 `showConfirmDialog`、`SectionCard`
+- Produces: 無下游
+
+**說明：** 新「物品資料」`SectionCard` 插在「圖片快取」（現約 110-114 行）之前。`_ItemDataSection` 為 `ConsumerWidget`，disable 條件比照 `_refetchAll`（`!hasData || progress != null`），確認用 `showConfirmDialog(isDanger: false)`，觸發用 `unawaited(...)`，進度 dialog 由 `app_shell` 既有 listener 自動彈出。
+
+- [ ] **Step 1: 寫失敗 widget 測試**
+
+新建 `test/pages/settings_item_data_section_test.dart`。先讀 `test/pages/` 既有測試（若有）對齊 harness 寫法；本測試自包含、用 `ProviderContainer` override 一個 spy 來驗證按鈕點擊→確認→呼叫。若 `_ItemDataSection` 為 private 無法直接 import，改以較輕的「getter 存在 + repository 方法可被呼叫」測試，或將測試聚焦在 `_ItemDataSection` 透過 `UncontrolledProviderScope` 掛載。實作如下（用一個可記錄呼叫的假 repository notifier 不易，故改驗證 UI 層級行為）：
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('物品資料區字串已生成且可取用', (tester) async {
+    late AppLocalizations l;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Builder(
+            builder: (context) {
+              l = AppLocalizations.of(context)!;
+              return const SizedBox();
+            },
+          ),
+        ),
+      ),
+    );
+    expect(l.settingsItemData, '物品資料');
+    expect(l.settingsRefreshItemDataTitle, '更新物品資料');
+    expect(l.confirmRefreshItemDataConfirm, '開始更新');
+  });
+}
+```
+
+> 此測試先守住 Task 3 字串落地（Task 4 依賴）。`_ItemDataSection` 的點擊→`refreshAllHoYoWikiMetadata` 行為已由 Task 2 的 repository 測試覆蓋；UI 互動採人工驗收（驗收條件 4），避免為 private widget + 真實 HTTP 疊出脆弱測試（YAGNI）。
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/pages/settings_item_data_section_test.dart`
+Expected: 若 Task 3 尚未合入此分支會 FAIL；本分支已含 Task 3，故此步應在 Step 1 之後直接驗證——若 getter 已存在則此測試在實作 UI 前就會 PASS（屬可接受，因為它守的是 Task 3 字串）。確認測試本身能編譯並執行。
+
+- [ ] **Step 3: 新增 `_ItemDataSection` widget**
+
+在 `lib/pages/settings_page.dart` 適當位置（建議緊鄰 `_ImageCacheSection` 之前）新增：
+
+```dart
+/// 物品資料區塊：提供「更新物品資料」按鈕，非破壞性重抓 HoYoWiki metadata。
+class _ItemDataSection extends ConsumerWidget {
+  /// 建立 [_ItemDataSection]。
+  const _ItemDataSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final hasData = ref.watch(
+      gachaRepositoryProvider.select((s) => s.byUid.isNotEmpty),
+    );
+    final progress = ref.watch(
+      gachaRepositoryProvider.select((s) => s.progress),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l.settingsRefreshItemDataDesc,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: tokens.textSecondary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.m),
+        Tooltip(
+          message: !hasData ? l.settingsRefreshItemDataEmpty : '',
+          child: FilledButton.icon(
+            onPressed: (!hasData || progress != null)
+                ? null
+                : () => _refreshItemData(context, ref),
+            icon: const Icon(Icons.sync, size: 18),
+            label: Text(l.settingsRefreshItemDataTitle),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 顯示輕量確認 dialog，確認後呼叫 [GachaRepository.refreshAllHoYoWikiMetadata]。
+  Future<void> _refreshItemData(BuildContext ctx, WidgetRef ref) async {
+    final l = AppLocalizations.of(ctx)!;
+    final ok = await showConfirmDialog(
+      context: ctx,
+      title: l.confirmRefreshItemDataTitle,
+      body: l.confirmRefreshItemDataBody,
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmRefreshItemDataConfirm,
+      isDanger: false,
+    );
+    if (ok != true) return;
+    // 後端流程獨立於 dialog lifecycle；UpdateProgressDialog 由 app_shell.dart
+    // 既有 ref.listen 自動彈出。
+    unawaited(
+      ref.read(gachaRepositoryProvider.notifier).refreshAllHoYoWikiMetadata(),
+    );
+  }
+}
+```
+
+> 確認 `lib/pages/settings_page.dart` 頂部已 import `dart:async`（`unawaited`）；`_ImageCacheSection` 既有 `unawaited` 用法表示應已 import，若無則補上。
+
+- [ ] **Step 4: 掛上 `SectionCard`**
+
+在 `build` 的 section 清單，「圖片快取」`SectionCard`（約 110 行）之前插入：
+
+```dart
+              SectionCard(
+                title: l.settingsItemData,
+                icon: Icons.dataset_outlined,
+                child: const _ItemDataSection(),
+              ),
+              const SizedBox(height: AppSpacing.xl),
+```
+
+- [ ] **Step 5: 跑全套測試 + analyze**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+fvm dart format lib/ test/
+git add lib/pages/settings_page.dart test/pages/settings_item_data_section_test.dart
+git commit -m "feat(settings): add Item Data section with non-destructive refresh button"
+```
+
+---
+
+### Task 5: 全套驗證與人工驗收
+
+**Files:** 無（驗證任務）
+
+- [ ] **Step 1: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 無檔案被改動（前面已格式化）或僅微調。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: 全套測試**
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 人工驗收（驗收條件 3、4）**
+
+1. 啟動 App → 設定頁出現獨立「物品資料」區與「更新物品資料」按鈕（非 danger 樣式）；無卡池記錄時 disable 並顯示 tooltip。
+2. 對一個已有 gallery 的物品，於 HoYoWiki 新增圖後點「更新物品資料」→ 輕量確認 dialog → 確認後出現進度 dialog（搜尋→抓頁面→下載階段）。
+3. 更新完成後開啟該物品詳情 → 可見新頁籤，缺的圖會 lazy 補下載；既有已下載的圖未被清除（「圖片快取」用量未歸零）。
+
+- [ ] **Step 5:（如有殘留改動）Commit**
+
+```bash
+git add -A
+git commit -m "chore: finalize manual item metadata refresh"
+```
+
+> 若前述任務已全部提交且無殘留，跳過此步。完成後不要 `git push`，依 finishing-a-development-branch 流程與使用者確認整合方式。
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 設定頁手動更新入口 → Task 4（按鈕）+ Task 2（method）。
+- 重抓範圍「全部已解析 entry + 重試未解析 search」→ Task 1（force entry）+ 既有 search 階段（未解析本就重試）。
+- 非破壞性、保留已下載圖 → Task 2（不 `resetAll`）+ Task 1 download 階段只補缺 icon。
+- 新圖 lazy、開詳情補下載 → 詳情頁零改動（spec 已論證），Task 1 測試驗證 gallery 不 eager 下載。
+- icon「缺才下、URL 變不重下」→ 既有 download 階段 + id-key 快取，Task 2 測試驗證不重下。
+- 獨立「物品資料」區 + 輕量確認 → Task 4。
+- i18n → Task 3。
+- 驗收條件（analyze/test 全綠、UI、實機）→ Task 5。
+
+**Placeholder scan：** 無 TBD／TODO；每個 code step 含完整程式碼與 ARB JSON。
+
+**Type consistency：** `_fetchHoYoWiki(client, {bool forceEntryRefetch})`、`debugRunHoYoWikiOnly({bool forceEntryRefetch})`、`refreshAllHoYoWikiMetadata()`、`_ItemDataSection`、`l.settingsItemData` 等命名跨 Task 一致。`UpdateCompleted` 具名參數（`totalNewRecords`/`failedBanners`/`updatedAt`/`hoYoWikiImagesDownloaded`）沿用 `forceRefetchAllHoYoWikiImages` 既有用法。

--- a/docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md
@@ -1,13 +1,15 @@
 # 手動更新物品詳細資料 — 設計文件
 
 - 日期：2026-06-18
-- 狀態：設計已確認，待寫實作計畫
+- 狀態：已實作並驗證（含實作後演進：完成訊息語意化、殘留語言清理與統計）
+
+> 本文件已更新為**最終出貨設計**。原始設計只涵蓋「非破壞性重抓 metadata」；實作驗收階段又依使用者回饋追加了兩項：(A) 完成訊息改用本流程專屬語意（不再沿用祈願記錄文案）、(B) 針對性清理「資料語言轉換後殘留的舊語言資料」並在完成訊息統計。姐妹專案可直接參考本文件的完整設計。
 
 ## 背景與問題
 
 物品詳細資料（HoYoWiki 的 gallery 清單、描述、tags）由 `GachaRepository._fetchHoYoWiki` 的三階段管線（search → entry → download）抓取，存進 `hoyowiki_index.json`。
 
-這條管線是**增量式**的：`needRefetchEntry`（`lib/state/gacha_repository.dart:1010`）判定「entry 已存在、menuId 有、該語言 page 也有」就回傳 `false`，不重抓。結果是——**若某物品在 HoYoWiki 後來新增了 gallery 圖（例如新增的立繪），正常更新永遠偵測不到**，因為該語言的 page 早已存在。
+這條管線是**增量式**的：`needRefetchEntry` 判定「entry 已存在、menuId 有、該語言 page 也有」就回傳 `false`，不重抓。結果是——**若某物品在 HoYoWiki 後來新增了 gallery 圖（例如新增的立繪），正常更新永遠偵測不到**，因為該語言的 page 早已存在。
 
 設定頁現有的「強制重抓物品圖片」按鈕雖能拿到新資料，但它走 `forceRefetchAllHoYoWikiImages()` → 先 `resetAll()` **清空整個 index 與所有快取圖**，再全部重抓並 eager 下載所有 icon。這是破壞性的、耗時且浪費頻寬。
 
@@ -19,21 +21,24 @@
 2. 重抓涵蓋：對先前**沒解析到**的物品重試 search；對**所有已解析**的條目強制重抓 entry 階段（更新 gallery 清單／描述／tags）。
 3. 不重抓已下載的圖；icon 僅在本地缺檔時 eager 補下載；gallery 大圖一律維持 lazy。
 4. 物品詳情頁的頁籤隨 index 更新自動反映新 gallery 條目；開啟詳情時補下載缺漏的圖。
+5. 完成訊息使用**本流程專屬語意**（「已更新 M 個物品的資料」），不沿用祈願記錄流程的「新增 N 筆紀錄」。
+6. **針對性清理殘留語言**：移除 index 中已不再被任何記錄使用的語言頁面（資料語言轉換後的殘留），維持非破壞性，並在完成訊息統計清理到的物品數。
 
 ## 非目標（YAGNI）
 
-- 不做「只更新逾期條目（依 `fetchedAt` 門檻）」的選擇性更新——使用者選擇「全部已解析條目都重抓」。
+- 不做「只更新逾期條目（依 `fetchedAt` 門檻）」的選擇性更新——「全部已解析條目都重抓」。
 - 不改 icon 快取的 key 策略（仍以 id 為 key）；不主動因 icon URL 字串變動而重下 icon。
 - 不在詳情頁新增任何 per-item 重抓入口（既有圖片選單的「重抓圖片」已涵蓋單張需求）。
-- 不保留「破壞性強制重抓」以外的相容路徑——既有按鈕原樣保留。
+- 既有「破壞性強制重抓」按鈕原樣保留，與新按鈕職責區隔（破壞性 vs 非破壞性）。
+- 殘留語言清理**只清 index 內的 `pageByLang` 資料**，不刪 `searchMap`（search hints 很小、保留可加速日後再轉回該語言）、不刪 orphan gallery 快取圖檔（殘留語言的 gallery 是 lazy，多半從未下載；少量 orphan 交給既有「清除詳情圖快取」）。
 
 ## 關鍵發現：詳情頁無需改動
 
-`GachaItemDetailDialog.build()`（`lib/widgets/dialogs/gacha_item_detail_dialog.dart:449`）`watch(hoyowikiIndexProvider)`，且既有的 lazy backfill（同檔 519-541 行）對「不在 `_loadStates` 的 chip」逐一檢查：本地有檔 → `_GalleryReady`，缺檔 → `_GalleryLoading` 並排程背景下載。
+`GachaItemDetailDialog.build()`（`lib/widgets/dialogs/gacha_item_detail_dialog.dart`）`watch(hoyowikiIndexProvider)`，且既有的 lazy backfill 對「不在 `_loadStates` 的 chip」逐一檢查：本地有檔 → `_GalleryReady`，缺檔 → `_GalleryLoading` 並排程背景下載。
 
-每次開啟 dialog 都是全新的 `State`、`_loadStates` 為空，因此**每次開啟都會重新檢查所有 gallery chip（含卡片大圖）並補下載缺的**。metadata 更新後，`mergeEntry`（`lib/state/hoyowiki_index.dart:117`）以 `lang: fetched.page` 覆蓋該語言 page → 新 gallery 條目進入 index → 下次（或開著時）重建即多出新 chip → 缺檔自動 lazy 補下載。
+每次開啟 dialog 都是全新的 `State`、`_loadStates` 為空，因此**每次開啟都會重新檢查所有 gallery chip（含卡片大圖）並補下載缺的**。metadata 更新後，`mergeEntry`（`lib/state/hoyowiki_index.dart`）以 `lang: fetched.page` 覆蓋該語言 page → 新 gallery 條目進入 index → 下次（或開著時）重建即多出新 chip → 缺檔自動 lazy 補下載。
 
-icon 則由 `hasHoYoWikiContent`（同檔 30 行）把關：icon 檔不存在時物品不可點。故 icon 必須在更新時就補齊（見下方 icon 策略），與本設計一致；詳情頁本身不處理 icon lazy 下載。
+icon 則由 `hasHoYoWikiContent` 把關：icon 檔不存在時物品不可點。故 icon 必須在更新時就補齊（見 icon 策略），與本設計一致；詳情頁本身不處理 icon lazy 下載。
 
 **結論：「頁籤跟著更新」與「開啟詳情時補下載缺圖」由既有機制完整涵蓋，本功能在詳情頁零改動，前提僅是 index 要先被更新。**
 
@@ -41,49 +46,88 @@ icon 則由 `hasHoYoWikiContent`（同檔 30 行）把關：icon 檔不存在時
 
 ### 1. 參數化 `_fetchHoYoWiki`（重用既有管線，不造新輪子）
 
-`lib/state/gacha_repository.dart`：
+`lib/state/gacha_repository.dart`，最終簽名：
 
-```
-Future<int> _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false})
+```dart
+Future<({int imagesDownloaded, int itemsRefreshed, int staleLangItemsPruned})>
+    _fetchHoYoWiki(
+  http.Client client, {
+  bool forceEntryRefetch = false,
+  bool pruneStaleLangs = false,
+})
 ```
 
+- **回傳改為 record**：`imagesDownloaded`（本次成功寫檔的 icon 張數）、`itemsRefreshed`（本次成功重抓 metadata 的**相異物品數**）、`staleLangItemsPruned`（本次清掉殘留語言的相異物品數）。其餘呼叫端只讀 `.imagesDownloaded`，不受影響。
 - **search 階段**：不變。`searchTodo` 本來就只收 `lookupId == null` 者，且無負快取——「對先前沒解析到的重試 search」現況已免費滿足。
-- **entry 階段（唯一行為變更）**：
+- **entry 階段**：
   - `forceEntryRefetch == false`：維持現狀，由 `needRefetchEntry` 決定。
-  - `forceEntryRefetch == true`：`entryTodo` 納入**所有已解析的 (id, lang)**，略過 `needRefetchEntry` 的「已有就跳過」。search 階段內部那段「命中後 add 進 entryTodo」的 `needRefetchEntry` 守衛在 force 模式下也改為無條件 add。
-- **download 階段**：不變。`enqueueDownloadsForEntry`（同檔 1042 行）本來就只 enqueue icon、且只在 `iconFile.existsSync() == false` 時加入；gallery 完全不在此下載。→ 自動符合「缺 icon 才 eager 下載、gallery 維持 lazy」。
-- **early return**：`totalInitial == 0` 的早退在 force 模式下因 `entryTodo` 非空（有已解析條目時）不會誤觸；無任何記錄時仍正確回 0。
-- 取消／互斥／進度（`FetchingHoYoWiki` 三階段）全部沿用既有邏輯。
+  - `forceEntryRefetch == true`：`entryTodo` 納入**所有已解析的 (id, lang)**，略過 `needRefetchEntry`。
+  - 注意：search 階段內部「命中後 add 進 entryTodo」那段的 `needRefetchEntry` 守衛**未**特別加 `forceEntryRefetch`——剛 search 命中的 id 其 entry 為 null，`needRefetchEntry(null, ...)` 本就回 true，force 與非 force 行為一致（程式碼內留有 WHY 註解說明）。
+  - `itemsRefreshed`：以 `Set<String> refreshedIds` 在每次成功 `mergeEntry` 後 `add(pair.id)`，回傳其 `length`（相異 id，2 個語言的同一物品只算 1）。
+- **download 階段**：不變。`enqueueDownloadsForEntry` 只 enqueue icon、且只在 `iconFile.existsSync() == false` 時加入；gallery 完全不在此下載。→ 自動符合「缺 icon 才 eager 下載、gallery 維持 lazy」。
+- **殘留語言清理**：`pruneStaleLangs == true` 時，在算出 `allLangs`（所有記錄語言集合）後、建 `entryTodo` 前，呼叫 `indexNotifier.pruneLanguages(allLangs)`，並**以 `allLangs.isNotEmpty` 守衛**避免無記錄時誤清全部；清完重讀 index 快照。`staleLangItemsPruned` = 該呼叫回傳值。
+- **early return / 取消 / 互斥 / 進度**（`FetchingHoYoWiki` 三階段）全部沿用既有邏輯；所有 return 點都回傳完整 record（prune 之前的早退點 `staleLangItemsPruned` 自然為 0）。
 
 ### 2. 新增 `refreshAllHoYoWikiMetadata()`
 
-`lib/state/gacha_repository.dart`，比照 `forceRefetchAllHoYoWikiImages`（534-604 行）的骨架，**但拿掉 `resetAll()`**：
+`lib/state/gacha_repository.dart`，比照 `forceRefetchAllHoYoWikiImages` 的骨架，**但拿掉 `resetAll()`**（非破壞性）：
 
 1. 互斥檢查（`state.progress != null` / `_isUpdating` → no-op）。
 2. emit `Preparing`、建 cancellable client、設 `_activeCancellable`。
-3. 直接呼叫 `_fetchHoYoWiki(cancellable.client, forceEntryRefetch: true)`（不清 index、不清 cache）。
-4. 依取消狀態 emit `UpdateCompleted(hoYoWikiImagesDownloaded: ...)` 或 `clearProgress`。
+3. 呼叫 `_fetchHoYoWiki(cancellable.client, forceEntryRefetch: true, pruneStaleLangs: true)`（不清 index、不清 cache）。
+4. 依取消狀態 emit `UpdateCompleted(hoYoWikiImagesDownloaded: result.imagesDownloaded, hoyoWikiEntriesRefreshed: result.itemsRefreshed, hoyoWikiStaleItemsPruned: result.staleLangItemsPruned)` 或 `clearProgress`。
 5. `finally` 收尾關 client、清旗標。
 
-新增專屬 logger（對齊既有樹，如 `Logger('gacha.hoyowiki.refreshMetadata')`），在開始（總條目數）、各階段結束、完成／取消處埋 `info`，單筆失敗沿用 `_fetchHoYoWiki` 內既有 `warning`。
+專屬 logger `Logger('gacha.hoyowiki.refreshMetadata')`，在開始、各階段、完成／取消處埋 `info`（帶 images／items 計數）。
 
 ### 3. 設定頁：新增「物品資料」區
 
 `lib/pages/settings_page.dart`：
 
-- 在 `build` 的 section 清單（66-126 行）新增一張 `SectionCard`，建議插在「圖片快取」（110 行）之前，視覺上把「物品資料更新」與「圖片快取管理」相鄰分組。圖示建議 `Icons.dataset_outlined`（或 `Icons.inventory_2_outlined`）。
-- 新增 `_ItemDataSection`（`ConsumerWidget`），內含：
-  - 一行簡短說明文字（`l.settingsRefreshItemDataDesc`）：說明此操作會連線 HoYoWiki 重抓最新詳細資料、保留已下載的圖、新圖於開啟詳情時補下載。
-  - 一顆 `FilledButton.icon`（**非** danger 樣式，用一般 FilledButton 與破壞性按鈕區分），label `l.settingsRefreshItemDataTitle`，icon `Icons.refresh`（或 `Icons.sync`）。
-  - disable 條件比照 `_refetchAll`：`!hasData || progress != null`；`!hasData` 時用 `Tooltip` 顯示 `l.settingsRefreshItemDataEmpty`。
-- 點擊 → `_refreshItemData(ctx)`：以 `showConfirmDialog`（`isDanger: false`）跳輕量確認（title／body／confirm 用新 key），確認後 `unawaited(ref.read(gachaRepositoryProvider.notifier).refreshAllHoYoWikiMetadata())`。進度 dialog 由 `app_shell.dart` 既有 `ref.listen` 自動彈出，無需額外處理。
+- 在 `build` 的 section 清單，於「圖片快取」之前新增一張 `SectionCard`（圖示 `Icons.dataset_outlined`），把「物品資料更新」與「圖片快取管理」相鄰分組。
+- 新增 `_ItemDataSection`（`ConsumerWidget`）：一行說明（`l.settingsRefreshItemDataDesc`）+ 一顆**一般** `FilledButton.icon`（非 danger 樣式，與破壞性按鈕區分）。
+- disable 條件比照 `_refetchAll`：`!hasData || progress != null`；`!hasData` 時 `Tooltip` 顯示 `l.settingsRefreshItemDataEmpty`。
+- 點擊 → `showConfirmDialog(isDanger: false)` 輕量確認 → `unawaited(refreshAllHoYoWikiMetadata())`。進度 dialog 由 `app_shell.dart` 既有 `ref.listen` 自動彈出。
 
-### 4. i18n 字串
+### 4. 殘留語言清理（`pruneLanguages`）
 
-依專案慣例：先寫 `app_zh.arb`，再以中文為基準翻已有實體翻譯的 ARB；**不碰空殼 ARB**（留給 Crowdin pipeline）；省略號一律半形。新增 key（命名對齊既有 `settingsRefetchHoyoWiki*` / `confirmRefetchHoyoWiki*` 範式）：
+**問題情境**：`_fetchHoYoWiki` 只從**目前記錄**收集 `(物品, lang)`。若使用者曾用「設定 → 資料語言 → 立即轉換」把記錄轉成別的語言再轉回（例如 en-us → zh-tw），index 裡那個 en-us 的 `pageByLang` 會殘留——`unifyDataLanguage` 只轉記錄、不清 index；後續更新也只抓當前語言，永遠不會碰到舊語言頁面。
 
-| key | 用途 | 繁中草案 |
-|-----|------|---------|
+**解法**（`lib/state/hoyowiki_index.dart`，`HoYoWikiIndexNotifier.pruneLanguages`）：
+
+```dart
+Future<int> pruneLanguages(Set<String> keepLangs)
+```
+
+- 移除所有 entry 中 `lang ∉ keepLangs` 的 `pageByLang` 條目；保留 `iconUrl`／`fetchedAt`／`searchMap`／`menuIds`。
+- **空 `keepLangs` 直接 `return 0`**（防呆：空集合會清掉全部）——這是 method 內部的第二道防線，呼叫端另有 `allLangs.isNotEmpty` 守衛。
+- 有實際縮減才 `_saveAndEmit`；無變動 `return 0`（不重建 index、不觸發 UI churn）。
+- 回傳值 = `pageByLang` 真的有縮減的**相異物品數**，供完成訊息統計。
+
+效果：更新只覆蓋「正在使用的語言」，舊語言殘留被清掉；當前語言的 icon／gallery 一律不動（非破壞性）。
+
+### 5. 完成訊息設計（語意化）
+
+「更新物品資料」**不可**沿用祈願記錄流程的「新增 N 筆紀錄」（對 metadata 刷新無意義）。改用本流程專屬摘要。
+
+- `UpdateCompleted`（`lib/state/update_progress.dart`）新增兩個欄位：
+  - `int? hoyoWikiEntriesRefreshed`（預設 null）——非 null 即代表「這是更新物品資料流程的完成」，UI 據此切換到物品資料摘要；值為本次成功刷新的物品數。
+  - `int hoyoWikiStaleItemsPruned`（預設 0）——本次清理殘留語言的物品數。
+- `UpdateProgressDialog._Body` 的 `UpdateCompleted` 分支改為**三路**（`lib/widgets/update_progress_dialog.dart`）：
+  1. `importSummary != null` → 匯入摘要（既有，不變）。
+  2. `hoyoWikiEntriesRefreshed != null` → 物品資料摘要：
+     - 主行：`已更新 {M} 個物品的資料`（`l.progressDoneItemDataSummary`）。
+     - 補圖行（僅 `hoYoWikiImagesDownloaded > 0`）：`補下載 {N} 張物品圖片`（`l.progressDoneItemDataImagesSummary`）。
+     - 清理行（僅 `hoyoWikiStaleItemsPruned > 0`）：`已清理 {K} 個物品的殘留語言資料`（`l.progressDoneItemDataPrunedSummary`）。
+  3. else → 一般更新摘要（既有「新增 N 筆紀錄」+「下載 N 張物品圖片」，不變）。
+- 標題沿用「更新完成」。
+
+### 6. i18n 字串
+
+依專案慣例：先寫 `app_zh.arb`（template，含 `@` 描述），再以中文為基準翻**已有實體翻譯**的 ARB；不碰空殼（留給 Crowdin pipeline）；省略號半形。最終實際出貨的 key：
+
+| key | 用途 | 繁中 |
+|-----|------|------|
 | `settingsItemData` | 區塊標題 | 物品資料 |
 | `settingsRefreshItemDataDesc` | 區塊說明 | 從 HoYoWiki 重新抓取所有物品的最新詳細資料（描述、圖片清單等），保留已下載的圖片；新增的圖片會在你開啟該物品詳情時才下載。 |
 | `settingsRefreshItemDataTitle` | 按鈕文字 | 更新物品資料 |
@@ -91,17 +135,20 @@ Future<int> _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false})
 | `confirmRefreshItemDataTitle` | 確認標題 | 更新物品資料？ |
 | `confirmRefreshItemDataBody` | 確認內文 | 將連線 HoYoWiki 重新抓取所有物品的詳細資料，依物品數量可能需要一段時間。已下載的圖片會保留，不會被清除。 |
 | `confirmRefreshItemDataConfirm` | 確認鈕 | 開始更新 |
-
-文案最終以實作時 `app_zh.arb` 為準。
+| `progressDoneItemDataSummary` | 完成主行 | 已更新 {count} 個物品的資料 |
+| `progressDoneItemDataImagesSummary` | 完成補圖行 | 補下載 {count} 張物品圖片 |
+| `progressDoneItemDataPrunedSummary` | 完成清理行 | 已清理 {count} 個物品的殘留語言資料 |
 
 ## 資料流
 
 ```
 設定頁「更新物品資料」→ refreshAllHoYoWikiMetadata()
-  → _fetchHoYoWiki(forceEntryRefetch: true)
+  → _fetchHoYoWiki(forceEntryRefetch: true, pruneStaleLangs: true)
+      pruneLanguages(allLangs)  ← 清掉殘留語言（allLangs 非空才執行）
       search（補未解析）→ entry（全部已解析條目重抓，含新 gallery 清單）→ download（只補缺 icon）
   → mergeEntry 覆蓋該 lang page + bumpCacheRevision → index 更新
-  → UpdateCompleted（進度 dialog 自動顯示，結束後刷新快取用量）
+  → UpdateCompleted(itemsRefreshed=M, imagesDownloaded=N, staleItemsPruned=K)
+  → 進度 dialog 顯示「已更新 M…／補下載 N…（N>0）／已清理 K…（K>0）」，結束後刷新快取用量
 
 之後使用者開某物品詳情：
   build() 讀最新 index → 新 gallery 條目變新 chip
@@ -111,26 +158,32 @@ Future<int> _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false})
 ## 錯誤處理
 
 - 單筆 search／entry／download 失敗：沿用 `_fetchHoYoWiki` 既有 per-item try/catch + `warning` log，不終止整段。
-- 整段例外：`refreshAllHoYoWikiMetadata` 不像破壞性流程有 `resetAll` 失敗路徑，故不需要 `UpdateErrorWipeHoYoWikiCache`；最壞情況是部分條目沒更新到，使用者可再次點擊。
-- 取消：使用者於進度 dialog 按取消 → `_cancelTriggered` → 各階段 `isAborted()` 早退 → emit `clearProgress`。已寫入 index 的部分保留（非破壞性，安全）。
+- 整段例外：`refreshAllHoYoWikiMetadata` 不像破壞性流程有 `resetAll` 失敗路徑，故不需要 `UpdateErrorWipeHoYoWikiCache`；最壞情況是部分條目沒更新到，使用者可再次點擊（非破壞性，重試安全）。
+- 取消：使用者於進度 dialog 按取消 → `_cancelTriggered` → 各階段早退 → emit `clearProgress`。已寫入 index 的部分保留。
 - 並發互斥：`progress != null` 或 `_isUpdating` 時按鈕已 disable，方法層再做 no-op 防呆。
 
 ## 已知次要行為
 
-- icon 快取檔以 id（與副檔名）為 key、不含 URL hash。若某條目 icon URL 僅字串變動但副檔名不變 → 路徑相同 → `existsSync()` 為真 → **不重下**（沿用舊 icon）。此與使用者選擇的「缺 icon 才下、URL 變不重下」一致；屬可接受行為，不在本次處理。
+- **icon 快取 key**：以 id（與副檔名）為 key、不含 URL hash。若 icon URL 僅字串變動但副檔名不變 → 路徑相同 → 不重下（沿用舊 icon）。屬可接受行為。
+- **只更新當前語言**：更新只抓記錄目前的語言。要更新／顯示某語言的物品資料，途徑是先「資料語言 → 立即轉換」統一記錄語言，再「更新物品資料」。
+- **清理只動 index**：`pruneLanguages` 只移除 `pageByLang`，不清 `searchMap` hints、不刪 orphan gallery 圖檔（前者很小且利於日後再轉回；後者交既有「清除詳情圖快取」）。
 
 ## 測試
 
-- **Repository（單元）**：擴充既有 HoYoWiki 抓取測試（參考 `debugRunHoYoWikiOnly` 與既有 fake fetcher 模式），新增案例：
-  - 給定一個「已解析、該 lang page 已存在」的 entry，`forceEntryRefetch: true` 時該 (id, lang) 仍進入 entry worklist 並被重抓；`false` 時不進入（守住既有增量行為）。
-  - fake fetcher 第二次回傳「多一張 gallery 圖」的 page → 斷言 `mergeEntry` 後 index 的該 lang gallery 清單變長，且 **download 階段未** eager 下載該 gallery 圖（只可能下 icon）。
-  - 本地已有 icon 檔時，force 重抓不重複下載 icon。
-- **設定頁（widget）**：新「物品資料」區按鈕在無資料時 disable、有資料時可點；點擊跳確認 dialog，確認後呼叫 `refreshAllHoYoWikiMetadata`（以 provider override / spy 驗證）。
-- 既有詳情頁 lazy backfill 測試若存在則無需改動；可補一個「index 新增 gallery 條目後，開啟 dialog 會對缺檔 chip 觸發下載」的迴歸測試（若既有測試未涵蓋）。
+- **Repository（單元，`gacha_repository_hoyowiki_test.dart`）**：
+  - `forceEntryRefetch: true` 時已解析 entry 仍進 worklist 並重抓；`false` 不進（守住增量行為）。
+  - 第二次回傳「多一張 gallery 圖」→ index 該 lang gallery 變長，且 gallery 未被 eager 下載。
+  - 本地已有 icon 時 force 重抓不重下 icon。
+  - `refreshAllHoYoWikiMetadata` 完成後 `UpdateCompleted.hoyoWikiEntriesRefreshed`（1 物品 → 1；同物品 2 語言 → 仍 1，驗證相異 id 計數）、`hoyoWikiStaleItemsPruned`（注入殘留語言 → 對應數）。
+  - 注入殘留語言 page → 執行 refresh → 該語言被清、當前語言保留。
+- **Notifier（單元，`hoyowiki_index_test.dart`）**：`pruneLanguages` 清掉殘留語言、保留 keep 語言與 iconUrl／searchMap；無變動為 no-op（state identity 不變）；空 keepLangs 回 0 且不動 state；回傳值為清理物品數。
+- **設定頁（widget）**：「物品資料」按鈕無資料 disable、有資料可點。
+- **完成 dialog（widget，`update_progress_dialog_test.dart`）**：metadata 完成顯示「已更新 M…」；`hoYoWikiImagesDownloaded == 0` 時無補圖行、`> 0` 時有；`hoyoWikiStaleItemsPruned == 0` 時無清理行、`> 0` 時有；任何情況都不出現「新增」字樣。
 
 ## 驗收條件
 
 1. `fvm flutter analyze` 輸出 `No issues found!`。
 2. `fvm flutter test` 輸出 `All tests passed!`，含上述新增測試。
-3. 設定頁出現獨立「物品資料」區與「更新物品資料」按鈕，行為符合上述（輕量確認、進度 dialog、非破壞性）。
-4. 實機驗證：對已有 gallery 的物品，HoYoWiki 新增圖後執行更新 → 開啟該物品詳情可見新頁籤且圖會補下載；已下載的圖未被清除。
+3. 設定頁出現獨立「物品資料」區與「更新物品資料」按鈕（輕量確認、進度 dialog、非破壞性）。
+4. 實機：對已有 gallery 的物品，HoYoWiki 新增圖後執行更新 → 開啟詳情可見新頁籤且圖會補下載；已下載的圖未被清除；完成訊息顯示「已更新 M 個物品的資料」（不顯示「新增 N 筆紀錄」）。
+5. 資料語言轉換情境：轉成他語言再轉回後執行更新 → 舊語言殘留被清、完成訊息顯示「已清理 K 個物品的殘留語言資料」。

--- a/docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md
@@ -1,0 +1,136 @@
+# 手動更新物品詳細資料 — 設計文件
+
+- 日期：2026-06-18
+- 狀態：設計已確認，待寫實作計畫
+
+## 背景與問題
+
+物品詳細資料（HoYoWiki 的 gallery 清單、描述、tags）由 `GachaRepository._fetchHoYoWiki` 的三階段管線（search → entry → download）抓取，存進 `hoyowiki_index.json`。
+
+這條管線是**增量式**的：`needRefetchEntry`（`lib/state/gacha_repository.dart:1010`）判定「entry 已存在、menuId 有、該語言 page 也有」就回傳 `false`，不重抓。結果是——**若某物品在 HoYoWiki 後來新增了 gallery 圖（例如新增的立繪），正常更新永遠偵測不到**，因為該語言的 page 早已存在。
+
+設定頁現有的「強制重抓物品圖片」按鈕雖能拿到新資料，但它走 `forceRefetchAllHoYoWikiImages()` → 先 `resetAll()` **清空整個 index 與所有快取圖**，再全部重抓並 eager 下載所有 icon。這是破壞性的、耗時且浪費頻寬。
+
+使用者需要一個**非破壞性**的入口：只重抓 metadata，讓新增的 gallery 圖／頁籤被偵測到，但保留已下載的圖、不 eager 下載新圖；新圖一律維持 lazy，等使用者開啟該物品詳情時才補下載。
+
+## 目標
+
+1. 設定頁新增一顆「更新物品資料」按鈕，點擊後重抓所有物品的 HoYoWiki metadata（非破壞性）。
+2. 重抓涵蓋：對先前**沒解析到**的物品重試 search；對**所有已解析**的條目強制重抓 entry 階段（更新 gallery 清單／描述／tags）。
+3. 不重抓已下載的圖；icon 僅在本地缺檔時 eager 補下載；gallery 大圖一律維持 lazy。
+4. 物品詳情頁的頁籤隨 index 更新自動反映新 gallery 條目；開啟詳情時補下載缺漏的圖。
+
+## 非目標（YAGNI）
+
+- 不做「只更新逾期條目（依 `fetchedAt` 門檻）」的選擇性更新——使用者選擇「全部已解析條目都重抓」。
+- 不改 icon 快取的 key 策略（仍以 id 為 key）；不主動因 icon URL 字串變動而重下 icon。
+- 不在詳情頁新增任何 per-item 重抓入口（既有圖片選單的「重抓圖片」已涵蓋單張需求）。
+- 不保留「破壞性強制重抓」以外的相容路徑——既有按鈕原樣保留。
+
+## 關鍵發現：詳情頁無需改動
+
+`GachaItemDetailDialog.build()`（`lib/widgets/dialogs/gacha_item_detail_dialog.dart:449`）`watch(hoyowikiIndexProvider)`，且既有的 lazy backfill（同檔 519-541 行）對「不在 `_loadStates` 的 chip」逐一檢查：本地有檔 → `_GalleryReady`，缺檔 → `_GalleryLoading` 並排程背景下載。
+
+每次開啟 dialog 都是全新的 `State`、`_loadStates` 為空，因此**每次開啟都會重新檢查所有 gallery chip（含卡片大圖）並補下載缺的**。metadata 更新後，`mergeEntry`（`lib/state/hoyowiki_index.dart:117`）以 `lang: fetched.page` 覆蓋該語言 page → 新 gallery 條目進入 index → 下次（或開著時）重建即多出新 chip → 缺檔自動 lazy 補下載。
+
+icon 則由 `hasHoYoWikiContent`（同檔 30 行）把關：icon 檔不存在時物品不可點。故 icon 必須在更新時就補齊（見下方 icon 策略），與本設計一致；詳情頁本身不處理 icon lazy 下載。
+
+**結論：「頁籤跟著更新」與「開啟詳情時補下載缺圖」由既有機制完整涵蓋，本功能在詳情頁零改動，前提僅是 index 要先被更新。**
+
+## 設計
+
+### 1. 參數化 `_fetchHoYoWiki`（重用既有管線，不造新輪子）
+
+`lib/state/gacha_repository.dart`：
+
+```
+Future<int> _fetchHoYoWiki(http.Client client, {bool forceEntryRefetch = false})
+```
+
+- **search 階段**：不變。`searchTodo` 本來就只收 `lookupId == null` 者，且無負快取——「對先前沒解析到的重試 search」現況已免費滿足。
+- **entry 階段（唯一行為變更）**：
+  - `forceEntryRefetch == false`：維持現狀，由 `needRefetchEntry` 決定。
+  - `forceEntryRefetch == true`：`entryTodo` 納入**所有已解析的 (id, lang)**，略過 `needRefetchEntry` 的「已有就跳過」。search 階段內部那段「命中後 add 進 entryTodo」的 `needRefetchEntry` 守衛在 force 模式下也改為無條件 add。
+- **download 階段**：不變。`enqueueDownloadsForEntry`（同檔 1042 行）本來就只 enqueue icon、且只在 `iconFile.existsSync() == false` 時加入；gallery 完全不在此下載。→ 自動符合「缺 icon 才 eager 下載、gallery 維持 lazy」。
+- **early return**：`totalInitial == 0` 的早退在 force 模式下因 `entryTodo` 非空（有已解析條目時）不會誤觸；無任何記錄時仍正確回 0。
+- 取消／互斥／進度（`FetchingHoYoWiki` 三階段）全部沿用既有邏輯。
+
+### 2. 新增 `refreshAllHoYoWikiMetadata()`
+
+`lib/state/gacha_repository.dart`，比照 `forceRefetchAllHoYoWikiImages`（534-604 行）的骨架，**但拿掉 `resetAll()`**：
+
+1. 互斥檢查（`state.progress != null` / `_isUpdating` → no-op）。
+2. emit `Preparing`、建 cancellable client、設 `_activeCancellable`。
+3. 直接呼叫 `_fetchHoYoWiki(cancellable.client, forceEntryRefetch: true)`（不清 index、不清 cache）。
+4. 依取消狀態 emit `UpdateCompleted(hoYoWikiImagesDownloaded: ...)` 或 `clearProgress`。
+5. `finally` 收尾關 client、清旗標。
+
+新增專屬 logger（對齊既有樹，如 `Logger('gacha.hoyowiki.refreshMetadata')`），在開始（總條目數）、各階段結束、完成／取消處埋 `info`，單筆失敗沿用 `_fetchHoYoWiki` 內既有 `warning`。
+
+### 3. 設定頁：新增「物品資料」區
+
+`lib/pages/settings_page.dart`：
+
+- 在 `build` 的 section 清單（66-126 行）新增一張 `SectionCard`，建議插在「圖片快取」（110 行）之前，視覺上把「物品資料更新」與「圖片快取管理」相鄰分組。圖示建議 `Icons.dataset_outlined`（或 `Icons.inventory_2_outlined`）。
+- 新增 `_ItemDataSection`（`ConsumerWidget`），內含：
+  - 一行簡短說明文字（`l.settingsRefreshItemDataDesc`）：說明此操作會連線 HoYoWiki 重抓最新詳細資料、保留已下載的圖、新圖於開啟詳情時補下載。
+  - 一顆 `FilledButton.icon`（**非** danger 樣式，用一般 FilledButton 與破壞性按鈕區分），label `l.settingsRefreshItemDataTitle`，icon `Icons.refresh`（或 `Icons.sync`）。
+  - disable 條件比照 `_refetchAll`：`!hasData || progress != null`；`!hasData` 時用 `Tooltip` 顯示 `l.settingsRefreshItemDataEmpty`。
+- 點擊 → `_refreshItemData(ctx)`：以 `showConfirmDialog`（`isDanger: false`）跳輕量確認（title／body／confirm 用新 key），確認後 `unawaited(ref.read(gachaRepositoryProvider.notifier).refreshAllHoYoWikiMetadata())`。進度 dialog 由 `app_shell.dart` 既有 `ref.listen` 自動彈出，無需額外處理。
+
+### 4. i18n 字串
+
+依專案慣例：先寫 `app_zh.arb`，再以中文為基準翻已有實體翻譯的 ARB；**不碰空殼 ARB**（留給 Crowdin pipeline）；省略號一律半形。新增 key（命名對齊既有 `settingsRefetchHoyoWiki*` / `confirmRefetchHoyoWiki*` 範式）：
+
+| key | 用途 | 繁中草案 |
+|-----|------|---------|
+| `settingsItemData` | 區塊標題 | 物品資料 |
+| `settingsRefreshItemDataDesc` | 區塊說明 | 從 HoYoWiki 重新抓取所有物品的最新詳細資料（描述、圖片清單等），保留已下載的圖片；新增的圖片會在你開啟該物品詳情時才下載。 |
+| `settingsRefreshItemDataTitle` | 按鈕文字 | 更新物品資料 |
+| `settingsRefreshItemDataEmpty` | 無資料 tooltip | 尚無卡池記錄，無法更新物品資料 |
+| `confirmRefreshItemDataTitle` | 確認標題 | 更新物品資料？ |
+| `confirmRefreshItemDataBody` | 確認內文 | 將連線 HoYoWiki 重新抓取所有物品的詳細資料，依物品數量可能需要一段時間。已下載的圖片會保留，不會被清除。 |
+| `confirmRefreshItemDataConfirm` | 確認鈕 | 開始更新 |
+
+文案最終以實作時 `app_zh.arb` 為準。
+
+## 資料流
+
+```
+設定頁「更新物品資料」→ refreshAllHoYoWikiMetadata()
+  → _fetchHoYoWiki(forceEntryRefetch: true)
+      search（補未解析）→ entry（全部已解析條目重抓，含新 gallery 清單）→ download（只補缺 icon）
+  → mergeEntry 覆蓋該 lang page + bumpCacheRevision → index 更新
+  → UpdateCompleted（進度 dialog 自動顯示，結束後刷新快取用量）
+
+之後使用者開某物品詳情：
+  build() 讀最新 index → 新 gallery 條目變新 chip
+  → _loadStates 缺該檔 → 背景 lazy 下載新圖（既有邏輯，零改動）
+```
+
+## 錯誤處理
+
+- 單筆 search／entry／download 失敗：沿用 `_fetchHoYoWiki` 既有 per-item try/catch + `warning` log，不終止整段。
+- 整段例外：`refreshAllHoYoWikiMetadata` 不像破壞性流程有 `resetAll` 失敗路徑，故不需要 `UpdateErrorWipeHoYoWikiCache`；最壞情況是部分條目沒更新到，使用者可再次點擊。
+- 取消：使用者於進度 dialog 按取消 → `_cancelTriggered` → 各階段 `isAborted()` 早退 → emit `clearProgress`。已寫入 index 的部分保留（非破壞性，安全）。
+- 並發互斥：`progress != null` 或 `_isUpdating` 時按鈕已 disable，方法層再做 no-op 防呆。
+
+## 已知次要行為
+
+- icon 快取檔以 id（與副檔名）為 key、不含 URL hash。若某條目 icon URL 僅字串變動但副檔名不變 → 路徑相同 → `existsSync()` 為真 → **不重下**（沿用舊 icon）。此與使用者選擇的「缺 icon 才下、URL 變不重下」一致；屬可接受行為，不在本次處理。
+
+## 測試
+
+- **Repository（單元）**：擴充既有 HoYoWiki 抓取測試（參考 `debugRunHoYoWikiOnly` 與既有 fake fetcher 模式），新增案例：
+  - 給定一個「已解析、該 lang page 已存在」的 entry，`forceEntryRefetch: true` 時該 (id, lang) 仍進入 entry worklist 並被重抓；`false` 時不進入（守住既有增量行為）。
+  - fake fetcher 第二次回傳「多一張 gallery 圖」的 page → 斷言 `mergeEntry` 後 index 的該 lang gallery 清單變長，且 **download 階段未** eager 下載該 gallery 圖（只可能下 icon）。
+  - 本地已有 icon 檔時，force 重抓不重複下載 icon。
+- **設定頁（widget）**：新「物品資料」區按鈕在無資料時 disable、有資料時可點；點擊跳確認 dialog，確認後呼叫 `refreshAllHoYoWikiMetadata`（以 provider override / spy 驗證）。
+- 既有詳情頁 lazy backfill 測試若存在則無需改動；可補一個「index 新增 gallery 條目後，開啟 dialog 會對缺檔 chip 觸發下載」的迴歸測試（若既有測試未涵蓋）。
+
+## 驗收條件
+
+1. `fvm flutter analyze` 輸出 `No issues found!`。
+2. `fvm flutter test` 輸出 `All tests passed!`，含上述新增測試。
+3. 設定頁出現獨立「物品資料」區與「更新物品資料」按鈕，行為符合上述（輕量確認、進度 dialog、非破壞性）。
+4. 實機驗證：對已有 gallery 的物品，HoYoWiki 新增圖後執行更新 → 開啟該物品詳情可見新頁籤且圖會補下載；已下載的圖未被清除。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "Item Data",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "Re-fetch the latest item details (descriptions, image lists, etc.) from HoYoWiki, keeping already-downloaded images. New images are downloaded when you open the item's details.",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "Update Item Data",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "No gacha records yet — nothing to update",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "Update item data?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "This will contact HoYoWiki to re-fetch every item's details, which may take a while depending on how many items you have. Already-downloaded images are kept and will not be cleared.",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "Start update",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "Image cache",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "Updated data for {count} items",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "Backfilled {count} item images",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Partial failure: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "Cleaned up stale-language data for {count} items",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Partial failure: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "Se limpiaron datos de idioma obsoletos de {count} objetos",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Parcialmente fallido: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "Datos de {count} objetos actualizados",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "Descargadas {count} imágenes de objetos faltantes",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Parcialmente fallido: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "Datos de objetos",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "Volver a obtener los últimos detalles de todos los objetos desde HoYoWiki (descripciones, listas de imágenes, etc.), conservando las imágenes ya descargadas. Las nuevas imágenes se descargarán al abrir los detalles del objeto.",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "Actualizar datos de objetos",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "Sin registros de gacha aún — nada que actualizar",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "¿Actualizar datos de objetos?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "Esto contactará HoYoWiki para volver a obtener los detalles de todos los objetos, lo que puede tardar un tiempo según la cantidad. Las imágenes ya descargadas se conservarán y no se eliminarán.",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "Iniciar actualización",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "Caché de imágenes",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "Données de {count} objets mises à jour",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "{count} images d'objets manquantes téléchargées",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Échec partiel : {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "Données de langue obsolètes nettoyées pour {count} objets",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Échec partiel : {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "Données des objets",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "Re-télécharger les dernières informations de tous les objets depuis HoYoWiki (descriptions, listes d'images, etc.), en conservant les images déjà téléchargées. Les nouvelles images seront téléchargées à l'ouverture des détails de l'objet.",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "Mettre à jour les données des objets",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "Aucun historique de vœux — rien à mettre à jour",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "Mettre à jour les données des objets ?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "Ceci contactera HoYoWiki pour re-télécharger les détails de tous les objets, ce qui peut prendre un certain temps selon le nombre d'objets. Les images déjà téléchargées seront conservées et ne seront pas supprimées.",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "Lancer la mise à jour",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "Cache d'images",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "{count} 件のアイテムの不要な言語データを削除しました",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ 一部失敗：{names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "{count} 個のアイテムデータを更新しました",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "アイテム画像 {count} 件を補充ダウンロード",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ 一部失敗：{names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "アイテムデータ",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "HoYoWiki からすべての物品の最新詳細情報（説明、画像リストなど）を再取得します。ダウンロード済みの画像は保持されます。新しい画像は物品詳細を開いた際にダウンロードされます。",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "物品データを更新",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "ガチャ記録がないため、物品データを更新できません",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "物品データを更新しますか？",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "HoYoWiki に接続してすべての物品の詳細情報を再取得します。物品数によっては時間がかかる場合があります。ダウンロード済みの画像は保持され、削除されません。",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "更新を開始",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "画像キャッシュ",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "Dados de {count} itens atualizados",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "{count} imagens de itens ausentes baixadas",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Falha parcial: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "Dados de itens",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "Reobter os detalhes mais recentes de todos os itens do HoYoWiki (descrições, listas de imagens, etc.), mantendo as imagens já baixadas. Novas imagens serão baixadas ao abrir os detalhes do item.",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "Atualizar dados de itens",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "Sem registros de gacha ainda — nada para atualizar",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "Atualizar dados de itens?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "Isso irá conectar ao HoYoWiki para reobter os detalhes de todos os itens, o que pode demorar dependendo da quantidade. As imagens já baixadas serão mantidas e não serão apagadas.",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "Iniciar atualização",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "Cache de imagens",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "Dados de idioma obsoletos removidos de {count} itens",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Falha parcial: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "ข้อมูลไอเทม",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "ดึงข้อมูลรายละเอียดล่าสุดของไอเทมทั้งหมดจาก HoYoWiki ใหม่อีกครั้ง (คำอธิบาย รายการรูปภาพ ฯลฯ) โดยคงรูปภาพที่ดาวน์โหลดไว้แล้ว รูปภาพใหม่จะถูกดาวน์โหลดเมื่อเปิดรายละเอียดไอเทม",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "อัปเดตข้อมูลไอเทม",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "ยังไม่มีประวัติการอธิษฐาน ไม่สามารถอัปเดตข้อมูลไอเทมได้",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "อัปเดตข้อมูลไอเทม?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "จะเชื่อมต่อ HoYoWiki เพื่อดึงข้อมูลรายละเอียดของไอเทมทั้งหมดใหม่อีกครั้ง อาจใช้เวลาสักครู่ขึ้นอยู่กับจำนวนไอเทม รูปภาพที่ดาวน์โหลดไว้แล้วจะถูกเก็บไว้และไม่ถูกลบ",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "เริ่มอัปเดต",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "แคชรูปภาพ",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "อัปเดตข้อมูลไอเทมแล้ว {count} รายการ",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "ดาวน์โหลดภาพไอเทมที่ขาดหายไปแล้ว {count} รายการ",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ บางส่วนล้มเหลว: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "ล้างข้อมูลภาษาที่ล้าสมัยของ {count} ไอเทมแล้ว",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ บางส่วนล้มเหลว: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -499,6 +499,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "Dữ liệu vật phẩm",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "Tải lại thông tin chi tiết mới nhất của tất cả vật phẩm từ HoYoWiki (mô tả, danh sách ảnh, v.v.), giữ nguyên ảnh đã tải. Ảnh mới sẽ được tải khi bạn mở chi tiết vật phẩm.",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "Cập nhật dữ liệu vật phẩm",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "Chưa có lịch sử cầu nguyện, không thể cập nhật dữ liệu vật phẩm",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "Cập nhật dữ liệu vật phẩm?",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "Thao tác này sẽ kết nối HoYoWiki để tải lại thông tin chi tiết của tất cả vật phẩm, có thể mất một lúc tuỳ vào số lượng. Ảnh đã tải sẽ được giữ nguyên, không bị xoá.",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "Bắt đầu cập nhật",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "Bộ nhớ đệm hình ảnh",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -203,6 +203,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "Đã cập nhật dữ liệu {count} vật phẩm",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "Đã tải bổ sung {count} ảnh vật phẩm còn thiếu",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Một phần thất bại: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -221,6 +221,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "Đã dọn sạch dữ liệu ngôn ngữ lỗi thời của {count} vật phẩm",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ Một phần thất bại: {names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -168,6 +168,11 @@
     "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
     "placeholders": { "count": { "type": "int" } }
   },
+  "progressDoneItemDataPrunedSummary": "已清理 {count} 個物品的殘留語言資料",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": { "count": { "type": "int" } }
+  },
   "progressPartialFailed": "⚠ 部分失敗：{names}",
   "@progressPartialFailed": {
     "placeholders": { "names": { "type": "String" } }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -368,6 +368,35 @@
     "description": "Confirm button label in the refetch AlertDialog."
   },
 
+  "settingsItemData": "物品資料",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "從 HoYoWiki 重新抓取所有物品的最新詳細資料（描述、圖片清單等），保留已下載的圖片；新增的圖片會在你開啟該物品詳情時才下載。",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "更新物品資料",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "尚無卡池記錄，無法更新物品資料",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "更新物品資料？",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "將連線 HoYoWiki 重新抓取所有物品的詳細資料，依物品數量可能需要一段時間。已下載的圖片會保留，不會被清除。",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "開始更新",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
+
   "settingsImageCache": "圖片快取",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -158,6 +158,16 @@
       "count": { "type": "int" }
     }
   },
+  "progressDoneItemDataSummary": "已更新 {count} 個物品的資料",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "progressDoneItemDataImagesSummary": "補下載 {count} 張物品圖片",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": { "count": { "type": "int" } }
+  },
   "progressPartialFailed": "⚠ 部分失敗：{names}",
   "@progressPartialFailed": {
     "placeholders": { "names": { "type": "String" } }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -217,6 +217,15 @@
       }
     }
   },
+  "progressDoneItemDataPrunedSummary": "已清理 {count} 个物品的残留语言数据",
+  "@progressDoneItemDataPrunedSummary": {
+    "description": "Completion dialog reminder line for the 'update item data' flow, shown only when count > 0: how many items had stale-language metadata (from a previous data-language conversion) cleaned up this run.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ 部分失败：{names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -495,6 +495,34 @@
   "@confirmRefetchHoyoWikiConfirm": {
     "description": "Confirm button label in the refetch AlertDialog."
   },
+  "settingsItemData": "物品资料",
+  "@settingsItemData": {
+    "description": "Settings page section title for item data (HoYoWiki metadata) controls."
+  },
+  "settingsRefreshItemDataDesc": "从 HoYoWiki 重新抓取所有物品的最新详细资料（描述、图片列表等），保留已下载的图片；新增的图片会在你打开该物品详情时才下载。",
+  "@settingsRefreshItemDataDesc": {
+    "description": "Description under the 'refresh item data' button explaining the non-destructive metadata refresh."
+  },
+  "settingsRefreshItemDataTitle": "更新物品资料",
+  "@settingsRefreshItemDataTitle": {
+    "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
+  },
+  "settingsRefreshItemDataEmpty": "暂无祈愿记录，无法更新物品资料",
+  "@settingsRefreshItemDataEmpty": {
+    "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
+  },
+  "confirmRefreshItemDataTitle": "更新物品资料？",
+  "@confirmRefreshItemDataTitle": {
+    "description": "Title of the AlertDialog confirming the non-destructive item metadata refresh."
+  },
+  "confirmRefreshItemDataBody": "将连接 HoYoWiki 重新抓取所有物品的详细资料，依物品数量可能需要一段时间。已下载的图片会保留，不会被清除。",
+  "@confirmRefreshItemDataBody": {
+    "description": "Body of the AlertDialog confirming the item metadata refresh; clarifies it is non-destructive."
+  },
+  "confirmRefreshItemDataConfirm": "开始更新",
+  "@confirmRefreshItemDataConfirm": {
+    "description": "Confirm button label in the refresh-item-data AlertDialog."
+  },
   "settingsImageCache": "图片缓存",
   "@settingsImageCache": {
     "description": "Settings page section title for image cache controls."

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -507,7 +507,7 @@
   "@settingsRefreshItemDataTitle": {
     "description": "Settings → Item data → button: re-fetch latest HoYoWiki item metadata without clearing cached images."
   },
-  "settingsRefreshItemDataEmpty": "暂无祈愿记录，无法更新物品资料",
+  "settingsRefreshItemDataEmpty": "暂无卡池记录，无法更新物品资料",
   "@settingsRefreshItemDataEmpty": {
     "description": "Tooltip shown when the refresh-item-data button is disabled because there are no gacha records on the device."
   },

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -199,6 +199,24 @@
       }
     }
   },
+  "progressDoneItemDataSummary": "已更新 {count} 个物品的数据",
+  "@progressDoneItemDataSummary": {
+    "description": "Completion dialog main line for the manual 'update item data' (HoYoWiki metadata refresh) flow: how many distinct items had their metadata refreshed. Replaces the gacha-record summary for this flow.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "progressDoneItemDataImagesSummary": "补下载 {count} 张物品图片",
+  "@progressDoneItemDataImagesSummary": {
+    "description": "Completion dialog secondary line for the 'update item data' flow, shown only when count > 0: how many missing item images (icons) were backfilled during the metadata refresh.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "progressPartialFailed": "⚠ 部分失败：{names}",
   "@progressPartialFailed": {
     "placeholders": {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -108,6 +108,12 @@ class SettingsPage extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xl),
               SectionCard(
+                title: l.settingsItemData,
+                icon: Icons.dataset_outlined,
+                child: const _ItemDataSection(),
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              SectionCard(
                 title: l.settingsImageCache,
                 icon: Icons.image_outlined,
                 child: const _ImageCacheSection(),
@@ -697,6 +703,67 @@ class _DataManagement extends ConsumerWidget {
     );
     if (ok != true) return;
     await ref.read(gachaRepositoryProvider.notifier).clearAll();
+  }
+}
+
+/// 物品資料區塊：提供「更新物品資料」按鈕，非破壞性重抓 HoYoWiki metadata。
+class _ItemDataSection extends ConsumerWidget {
+  /// 建立 [_ItemDataSection]。
+  const _ItemDataSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final hasData = ref.watch(
+      gachaRepositoryProvider.select((s) => s.byUid.isNotEmpty),
+    );
+    final progress = ref.watch(
+      gachaRepositoryProvider.select((s) => s.progress),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l.settingsRefreshItemDataDesc,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: tokens.textSecondary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.m),
+        Tooltip(
+          message: !hasData ? l.settingsRefreshItemDataEmpty : '',
+          child: FilledButton.icon(
+            onPressed: (!hasData || progress != null)
+                ? null
+                : () => _refreshItemData(context, ref),
+            icon: const Icon(Icons.sync, size: 18),
+            label: Text(l.settingsRefreshItemDataTitle),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 顯示輕量確認 dialog，確認後呼叫 [GachaRepository.refreshAllHoYoWikiMetadata]。
+  Future<void> _refreshItemData(BuildContext ctx, WidgetRef ref) async {
+    final l = AppLocalizations.of(ctx)!;
+    final ok = await showConfirmDialog(
+      context: ctx,
+      title: l.confirmRefreshItemDataTitle,
+      body: l.confirmRefreshItemDataBody,
+      cancelLabel: l.actionCancel,
+      confirmLabel: l.confirmRefreshItemDataConfirm,
+      isDanger: false,
+    );
+    if (ok != true) return;
+    // 後端流程獨立於 dialog lifecycle；UpdateProgressDialog 由 app_shell.dart
+    // 既有 ref.listen 自動彈出。
+    unawaited(
+      ref.read(gachaRepositoryProvider.notifier).refreshAllHoYoWikiMetadata(),
+    );
   }
 }
 

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -116,6 +116,9 @@ class GachaRepository extends Notifier<GachaState> {
   /// Logger 實例（匯入流程，獨立子樹以利日誌過濾）。
   static final _importLog = Logger('gacha.import');
 
+  /// Logger 實例（非破壞性 metadata 更新流程）。
+  static final _refreshMetaLog = Logger('gacha.hoyowiki.refreshMetadata');
+
   /// build() 內 `_bootstrapLoad()` 完成的 future，供測試 await。
   Completer<void>? _bootstrapCompleter;
 
@@ -593,6 +596,64 @@ class GachaRepository extends Notifier<GachaState> {
           failedBanners: const [],
           updatedAt: DateTime.now().toUtc(),
           hoYoWikiImagesDownloaded: hoYoWikiImagesDownloaded,
+        ),
+      );
+    } finally {
+      _activeCancellable?.client.close();
+      _activeCancellable = null;
+      _cancelTriggered = false;
+      _isUpdating = false;
+    }
+  }
+
+  /// 非破壞性更新所有物品的 HoYoWiki metadata（強制重抓已解析條目的 entry 階段）。
+  ///
+  /// 與 [forceRefetchAllHoYoWikiImages] 不同：**不** `resetAll()`，保留既有 index
+  /// 與快取圖。重抓後 [HoYoWikiIndexNotifier.mergeEntry] 覆蓋各 lang page，新增的
+  /// gallery 圖只更新 index、不在此下載（維持 lazy，由詳情頁開啟時補）；icon 僅在
+  /// 本地缺檔時才下載。
+  ///
+  /// 流程：互斥檢查 → emit `Preparing` → `_fetchHoYoWiki(forceEntryRefetch: true)`
+  /// → 依取消狀態 emit `UpdateCompleted` 或 `clearProgress`。
+  Future<void> refreshAllHoYoWikiMetadata() async {
+    if (state.progress != null) {
+      _refreshMetaLog.info('skip: another progress in-flight');
+      return;
+    }
+    if (_isUpdating) return;
+    _isUpdating = true;
+    _cancelTriggered = false;
+    _refreshMetaLog.info('start, totalUids=${state.byUid.length}');
+
+    final cancellable = ref.read(cancellableHttpClientFactoryProvider)();
+    _activeCancellable = cancellable;
+    state = state.copyWith(progress: const Preparing());
+
+    try {
+      var images = 0;
+      try {
+        images = await _fetchHoYoWiki(
+          cancellable.client,
+          forceEntryRefetch: true,
+        );
+      } catch (e, st) {
+        _refreshMetaLog.warning('hoyowiki stage threw (ignored)', e, st);
+      }
+      if (!ref.mounted) return;
+
+      if (_cancelTriggered) {
+        _refreshMetaLog.warning('cancelled');
+        state = state.copyWith(clearProgress: true);
+        return;
+      }
+
+      _refreshMetaLog.info('done, images=$images');
+      state = state.copyWith(
+        progress: UpdateCompleted(
+          totalNewRecords: 0,
+          failedBanners: const [],
+          updatedAt: DateTime.now().toUtc(),
+          hoYoWikiImagesDownloaded: images,
         ),
       );
     } finally {
@@ -1207,6 +1268,10 @@ class GachaRepository extends Notifier<GachaState> {
   }
 
   /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）。
+  ///
+  /// WHY clearProgress：_fetchHoYoWiki 跑完後 state.progress 停留在最後一個
+  /// FetchingHoYoWiki phase，若不清除，後續呼叫帶互斥檢查的 public method
+  ///（例如 [refreshAllHoYoWikiMetadata]）會因 progress != null 而直接跳過。
   @visibleForTesting
   Future<void> debugRunHoYoWikiOnly({bool forceEntryRefetch = false}) async {
     _cancelTriggered = false;
@@ -1218,6 +1283,7 @@ class GachaRepository extends Notifier<GachaState> {
       );
     } finally {
       cancellable.client.close();
+      if (ref.mounted) state = state.copyWith(clearProgress: true);
     }
   }
 

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -975,8 +975,14 @@ class GachaRepository extends Notifier<GachaState> {
   /// 每筆獨立 try/catch：單筆失敗不終止整段。每筆完成更新 progress。整段失敗
   /// 不影響 `UpdateCompleted`。取消（`_cancelTriggered` 或 `!ref.mounted`）早退。
   ///
+  /// `forceEntryRefetch` 為 true 時，entry 階段強制納入所有已解析的 (id, lang)，
+  /// 用於設定頁手動更新物品資料。
+  ///
   /// 回傳本次成功寫入磁碟的圖片張數（icon + header 各算一張）。
-  Future<int> _fetchHoYoWiki(http.Client client) async {
+  Future<int> _fetchHoYoWiki(
+    http.Client client, {
+    bool forceEntryRefetch = false,
+  }) async {
     var downloaded = 0;
     final fetcher = ref.read(hoyowikiFetcherProvider);
     final indexNotifier = ref.read(hoyowikiIndexProvider.notifier);
@@ -1025,11 +1031,12 @@ class GachaRepository extends Notifier<GachaState> {
       for (final name in namesByLang[lang] ?? const <String>{}) {
         final id = index.lookupId(name: name, lang: lang);
         if (id == null) continue;
-        if (needRefetchEntry(
-          index.lookupEntry(id),
-          index.lookupMenuId(id),
-          lang,
-        )) {
+        if (forceEntryRefetch ||
+            needRefetchEntry(
+              index.lookupEntry(id),
+              index.lookupMenuId(id),
+              lang,
+            )) {
           entryTodo.add((id: id, lang: lang));
         }
       }
@@ -1201,11 +1208,14 @@ class GachaRepository extends Notifier<GachaState> {
 
   /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）。
   @visibleForTesting
-  Future<void> debugRunHoYoWikiOnly() async {
+  Future<void> debugRunHoYoWikiOnly({bool forceEntryRefetch = false}) async {
     _cancelTriggered = false;
     final cancellable = ref.read(cancellableHttpClientFactoryProvider)();
     try {
-      await _fetchHoYoWiki(cancellable.client);
+      await _fetchHoYoWiki(
+        cancellable.client,
+        forceEntryRefetch: forceEntryRefetch,
+      );
     } finally {
       cancellable.client.close();
     }

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -1158,6 +1158,8 @@ class GachaRepository extends Notifier<GachaState> {
                 id: hit.id,
                 menuId: hit.menuId,
               );
+              // 此處不需判 forceEntryRefetch：剛 search 命中的 id 其 entry 尚為 null，
+              // needRefetchEntry(null, ...) 必為 true，force 與非 force 行為一致。
               if (!entryTodo.contains((id: hit.id, lang: pair.$2)) &&
                   needRefetchEntry(
                     ref.read(hoyowikiIndexProvider).lookupEntry(hit.id),
@@ -1267,7 +1269,7 @@ class GachaRepository extends Notifier<GachaState> {
     return downloaded;
   }
 
-  /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）。
+  /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）；`forceEntryRefetch` 透傳給 [_fetchHoYoWiki]。
   ///
   /// WHY clearProgress：_fetchHoYoWiki 跑完後 state.progress 停留在最後一個
   /// FetchingHoYoWiki phase，若不清除，後續呼叫帶互斥檢查的 public method

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -451,7 +451,8 @@ class GachaRepository extends Notifier<GachaState> {
     // HoYoWiki 補圖階段（best-effort，不影響 UpdateCompleted）
     var hoYoWikiImagesDownloaded = 0;
     try {
-      hoYoWikiImagesDownloaded = await _fetchHoYoWiki(client);
+      final result = await _fetchHoYoWiki(client);
+      hoYoWikiImagesDownloaded = result.imagesDownloaded;
     } catch (e, st) {
       _log.warning('hoyowiki stage threw (ignored)', e, st);
     }
@@ -577,7 +578,8 @@ class GachaRepository extends Notifier<GachaState> {
 
       var hoYoWikiImagesDownloaded = 0;
       try {
-        hoYoWikiImagesDownloaded = await _fetchHoYoWiki(cancellable.client);
+        final result = await _fetchHoYoWiki(cancellable.client);
+        hoYoWikiImagesDownloaded = result.imagesDownloaded;
       } catch (e, st) {
         _refetchLog.warning('hoyowiki stage threw (ignored)', e, st);
       }
@@ -630,9 +632,9 @@ class GachaRepository extends Notifier<GachaState> {
     state = state.copyWith(progress: const Preparing());
 
     try {
-      var images = 0;
+      var result = (imagesDownloaded: 0, itemsRefreshed: 0);
       try {
-        images = await _fetchHoYoWiki(
+        result = await _fetchHoYoWiki(
           cancellable.client,
           forceEntryRefetch: true,
         );
@@ -647,13 +649,16 @@ class GachaRepository extends Notifier<GachaState> {
         return;
       }
 
-      _refreshMetaLog.info('done, images=$images');
+      _refreshMetaLog.info(
+        'done, images=${result.imagesDownloaded} items=${result.itemsRefreshed}',
+      );
       state = state.copyWith(
         progress: UpdateCompleted(
           totalNewRecords: 0,
           failedBanners: const [],
           updatedAt: DateTime.now().toUtc(),
-          hoYoWikiImagesDownloaded: images,
+          hoYoWikiImagesDownloaded: result.imagesDownloaded,
+          hoyoWikiEntriesRefreshed: result.itemsRefreshed,
         ),
       );
     } finally {
@@ -699,7 +704,8 @@ class GachaRepository extends Notifier<GachaState> {
 
       var images = 0;
       try {
-        images = await _fetchHoYoWiki(cancellable.client);
+        final fetchResult = await _fetchHoYoWiki(cancellable.client);
+        images = fetchResult.imagesDownloaded;
       } catch (e, st) {
         _importLog.warning('hoyowiki stage threw (ignored)', e, st);
       }
@@ -1039,12 +1045,14 @@ class GachaRepository extends Notifier<GachaState> {
   /// `forceEntryRefetch` 為 true 時，entry 階段強制納入所有已解析的 (id, lang)，
   /// 用於設定頁手動更新物品資料。
   ///
-  /// 回傳本次成功寫入磁碟的圖片張數（icon + header 各算一張）。
-  Future<int> _fetchHoYoWiki(
+  /// 回傳本次成功寫入磁碟的圖片張數（`imagesDownloaded`）及成功刷新 metadata
+  /// 的相異物品數（`itemsRefreshed`）。
+  Future<({int imagesDownloaded, int itemsRefreshed})> _fetchHoYoWiki(
     http.Client client, {
     bool forceEntryRefetch = false,
   }) async {
     var downloaded = 0;
+    final refreshedIds = <String>{};
     final fetcher = ref.read(hoyowikiFetcherProvider);
     final indexNotifier = ref.read(hoyowikiIndexProvider.notifier);
     final cacheDir = ref.read(hoyowikiCacheDirProvider);
@@ -1133,7 +1141,12 @@ class GachaRepository extends Notifier<GachaState> {
     // 三段加起來都沒工作就直接結束。
     final totalInitial =
         searchTodo.length + entryTodo.length + downloadTodo.length;
-    if (totalInitial == 0) return downloaded;
+    if (totalInitial == 0) {
+      return (
+        imagesDownloaded: downloaded,
+        itemsRefreshed: refreshedIds.length,
+      );
+    }
 
     bool isAborted() => !ref.mounted || _cancelTriggered;
 
@@ -1183,7 +1196,12 @@ class GachaRepository extends Notifier<GachaState> {
           );
         },
       );
-      if (isAborted()) return downloaded;
+      if (isAborted()) {
+        return (
+          imagesDownloaded: downloaded,
+          itemsRefreshed: refreshedIds.length,
+        );
+      }
     }
 
     // (2) entry 階段
@@ -1206,6 +1224,7 @@ class GachaRepository extends Notifier<GachaState> {
               lang: pair.lang,
               fetched: fetched,
             );
+            refreshedIds.add(pair.id);
             // enqueueDownloadsForEntry 會處理 icon + 各 lang 的 gallery 圖（URL 去重）。
             final entry = ref.read(hoyowikiIndexProvider).lookupEntry(pair.id);
             if (entry != null) enqueueDownloadsForEntry(pair.id, entry);
@@ -1225,7 +1244,12 @@ class GachaRepository extends Notifier<GachaState> {
           );
         },
       );
-      if (isAborted()) return downloaded;
+      if (isAborted()) {
+        return (
+          imagesDownloaded: downloaded,
+          itemsRefreshed: refreshedIds.length,
+        );
+      }
     }
 
     // (3) download 階段
@@ -1264,9 +1288,14 @@ class GachaRepository extends Notifier<GachaState> {
           );
         },
       );
-      if (isAborted()) return downloaded;
+      if (isAborted()) {
+        return (
+          imagesDownloaded: downloaded,
+          itemsRefreshed: refreshedIds.length,
+        );
+      }
     }
-    return downloaded;
+    return (imagesDownloaded: downloaded, itemsRefreshed: refreshedIds.length);
   }
 
   /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）；`forceEntryRefetch` 透傳給 [_fetchHoYoWiki]。

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -637,6 +637,7 @@ class GachaRepository extends Notifier<GachaState> {
         result = await _fetchHoYoWiki(
           cancellable.client,
           forceEntryRefetch: true,
+          pruneStaleLangs: true,
         );
       } catch (e, st) {
         _refreshMetaLog.warning('hoyowiki stage threw (ignored)', e, st);
@@ -1050,6 +1051,7 @@ class GachaRepository extends Notifier<GachaState> {
   Future<({int imagesDownloaded, int itemsRefreshed})> _fetchHoYoWiki(
     http.Client client, {
     bool forceEntryRefetch = false,
+    bool pruneStaleLangs = false,
   }) async {
     var downloaded = 0;
     final refreshedIds = <String>{};
@@ -1091,6 +1093,17 @@ class GachaRepository extends Notifier<GachaState> {
 
     // entryTodo 初始：走過所有 record lang+name，蒐集需要重抓的 (id, lang) pair
     final allLangs = uniquePairs.map((p) => p.$2).toSet();
+
+    // 針對性清理：移除已不再被任何記錄使用的語言殘留頁面（非破壞性，僅 index 內 pageByLang）。
+    // allLangs 為空（無記錄）時略過，避免誤清全部。
+    if (pruneStaleLangs && allLangs.isNotEmpty) {
+      await indexNotifier.pruneLanguages(allLangs);
+      if (!ref.mounted || _cancelTriggered) {
+        return (imagesDownloaded: 0, itemsRefreshed: 0);
+      }
+      index = ref.read(hoyowikiIndexProvider); // 重讀 prune 後的 index 快照
+    }
+
     final namesByLang = <String, Set<String>>{};
     for (final pair in uniquePairs) {
       namesByLang.putIfAbsent(pair.$2, () => {}).add(pair.$1);

--- a/lib/state/gacha_repository.dart
+++ b/lib/state/gacha_repository.dart
@@ -632,7 +632,11 @@ class GachaRepository extends Notifier<GachaState> {
     state = state.copyWith(progress: const Preparing());
 
     try {
-      var result = (imagesDownloaded: 0, itemsRefreshed: 0);
+      var result = (
+        imagesDownloaded: 0,
+        itemsRefreshed: 0,
+        staleLangItemsPruned: 0,
+      );
       try {
         result = await _fetchHoYoWiki(
           cancellable.client,
@@ -651,7 +655,8 @@ class GachaRepository extends Notifier<GachaState> {
       }
 
       _refreshMetaLog.info(
-        'done, images=${result.imagesDownloaded} items=${result.itemsRefreshed}',
+        'done, images=${result.imagesDownloaded} items=${result.itemsRefreshed} '
+        'stalePruned=${result.staleLangItemsPruned}',
       );
       state = state.copyWith(
         progress: UpdateCompleted(
@@ -660,6 +665,7 @@ class GachaRepository extends Notifier<GachaState> {
           updatedAt: DateTime.now().toUtc(),
           hoYoWikiImagesDownloaded: result.imagesDownloaded,
           hoyoWikiEntriesRefreshed: result.itemsRefreshed,
+          hoyoWikiStaleItemsPruned: result.staleLangItemsPruned,
         ),
       );
     } finally {
@@ -1046,15 +1052,18 @@ class GachaRepository extends Notifier<GachaState> {
   /// `forceEntryRefetch` 為 true 時，entry 階段強制納入所有已解析的 (id, lang)，
   /// 用於設定頁手動更新物品資料。
   ///
-  /// 回傳本次成功寫入磁碟的圖片張數（`imagesDownloaded`）及成功刷新 metadata
-  /// 的相異物品數（`itemsRefreshed`）。
-  Future<({int imagesDownloaded, int itemsRefreshed})> _fetchHoYoWiki(
+  /// 回傳本次成功寫入磁碟的圖片張數（`imagesDownloaded`）、成功刷新 metadata
+  /// 的相異物品數（`itemsRefreshed`），以及 `pageByLang` 被縮減的相異物品數
+  /// （`staleLangItemsPruned`）。
+  Future<({int imagesDownloaded, int itemsRefreshed, int staleLangItemsPruned})>
+  _fetchHoYoWiki(
     http.Client client, {
     bool forceEntryRefetch = false,
     bool pruneStaleLangs = false,
   }) async {
     var downloaded = 0;
     final refreshedIds = <String>{};
+    var staleLangItemsPruned = 0;
     final fetcher = ref.read(hoyowikiFetcherProvider);
     final indexNotifier = ref.read(hoyowikiIndexProvider.notifier);
     final cacheDir = ref.read(hoyowikiCacheDirProvider);
@@ -1097,9 +1106,13 @@ class GachaRepository extends Notifier<GachaState> {
     // 針對性清理：移除已不再被任何記錄使用的語言殘留頁面（非破壞性，僅 index 內 pageByLang）。
     // allLangs 為空（無記錄）時略過，避免誤清全部。
     if (pruneStaleLangs && allLangs.isNotEmpty) {
-      await indexNotifier.pruneLanguages(allLangs);
+      staleLangItemsPruned = await indexNotifier.pruneLanguages(allLangs);
       if (!ref.mounted || _cancelTriggered) {
-        return (imagesDownloaded: 0, itemsRefreshed: 0);
+        return (
+          imagesDownloaded: 0,
+          itemsRefreshed: 0,
+          staleLangItemsPruned: staleLangItemsPruned,
+        );
       }
       index = ref.read(hoyowikiIndexProvider); // 重讀 prune 後的 index 快照
     }
@@ -1158,6 +1171,7 @@ class GachaRepository extends Notifier<GachaState> {
       return (
         imagesDownloaded: downloaded,
         itemsRefreshed: refreshedIds.length,
+        staleLangItemsPruned: staleLangItemsPruned,
       );
     }
 
@@ -1213,6 +1227,7 @@ class GachaRepository extends Notifier<GachaState> {
         return (
           imagesDownloaded: downloaded,
           itemsRefreshed: refreshedIds.length,
+          staleLangItemsPruned: staleLangItemsPruned,
         );
       }
     }
@@ -1261,6 +1276,7 @@ class GachaRepository extends Notifier<GachaState> {
         return (
           imagesDownloaded: downloaded,
           itemsRefreshed: refreshedIds.length,
+          staleLangItemsPruned: staleLangItemsPruned,
         );
       }
     }
@@ -1305,10 +1321,15 @@ class GachaRepository extends Notifier<GachaState> {
         return (
           imagesDownloaded: downloaded,
           itemsRefreshed: refreshedIds.length,
+          staleLangItemsPruned: staleLangItemsPruned,
         );
       }
     }
-    return (imagesDownloaded: downloaded, itemsRefreshed: refreshedIds.length);
+    return (
+      imagesDownloaded: downloaded,
+      itemsRefreshed: refreshedIds.length,
+      staleLangItemsPruned: staleLangItemsPruned,
+    );
   }
 
   /// 測試用：略過 banner fetch 直接跑 hoyowiki 階段（用既有 state.byUid）；`forceEntryRefetch` 透傳給 [_fetchHoYoWiki]。

--- a/lib/state/hoyowiki_index.dart
+++ b/lib/state/hoyowiki_index.dart
@@ -116,6 +116,7 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
   /// 記錄使用的語言殘留資料。只動 `pageByLang`；icon／searchMap／menuIds 皆不變。
   /// 有實際變動才 persist／emit；無變動為 no-op（避免無謂寫檔與 UI 重建）。
   Future<void> pruneLanguages(Set<String> keepLangs) async {
+    if (keepLangs.isEmpty) return; // 防呆：空 keepLangs 會清掉全部頁面，直接 no-op
     await _lock.synchronized(() async {
       var changed = false;
       final newEntries = <String, HoYoWikiEntry>{};

--- a/lib/state/hoyowiki_index.dart
+++ b/lib/state/hoyowiki_index.dart
@@ -115,10 +115,12 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
   /// 移除所有 entry 中 lang ∉ [keepLangs] 的 `pageByLang` 條目，清理已不再被任何
   /// 記錄使用的語言殘留資料。只動 `pageByLang`；icon／searchMap／menuIds 皆不變。
   /// 有實際變動才 persist／emit；無變動為 no-op（避免無謂寫檔與 UI 重建）。
-  Future<void> pruneLanguages(Set<String> keepLangs) async {
-    if (keepLangs.isEmpty) return; // 防呆：空 keepLangs 會清掉全部頁面，直接 no-op
-    await _lock.synchronized(() async {
-      var changed = false;
+  /// 回傳 `pageByLang` 被縮減（至少移除一個 lang）的相異物品數；無變動或 empty
+  /// guard 觸發時回傳 `0`。
+  Future<int> pruneLanguages(Set<String> keepLangs) async {
+    if (keepLangs.isEmpty) return 0; // 防呆：空 keepLangs 會清掉全部頁面，直接 no-op
+    return _lock.synchronized(() async {
+      var prunedCount = 0;
       final newEntries = <String, HoYoWikiEntry>{};
       for (final e in state.entries.entries) {
         final entry = e.value;
@@ -127,7 +129,7 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
             if (keepLangs.contains(p.key)) p.key: p.value,
         };
         if (keptPages.length != entry.pageByLang.length) {
-          changed = true;
+          prunedCount++;
           newEntries[e.key] = HoYoWikiEntry(
             iconUrl: entry.iconUrl,
             pageByLang: keptPages,
@@ -137,7 +139,7 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
           newEntries[e.key] = entry;
         }
       }
-      if (!changed) return;
+      if (prunedCount == 0) return 0;
       final next = HoYoWikiIndex(
         searchMap: state.searchMap,
         entries: newEntries,
@@ -145,8 +147,9 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
       );
       await _saveAndEmit(next);
       _log.info(
-        'pruneLanguages: keep=${keepLangs.length} langs, pruned stale pages',
+        'pruneLanguages: keep=${keepLangs.length} langs, pruned=$prunedCount items',
       );
+      return prunedCount;
     });
   }
 

--- a/lib/state/hoyowiki_index.dart
+++ b/lib/state/hoyowiki_index.dart
@@ -112,6 +112,43 @@ class HoYoWikiIndexNotifier extends Notifier<HoYoWikiIndex> {
     });
   }
 
+  /// 移除所有 entry 中 lang ∉ [keepLangs] 的 `pageByLang` 條目，清理已不再被任何
+  /// 記錄使用的語言殘留資料。只動 `pageByLang`；icon／searchMap／menuIds 皆不變。
+  /// 有實際變動才 persist／emit；無變動為 no-op（避免無謂寫檔與 UI 重建）。
+  Future<void> pruneLanguages(Set<String> keepLangs) async {
+    await _lock.synchronized(() async {
+      var changed = false;
+      final newEntries = <String, HoYoWikiEntry>{};
+      for (final e in state.entries.entries) {
+        final entry = e.value;
+        final keptPages = <String, HoYoWikiPageData>{
+          for (final p in entry.pageByLang.entries)
+            if (keepLangs.contains(p.key)) p.key: p.value,
+        };
+        if (keptPages.length != entry.pageByLang.length) {
+          changed = true;
+          newEntries[e.key] = HoYoWikiEntry(
+            iconUrl: entry.iconUrl,
+            pageByLang: keptPages,
+            fetchedAt: entry.fetchedAt,
+          );
+        } else {
+          newEntries[e.key] = entry;
+        }
+      }
+      if (!changed) return;
+      final next = HoYoWikiIndex(
+        searchMap: state.searchMap,
+        entries: newEntries,
+        menuIds: state.menuIds,
+      );
+      await _saveAndEmit(next);
+      _log.info(
+        'pruneLanguages: keep=${keepLangs.length} langs, pruned stale pages',
+      );
+    });
+  }
+
   /// 把單一 lang 的 fetch 結果 merge 進既有 entry（不覆蓋其他 lang）。icon
   /// 採「非空覆寫」策略，避免某 lang 抓回空 icon 把既有好值清掉。
   Future<void> mergeEntry({

--- a/lib/state/update_progress.dart
+++ b/lib/state/update_progress.dart
@@ -83,6 +83,7 @@ class UpdateCompleted extends UpdateProgress {
     required this.updatedAt,
     required this.hoYoWikiImagesDownloaded,
     this.importSummary,
+    this.hoyoWikiEntriesRefreshed,
   });
 
   /// 本次更新新增的總紀錄數（update 流程用；import 流程為 0）。
@@ -100,6 +101,10 @@ class UpdateCompleted extends UpdateProgress {
 
   /// 匯入流程的結果摘要；非 import 入口為 null。
   final ImportResult? importSummary;
+
+  /// 非 null 表示這是「更新物品資料」流程的完成；值為本次成功刷新 metadata 的
+  /// 相異物品數。UI 據此改顯示物品資料摘要（已更新 M 個物品）而非紀錄摘要。
+  final int? hoyoWikiEntriesRefreshed;
 }
 
 /// 更新失敗。

--- a/lib/state/update_progress.dart
+++ b/lib/state/update_progress.dart
@@ -84,6 +84,7 @@ class UpdateCompleted extends UpdateProgress {
     required this.hoYoWikiImagesDownloaded,
     this.importSummary,
     this.hoyoWikiEntriesRefreshed,
+    this.hoyoWikiStaleItemsPruned = 0,
   });
 
   /// 本次更新新增的總紀錄數（update 流程用；import 流程為 0）。
@@ -105,6 +106,10 @@ class UpdateCompleted extends UpdateProgress {
   /// 非 null 表示這是「更新物品資料」流程的完成；值為本次成功刷新 metadata 的
   /// 相異物品數。UI 據此改顯示物品資料摘要（已更新 M 個物品）而非紀錄摘要。
   final int? hoyoWikiEntriesRefreshed;
+
+  /// 「更新物品資料」流程中本次被清理掉殘留語言的相異物品數（pageByLang 有縮減者）。
+  /// 0 表示無殘留可清；UI 僅在 > 0 時顯示清理提醒行。其他流程恆為 0。
+  final int hoyoWikiStaleItemsPruned;
 }
 
 /// 更新失敗。

--- a/lib/widgets/update_progress_dialog.dart
+++ b/lib/widgets/update_progress_dialog.dart
@@ -240,6 +240,7 @@ class _Body extends StatelessWidget {
         :final hoYoWikiImagesDownloaded,
         :final importSummary,
         :final hoyoWikiEntriesRefreshed,
+        :final hoyoWikiStaleItemsPruned,
       ) =>
         Column(
           mainAxisSize: MainAxisSize.min,
@@ -261,6 +262,12 @@ class _Body extends StatelessWidget {
                 const SizedBox(height: AppSpacing.xs),
                 Text(
                   l.progressDoneItemDataImagesSummary(hoYoWikiImagesDownloaded),
+                ),
+              ],
+              if (hoyoWikiStaleItemsPruned > 0) ...[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  l.progressDoneItemDataPrunedSummary(hoyoWikiStaleItemsPruned),
                 ),
               ],
             ] else ...[

--- a/lib/widgets/update_progress_dialog.dart
+++ b/lib/widgets/update_progress_dialog.dart
@@ -239,23 +239,35 @@ class _Body extends StatelessWidget {
         :final failedBanners,
         :final hoYoWikiImagesDownloaded,
         :final importSummary,
+        :final hoyoWikiEntriesRefreshed,
       ) =>
         Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (importSummary != null)
+            if (importSummary != null) ...[
               Text(
                 l.progressDoneImportSummary(
                   importSummary.successAccounts,
                   importSummary.addedRecords,
                   importSummary.duplicateRecords,
                 ),
-              )
-            else
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(l.progressDoneImagesSummary(hoYoWikiImagesDownloaded)),
+            ] else if (hoyoWikiEntriesRefreshed != null) ...[
+              Text(l.progressDoneItemDataSummary(hoyoWikiEntriesRefreshed)),
+              if (hoYoWikiImagesDownloaded > 0) ...[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  l.progressDoneItemDataImagesSummary(hoYoWikiImagesDownloaded),
+                ),
+              ],
+            ] else ...[
               Text(l.progressDoneSummary(totalNewRecords)),
-            const SizedBox(height: AppSpacing.xs),
-            Text(l.progressDoneImagesSummary(hoYoWikiImagesDownloaded)),
+              const SizedBox(height: AppSpacing.xs),
+              Text(l.progressDoneImagesSummary(hoYoWikiImagesDownloaded)),
+            ],
             if (failedBanners.isNotEmpty) ...[
               const SizedBox(height: AppSpacing.s),
               Text(

--- a/test/pages/settings_item_data_section_test.dart
+++ b/test/pages/settings_item_data_section_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('物品資料區字串已生成且可取用', (tester) async {
+    late AppLocalizations l;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Builder(
+            builder: (context) {
+              l = AppLocalizations.of(context)!;
+              return const SizedBox();
+            },
+          ),
+        ),
+      ),
+    );
+    expect(l.settingsItemData, '物品資料');
+    expect(l.settingsRefreshItemDataTitle, '更新物品資料');
+    expect(l.confirmRefreshItemDataConfirm, '開始更新');
+  });
+}

--- a/test/state/gacha_repository_hoyowiki_test.dart
+++ b/test/state/gacha_repository_hoyowiki_test.dart
@@ -1443,5 +1443,10 @@ void main() {
       isTrue,
       reason: 'en-us page 應仍保留',
     );
+
+    // UpdateCompleted 應帶 hoyoWikiStaleItemsPruned = 1（id '111' 被清理了 zh-tw）
+    final done =
+        container.read(gachaRepositoryProvider).progress as UpdateCompleted;
+    expect(done.hoyoWikiStaleItemsPruned, 1, reason: '1 個物品（id 111）有殘留語言被清理');
   });
 }

--- a/test/state/gacha_repository_hoyowiki_test.dart
+++ b/test/state/gacha_repository_hoyowiki_test.dart
@@ -1070,4 +1070,114 @@ void main() {
     // 50 筆中只應 dispatch 少數幾筆（不可能 50 全跑）
     expect(dispatched.length, lessThan(10));
   });
+
+  test('forceEntryRefetch=true：已解析的 entry 仍重抓並更新 gallery', () async {
+    var entryCallCount = 0;
+    var galleryListLen = 1;
+    final apiClient = MockClient((req) async {
+      if (req.url.path.endsWith('/search')) {
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'list': [
+                {
+                  'name': 'Hu Tao',
+                  'entry_page_id': '111',
+                  'menu': {
+                    'sub_menus': [
+                      {'id': 2},
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+          200,
+        );
+      }
+      if (req.url.path.endsWith('/entry_page')) {
+        entryCallCount++;
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'page': {
+                'icon_url': 'https://x/icon.png',
+                'modules': [
+                  {
+                    'components': [
+                      {
+                        'component_id': 'gallery_character',
+                        'data': jsonEncode({
+                          'pic': '',
+                          'list': [
+                            for (var i = 0; i < galleryListLen; i++)
+                              {
+                                'id': 'g$i',
+                                'key': 'k$i',
+                                'img': 'https://x/g$i.png',
+                                'imgDesc': '',
+                              },
+                          ],
+                        }),
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+          200,
+        );
+      }
+      return http.Response.bytes([1, 2, 3], 200);
+    });
+    final container = await setupContainer(apiClient: apiClient);
+    final notifier = container.read(gachaRepositoryProvider.notifier);
+
+    // 第一次增量抓取：entry 抓 1 次，gallery 1 張
+    await notifier.debugRunHoYoWikiOnly();
+    expect(entryCallCount, 1);
+    expect(
+      container
+          .read(hoyowikiIndexProvider)
+          .lookupEntry('111')!
+          .pageByLang['en-us']!
+          .gallery!
+          .list
+          .length,
+      1,
+    );
+
+    // HoYoWiki 端新增一張 gallery 圖
+    galleryListLen = 2;
+
+    // 非 force：已抓過 → 不重抓，gallery 仍是舊的 1 張
+    await notifier.debugRunHoYoWikiOnly();
+    expect(entryCallCount, 1, reason: '非 force 模式不重抓已解析 entry');
+
+    // force：強制重抓 entry → gallery 更新為 2 張
+    await notifier.debugRunHoYoWikiOnly(forceEntryRefetch: true);
+    expect(entryCallCount, 2, reason: 'force 模式重抓已解析 entry');
+    expect(
+      container
+          .read(hoyowikiIndexProvider)
+          .lookupEntry('111')!
+          .pageByLang['en-us']!
+          .gallery!
+          .list
+          .length,
+      2,
+      reason: 'force 重抓後 mergeEntry 覆蓋 gallery，新圖出現',
+    );
+
+    // gallery 大圖不應被 eager 下載（維持 lazy）
+    final galleryFiles = tempDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => RegExp(r'111_gallery_').hasMatch(f.path))
+        .toList();
+    expect(galleryFiles, isEmpty, reason: 'gallery 維持 lazy，不在更新流程下載');
+  });
 }

--- a/test/state/gacha_repository_hoyowiki_test.dart
+++ b/test/state/gacha_repository_hoyowiki_test.dart
@@ -1180,4 +1180,75 @@ void main() {
         .toList();
     expect(galleryFiles, isEmpty, reason: 'gallery 維持 lazy，不在更新流程下載');
   });
+
+  test(
+    'refreshAllHoYoWikiMetadata：非破壞性重抓，保留 icon、emit UpdateCompleted',
+    () async {
+      var entryCallCount = 0;
+      var imageDownloadCount = 0;
+      final apiClient = MockClient((req) async {
+        if (req.url.path.endsWith('/search')) {
+          return http.Response(
+            jsonEncode({
+              'retcode': 0,
+              'data': {
+                'list': [
+                  {
+                    'name': 'Hu Tao',
+                    'entry_page_id': '111',
+                    'menu': {
+                      'sub_menus': [
+                        {'id': 2},
+                      ],
+                    },
+                  },
+                ],
+              },
+            }),
+            200,
+          );
+        }
+        if (req.url.path.endsWith('/entry_page')) {
+          entryCallCount++;
+          return http.Response(
+            jsonEncode({
+              'retcode': 0,
+              'data': {
+                'page': {
+                  'icon_url': 'https://x/icon.png',
+                  'header_img_url': '',
+                },
+              },
+            }),
+            200,
+          );
+        }
+        imageDownloadCount++;
+        return http.Response.bytes([1, 2, 3], 200);
+      });
+      final container = await setupContainer(apiClient: apiClient);
+      final notifier = container.read(gachaRepositoryProvider.notifier);
+
+      // 先增量抓一次：建立 index + icon 快取檔
+      await notifier.debugRunHoYoWikiOnly();
+      expect(entryCallCount, 1);
+      expect(imageDownloadCount, 1, reason: '第一次下 icon');
+      final iconFile = File('${tempDir.path}/111_icon.png');
+      expect(iconFile.existsSync(), isTrue);
+
+      // 非破壞性更新
+      await notifier.refreshAllHoYoWikiMetadata();
+
+      // entry 被強制重抓；icon 已在快取 → 不重下；icon 檔仍在（未被 wipe）
+      expect(entryCallCount, 2, reason: 'force 重抓 entry');
+      expect(imageDownloadCount, 1, reason: 'icon 已快取，缺才下 → 不重下');
+      expect(iconFile.existsSync(), isTrue, reason: '非破壞性：既有快取保留');
+
+      // 結束狀態為 UpdateCompleted
+      expect(
+        container.read(gachaRepositoryProvider).progress,
+        isA<UpdateCompleted>(),
+      );
+    },
+  );
 }

--- a/test/state/gacha_repository_hoyowiki_test.dart
+++ b/test/state/gacha_repository_hoyowiki_test.dart
@@ -1249,6 +1249,112 @@ void main() {
         container.read(gachaRepositoryProvider).progress,
         isA<UpdateCompleted>(),
       );
+
+      // hoyoWikiEntriesRefreshed 應為 1（Hu Tao，相異物品數）
+      final done =
+          container.read(gachaRepositoryProvider).progress as UpdateCompleted;
+      expect(done.hoyoWikiEntriesRefreshed, 1);
+      expect(done.hoYoWikiImagesDownloaded, 0, reason: 'icon 已快取，不重下');
+    },
+  );
+
+  test(
+    'refreshAllHoYoWikiMetadata：同 id 兩 lang → hoyoWikiEntriesRefreshed 為 1（相異 id，非 lang 配對數）',
+    () async {
+      var entryCallCount = 0;
+      final apiClient = MockClient((req) async {
+        if (req.url.path.endsWith('/search')) {
+          return http.Response(
+            jsonEncode({
+              'retcode': 0,
+              'data': {
+                'list': [
+                  {
+                    'name': req.url.queryParameters['keyword'],
+                    'entry_page_id': '111',
+                    'menu': {
+                      'sub_menus': [
+                        {'id': 2},
+                      ],
+                    },
+                  },
+                ],
+              },
+            }),
+            200,
+          );
+        }
+        if (req.url.path.endsWith('/entry_page')) {
+          entryCallCount++;
+          return http.Response(
+            jsonEncode({
+              'retcode': 0,
+              'data': {
+                'page': {
+                  'icon_url': 'https://x/icon.png',
+                  'header_img_url': '',
+                },
+              },
+            }),
+            200,
+          );
+        }
+        return http.Response.bytes([1, 2, 3], 200);
+      });
+
+      // 兩筆 record：同 name（Hu Tao）不同 lang
+      tempDir = await Directory.systemTemp.createTemp('gacha_hoyowiki_2lang_');
+      SharedPreferences.setMockInitialValues({});
+      final storage = GachaStorage(tempDir);
+      await storage.save(
+        BannerStorage(
+          uid: '801057625',
+          lastUpdated: DateTime.utc(2026, 6, 18),
+          banners: {
+            '301': [
+              _rec(id: '1', name: 'Hu Tao', gachaType: '301', lang: 'zh-tw'),
+              _rec(id: '2', name: 'Hu Tao', gachaType: '301', lang: 'en-us'),
+            ],
+            '302': [],
+            '500': [],
+            '200': [],
+            '100': [],
+            '2000': [],
+            '1000': [],
+          },
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          gachaStorageProvider.overrideWithValue(storage),
+          hoyowikiIndexStorageProvider.overrideWithValue(
+            HoYoWikiIndexStorage(tempDir),
+          ),
+          hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+          hoyowikiFetcherProvider.overrideWithValue(HoYoWikiFetcher()),
+          cancellableHttpClientFactoryProvider.overrideWithValue(
+            () => CancellableHttpClient(client: apiClient, cancel: () {}),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async {
+        if (await tempDir.exists()) await tempDir.delete(recursive: true);
+      });
+      await container.read(gachaRepositoryProvider.notifier).waitForBootstrap();
+      await container.read(hoyowikiIndexProvider.notifier).waitForLoad();
+
+      await container
+          .read(gachaRepositoryProvider.notifier)
+          .refreshAllHoYoWikiMetadata();
+
+      // 兩 lang 各一次 entry 請求
+      expect(entryCallCount, 2, reason: '同 id 兩 lang 各發一次 entry_page');
+
+      final done =
+          container.read(gachaRepositoryProvider).progress as UpdateCompleted;
+      // 雖然 entry 階段處理了 2 個 (id, lang) 配對，相異 id 只有 1 個
+      expect(done.hoyoWikiEntriesRefreshed, 1, reason: '相異 id 只有 1 個');
     },
   );
 }

--- a/test/state/gacha_repository_hoyowiki_test.dart
+++ b/test/state/gacha_repository_hoyowiki_test.dart
@@ -1357,4 +1357,91 @@ void main() {
       expect(done.hoyoWikiEntriesRefreshed, 1, reason: '相異 id 只有 1 個');
     },
   );
+
+  test('refreshAllHoYoWikiMetadata 清掉殘留語言（stale zh-tw page 被移除）', () async {
+    final apiClient = MockClient((req) async {
+      if (req.url.path.endsWith('/search')) {
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'list': [
+                {
+                  'name': req.url.queryParameters['keyword'],
+                  'entry_page_id': '111',
+                  'menu': {
+                    'sub_menus': [
+                      {'id': 2},
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+          200,
+        );
+      }
+      if (req.url.path.endsWith('/entry_page')) {
+        return http.Response(
+          jsonEncode({
+            'retcode': 0,
+            'data': {
+              'page': {'icon_url': 'https://x/icon.png', 'header_img_url': ''},
+            },
+          }),
+          200,
+        );
+      }
+      return http.Response.bytes([1, 2, 3], 200);
+    });
+
+    // setupContainer 預設記錄 lang = en-us（_rec 預設值）
+    final container = await setupContainer(apiClient: apiClient);
+    final notifier = container.read(gachaRepositoryProvider.notifier);
+    final indexNotifier = container.read(hoyowikiIndexProvider.notifier);
+
+    // 先跑一次 hoyowiki，建立 en-us 的 search + entry
+    await notifier.debugRunHoYoWikiOnly();
+    expect(
+      container.read(hoyowikiIndexProvider).lookupEntry('111'),
+      isNotNull,
+      reason: 'en-us entry 應已建立',
+    );
+
+    // 手動注入一個不在記錄中的 zh-tw 殘留 page
+    await indexNotifier.mergeEntry(
+      id: '111',
+      lang: 'zh-tw',
+      fetched: const HoYoWikiEntryFetched(
+        iconUrl: 'https://x/icon.png',
+        page: HoYoWikiPageData(gallery: null, desc: '繁中說明', tags: []),
+      ),
+    );
+    // 確認此時兩 lang 均在
+    expect(
+      container
+          .read(hoyowikiIndexProvider)
+          .lookupEntry('111')!
+          .pageByLang
+          .keys
+          .toSet(),
+      containsAll(['en-us', 'zh-tw']),
+    );
+
+    // 執行 refreshAllHoYoWikiMetadata（含 pruneStaleLangs = true）
+    await notifier.refreshAllHoYoWikiMetadata();
+
+    // 殘留的 zh-tw 應被清除；en-us 仍在
+    final entry = container.read(hoyowikiIndexProvider).lookupEntry('111')!;
+    expect(
+      entry.pageByLang.containsKey('zh-tw'),
+      isFalse,
+      reason: '殘留的 zh-tw page 應被 pruneLanguages 清除',
+    );
+    expect(
+      entry.pageByLang.containsKey('en-us'),
+      isTrue,
+      reason: 'en-us page 應仍保留',
+    );
+  });
 }

--- a/test/state/hoyowiki_index_test.dart
+++ b/test/state/hoyowiki_index_test.dart
@@ -208,6 +208,97 @@ void main() {
     });
   });
 
+  group('HoYoWikiIndexNotifier.pruneLanguages', () {
+    late Directory tempDir;
+    late ProviderContainer container;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('pruneLanguages_test_');
+      container = ProviderContainer(
+        overrides: [
+          hoyowikiIndexStorageProvider.overrideWithValue(
+            HoYoWikiIndexStorage(tempDir),
+          ),
+          hoyowikiCacheDirProvider.overrideWithValue(tempDir),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(hoyowikiIndexProvider.notifier).waitForLoad();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        try {
+          await tempDir.delete(recursive: true);
+        } catch (_) {}
+      }
+    });
+
+    test('清掉殘留語言、保留當前語言', () async {
+      final notifier = container.read(hoyowikiIndexProvider.notifier);
+      // 寫入同一 id 的 zh-tw 與 en-us 兩個 page
+      await notifier.mergeEntry(
+        id: '999',
+        lang: 'zh-tw',
+        fetched: const HoYoWikiEntryFetched(
+          iconUrl: 'https://x/icon.png',
+          page: HoYoWikiPageData(gallery: null, desc: '繁中說明', tags: ['tag1']),
+        ),
+      );
+      await notifier.mergeEntry(
+        id: '999',
+        lang: 'en-us',
+        fetched: const HoYoWikiEntryFetched(
+          iconUrl: 'https://x/icon.png',
+          page: HoYoWikiPageData(gallery: null, desc: 'en desc', tags: []),
+        ),
+      );
+      // 確認兩 lang 均在
+      expect(
+        container
+            .read(hoyowikiIndexProvider)
+            .lookupEntry('999')!
+            .pageByLang
+            .keys
+            .toSet(),
+        {'zh-tw', 'en-us'},
+      );
+
+      // pruneLanguages 只保留 zh-tw
+      await notifier.pruneLanguages({'zh-tw'});
+
+      final entry = container.read(hoyowikiIndexProvider).lookupEntry('999')!;
+      expect(entry.pageByLang.keys.toSet(), {'zh-tw'});
+      // iconUrl 與 zh-tw page 保留
+      expect(entry.iconUrl, 'https://x/icon.png');
+      expect(entry.pageByLang['zh-tw']!.desc, '繁中說明');
+    });
+
+    test('無變動為 no-op（keepLangs 為超集）', () async {
+      final notifier = container.read(hoyowikiIndexProvider.notifier);
+      await notifier.mergeEntry(
+        id: '888',
+        lang: 'zh-tw',
+        fetched: const HoYoWikiEntryFetched(
+          iconUrl: 'https://x/icon.png',
+          page: HoYoWikiPageData(gallery: null, desc: '內容', tags: []),
+        ),
+      );
+      final before = container.read(hoyowikiIndexProvider);
+
+      // keepLangs 為超集（包含比實際存在更多的 lang）
+      await notifier.pruneLanguages({'zh-tw', 'en-us'});
+
+      final after = container.read(hoyowikiIndexProvider);
+      // 無實際變動 → entry 內容不變
+      expect(after.lookupEntry('888')!.pageByLang.keys.toSet(), {'zh-tw'});
+      expect(
+        after.lookupEntry('888')!.iconUrl,
+        before.lookupEntry('888')!.iconUrl,
+      );
+    });
+  });
+
   group('HoYoWikiIndexNotifier.mergeEntry', () {
     late Directory tempDir;
     late ProviderContainer container;

--- a/test/state/hoyowiki_index_test.dart
+++ b/test/state/hoyowiki_index_test.dart
@@ -264,8 +264,9 @@ void main() {
         {'zh-tw', 'en-us'},
       );
 
-      // pruneLanguages 只保留 zh-tw
-      await notifier.pruneLanguages({'zh-tw'});
+      // pruneLanguages 只保留 zh-tw → 回傳 1（1 個物品被清理）
+      final pruned = await notifier.pruneLanguages({'zh-tw'});
+      expect(pruned, 1);
 
       final entry = container.read(hoyowikiIndexProvider).lookupEntry('999')!;
       expect(entry.pageByLang.keys.toSet(), {'zh-tw'});
@@ -286,8 +287,9 @@ void main() {
       );
       final before = container.read(hoyowikiIndexProvider);
 
-      // keepLangs 為超集（包含比實際存在更多的 lang）
-      await notifier.pruneLanguages({'zh-tw', 'en-us'});
+      // keepLangs 為超集（包含比實際存在更多的 lang）→ 回傳 0（無物品被清理）
+      final pruned = await notifier.pruneLanguages({'zh-tw', 'en-us'});
+      expect(pruned, 0);
 
       final after = container.read(hoyowikiIndexProvider);
       // 無實際變動 → entry 內容不變
@@ -298,6 +300,31 @@ void main() {
       );
       // 無變動時不應重建 index state
       expect(identical(before, after), isTrue, reason: '無變動時不應重建 index');
+    });
+
+    test('空 keepLangs 為 no-op，回傳 0', () async {
+      final notifier = container.read(hoyowikiIndexProvider.notifier);
+      await notifier.mergeEntry(
+        id: '777',
+        lang: 'zh-tw',
+        fetched: const HoYoWikiEntryFetched(
+          iconUrl: 'https://x/icon.png',
+          page: HoYoWikiPageData(gallery: null, desc: '內容', tags: []),
+        ),
+      );
+      final before = container.read(hoyowikiIndexProvider);
+
+      // 空 keepLangs → no-op，回傳 0
+      final pruned = await notifier.pruneLanguages({});
+      expect(pruned, 0);
+
+      // state 應未變動
+      final after = container.read(hoyowikiIndexProvider);
+      expect(
+        identical(before, after),
+        isTrue,
+        reason: '空 keepLangs 不應變動 index',
+      );
     });
   });
 

--- a/test/state/hoyowiki_index_test.dart
+++ b/test/state/hoyowiki_index_test.dart
@@ -296,6 +296,8 @@ void main() {
         after.lookupEntry('888')!.iconUrl,
         before.lookupEntry('888')!.iconUrl,
       );
+      // 無變動時不應重建 index state
+      expect(identical(before, after), isTrue, reason: '無變動時不應重建 index');
     });
   });
 

--- a/test/widgets/dialogs/update_progress_dialog_test.dart
+++ b/test/widgets/dialogs/update_progress_dialog_test.dart
@@ -98,7 +98,7 @@ void main() {
     );
 
     expect(find.textContaining('已清理'), findsOneWidget);
-    expect(find.textContaining('2'), findsWidgets);
+    expect(find.textContaining('已清理 2'), findsOneWidget);
   });
 
   testWidgets('hoyoWikiStaleItemsPruned=0：不顯示已清理字樣', (tester) async {

--- a/test/widgets/dialogs/update_progress_dialog_test.dart
+++ b/test/widgets/dialogs/update_progress_dialog_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/state/gacha_repository.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/update_progress_dialog.dart';
+
+/// 測試用 stub：固定回傳指定的 [GachaState]，不執行任何真實邏輯。
+class _StubRepo extends GachaRepository {
+  _StubRepo(this._fixedState);
+  final GachaState _fixedState;
+
+  @override
+  GachaState build() => _fixedState;
+}
+
+/// 最小 pump harness：直接渲染 [UpdateProgressDialog]，progress 固定為指定值。
+Future<void> pumpDialog(
+  WidgetTester tester, {
+  required UpdateCompleted completed,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        gachaRepositoryProvider.overrideWith(
+          () => _StubRepo(GachaState(progress: completed)),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: const Scaffold(body: UpdateProgressDialog()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  final fixedDate = DateTime.utc(2026, 6, 18);
+
+  testWidgets(
+    'hoyoWikiEntriesRefreshed != null, imagesDownloaded=0：顯示已更新摘要，無新增／無補下載行',
+    (tester) async {
+      await pumpDialog(
+        tester,
+        completed: UpdateCompleted(
+          totalNewRecords: 0,
+          failedBanners: const [],
+          updatedAt: fixedDate,
+          hoYoWikiImagesDownloaded: 0,
+          hoyoWikiEntriesRefreshed: 5,
+        ),
+      );
+
+      expect(find.textContaining('已更新'), findsOneWidget);
+      // 不應出現「新增」紀錄字樣
+      expect(find.textContaining('新增'), findsNothing);
+      // imagesDownloaded=0 → 不應出現「補下載」行
+      expect(find.textContaining('補下載'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'hoyoWikiEntriesRefreshed != null, imagesDownloaded=2：顯示已更新 + 補下載行',
+    (tester) async {
+      await pumpDialog(
+        tester,
+        completed: UpdateCompleted(
+          totalNewRecords: 0,
+          failedBanners: const [],
+          updatedAt: fixedDate,
+          hoYoWikiImagesDownloaded: 2,
+          hoyoWikiEntriesRefreshed: 5,
+        ),
+      );
+
+      expect(find.textContaining('已更新'), findsOneWidget);
+      expect(find.textContaining('補下載'), findsOneWidget);
+      expect(find.textContaining('新增'), findsNothing);
+    },
+  );
+}

--- a/test/widgets/dialogs/update_progress_dialog_test.dart
+++ b/test/widgets/dialogs/update_progress_dialog_test.dart
@@ -83,4 +83,37 @@ void main() {
       expect(find.textContaining('新增'), findsNothing);
     },
   );
+
+  testWidgets('hoyoWikiStaleItemsPruned=2：顯示已清理殘留語言提醒行', (tester) async {
+    await pumpDialog(
+      tester,
+      completed: UpdateCompleted(
+        totalNewRecords: 0,
+        failedBanners: const [],
+        updatedAt: fixedDate,
+        hoYoWikiImagesDownloaded: 0,
+        hoyoWikiEntriesRefreshed: 5,
+        hoyoWikiStaleItemsPruned: 2,
+      ),
+    );
+
+    expect(find.textContaining('已清理'), findsOneWidget);
+    expect(find.textContaining('2'), findsWidgets);
+  });
+
+  testWidgets('hoyoWikiStaleItemsPruned=0：不顯示已清理字樣', (tester) async {
+    await pumpDialog(
+      tester,
+      completed: UpdateCompleted(
+        totalNewRecords: 0,
+        failedBanners: const [],
+        updatedAt: fixedDate,
+        hoYoWikiImagesDownloaded: 0,
+        hoyoWikiEntriesRefreshed: 5,
+        hoyoWikiStaleItemsPruned: 0,
+      ),
+    );
+
+    expect(find.textContaining('已清理'), findsNothing);
+  });
 }


### PR DESCRIPTION
## 摘要

設定頁新增獨立「物品資料」區與「更新物品資料」按鈕，提供**非破壞性**的 HoYoWiki metadata 重抓：讓 HoYoWiki 後來新增的 gallery 圖／頁籤能被偵測到，同時保留已下載的圖、新圖維持 lazy（開啟該物品詳情時才補下載）。

與既有破壞性「強制重抓物品圖片」（先清空整個 index＋快取再全抓）區隔：新按鈕用一般樣式＋輕量確認，不清既有資料。

## 主要變更

- **`_fetchHoYoWiki` 參數化**：新增 `forceEntryRefetch`（強制重抓所有已解析條目的 entry 階段，偵測新 gallery）與 `pruneStaleLangs` 旗標；回傳型別改為 record `({imagesDownloaded, itemsRefreshed, staleLangItemsPruned})`。
- **`refreshAllHoYoWikiMetadata()`**：非破壞性入口（比照既有骨架但不 `resetAll()`）；icon 僅缺檔才補、gallery 一律 lazy。
- **詳情頁零改動**：既有 lazy backfill（`build()` watch index＋每次開啟檢查缺圖補下載）已完整涵蓋「頁籤跟著更新」「補下載缺圖」。
- **完成訊息語意化**：不再沿用祈願記錄的「新增 N 筆紀錄」；改顯示「已更新 M 個物品的資料」＋條件式「補下載 N 張物品圖片」＋條件式「已清理 K 個物品的殘留語言資料」。
- **針對性清理殘留語言**：`pruneLanguages(keepLangs)` 移除 index 中已不再被任何記錄使用的語言頁面（資料語言轉換後的殘留），非破壞性、空 keepLangs 雙重防呆。
- **i18n**：新增 10 個 key，補進繁中 template ＋ 9 個已翻譯語系。

## 測試

- `fvm flutter analyze` → `No issues found!`
- `fvm flutter test` → `All tests passed!`（972 個測試，含新增的 repository／notifier／widget 測試）
- 涵蓋：force 重抓行為、gallery 不 eager 下載、icon 不重下、相異物品數計數（同物品多語言只算一次）、殘留語言清理與保留、完成訊息三種行的條件顯示。

## 設計文件

`docs/superpowers/specs/2026-06-18-manual-refresh-item-metadata-design.md`（已更新為最終出貨設計，供姐妹專案參考）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)