### PR TITLE
feat(item-detail): auto-linkify plain-text URLs in item detail

### DIFF
--- a/docs/superpowers/plans/2026-06-18-item-detail-linkify-urls.md
+++ b/docs/superpowers/plans/2026-06-18-item-detail-linkify-urls.md
@@ -1,0 +1,548 @@
+# 物品詳情純文字網址自動連結化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓物品詳情 dialog 內的純文字 `http(s)` 網址自動變成可點擊連結（既有 `<a href>` 一併可點），點擊以系統瀏覽器開啟。
+
+**Architecture:** 新增純函式 `linkifyHtml`（用 `html` DOM parser 只走訪 text node，把裸網址包成 `<a>`，跳過既有 `<a>` 子樹）；新增共用 `AppHtml` 元件（注入統一 `onLinkTap` 與靜態 primary 連結色）；抽出共用 `openExternalUrlString` helper；物品詳情 dialog 兩處 `Html` 改用 `AppHtml`。
+
+**Tech Stack:** Flutter、`flutter_html: ^3.0.0`、`html: ^0.15.5`（DOM parser，原為 flutter_html 傳遞依賴，提升為顯式依賴）、`url_launcher`、`logging`。
+
+## Global Constraints
+
+- 回答／文件／註解／dartdoc／UI 文字用**繁體中文（台灣）全形標點**；commit message 與 PR 標題用英文半形、conventional commits 格式。
+- 所有宣告（含 private `_xxx`）寫一行 `///` dartdoc（Flutter override 簽名自明者免）。
+- 新功能在關鍵節點埋 `Logger('xxx').info/warning/severe(...)`，敏感資料先脫敏。
+- Dialog 一律用 `AppDialog`（本計畫不新建 dialog，不涉及）。
+- 偵測範圍**只**比對 `http://` 與 `https://` 開頭網址；不處理 `www.` 與裸網域。
+- 行內連結採靜態 primary 色（`linkBaseColor`）+ 底線，**不做** hover 重新著色。
+- 禁止重複造輪子：複用既有 `openExternalUrl`、`linkBaseColor`。
+- 指令一律優先透過 `fvm` 執行。
+- 提交前依序通過：`fvm dart format lib/ test/` → `fvm flutter analyze`（須 `No issues found!`）→ `fvm flutter test`（須 `All tests passed!`）。不要 `--no-verify`，不要主動 `git push`。
+
+---
+
+### Task 1: `linkifyHtml` 純函式 + `html` 依賴
+
+把純文字 `http(s)` 裸網址改寫成 `<a href>`，是整個功能的核心邏輯，完整單元測試。
+
+**Files:**
+- Modify: `pubspec.yaml`（dependencies 區，在 `flutter_html: ^3.0.0` 之後加一行）
+- Create: `lib/utils/html_linkify.dart`
+- Test: `test/utils/html_linkify_test.dart`
+
+**Interfaces:**
+- Consumes: `package:html/dom.dart`（`Node`、`Element`、`Text`、`DocumentFragment.outerHtml`、`Element.tag`、`NodeList.insertAll/removeAt`）、`package:html/parser.dart`（`parseFragment`）。
+- Produces: `String linkifyHtml(String html)` — 供 Task 3 的 `AppHtml` 使用。
+
+- [ ] **Step 1: 加入 `html` 顯式依賴**
+
+編輯 `pubspec.yaml`，在 `flutter_html: ^3.0.0` 那行之後新增：
+
+```yaml
+  flutter_html: ^3.0.0
+  html: ^0.15.5
+```
+
+執行：`fvm flutter pub get`
+預期：`Got dependencies!`（`html` 已是傳遞依賴，版本不變、不應有衝突）。
+
+- [ ] **Step 2: 寫失敗測試**
+
+建立 `test/utils/html_linkify_test.dart`：
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/html_linkify.dart';
+
+/// 計算 [out] 內 `<a ` 出現次數，用來驗證沒有產生多餘／巢狀連結。
+int _anchorCount(String out) => '<a '.allMatches(out).length;
+
+void main() {
+  group('linkifyHtml', () {
+    test('純文字 https 網址 → 包成 <a href>', () {
+      final out = linkifyHtml('visit https://example.com now');
+      expect(
+        out,
+        contains('<a href="https://example.com">https://example.com</a>'),
+      );
+      expect(_anchorCount(out), 1);
+    });
+
+    test('http 也會被連結化', () {
+      final out = linkifyHtml('go http://foo.com');
+      expect(out, contains('<a href="http://foo.com">http://foo.com</a>'));
+    });
+
+    test('ftp / www / 裸網域不被連結化', () {
+      expect(_anchorCount(linkifyHtml('x ftp://foo.com y')), 0);
+      expect(_anchorCount(linkifyHtml('visit www.foo.com')), 0);
+      expect(_anchorCount(linkifyHtml('go to foo.com now')), 0);
+    });
+
+    test('尾端半形句點不吃進連結', () {
+      final out = linkifyHtml('see https://foo.com.');
+      expect(out, contains('<a href="https://foo.com">https://foo.com</a>'));
+      expect(out, contains('</a>.'));
+    });
+
+    test('尾端全形句號不吃進連結', () {
+      final out = linkifyHtml('詳見 https://foo.com。');
+      expect(out, contains('<a href="https://foo.com">https://foo.com</a>'));
+      expect(out, contains('</a>。'));
+    });
+
+    test('既有 <a href> 不被改、不雙重包覆', () {
+      final out = linkifyHtml('<a href="https://x.com">link</a>');
+      expect(out, contains('<a href="https://x.com">link</a>'));
+      expect(_anchorCount(out), 1);
+    });
+
+    test('既有 <a> 內文是網址也不產生巢狀 <a>', () {
+      final out = linkifyHtml('<a href="x">https://foo.com</a>');
+      expect(_anchorCount(out), 1);
+    });
+
+    test('屬性值內的網址不被當文字連結化', () {
+      final out = linkifyHtml('<img src="https://img.com/a.png">');
+      expect(out, isNot(contains('<a')));
+    });
+
+    test('同段多個網址各自連結化', () {
+      final out = linkifyHtml('a https://1.com b https://2.com');
+      expect(_anchorCount(out), 2);
+    });
+
+    test('無網址純文字語意不變', () {
+      expect(linkifyHtml('hello world'), 'hello world');
+    });
+
+    test('空字串回空字串', () {
+      expect(linkifyHtml(''), '');
+    });
+  });
+}
+```
+
+- [ ] **Step 3: 跑測試確認失敗**
+
+執行：`fvm flutter test test/utils/html_linkify_test.dart`
+預期：FAIL，`Error: ... 'linkifyHtml' isn't defined`（或 import 解析失敗）。
+
+- [ ] **Step 4: 實作 `linkifyHtml`**
+
+建立 `lib/utils/html_linkify.dart`：
+
+```dart
+import 'package:html/dom.dart';
+import 'package:html/parser.dart' as html_parser;
+import 'package:logging/logging.dart';
+
+/// [linkifyHtml] 的 logger。
+final Logger _log = Logger('ui.linkify');
+
+/// 比對 `http://` 或 `https://` 開頭的裸網址（延伸到空白或 `<` 為止）。
+final RegExp _urlRe = RegExp(r'https?://[^\s<]+');
+
+/// 連結尾端要剝除的標點（半形 + 全形），避免把句末標點吃進網址。
+const String _trailingPunct = '.,;:!?)]}。，！？；：）」』】';
+
+/// 把 [html] 內的純文字 `http(s)` 裸網址包成 `<a href>`，回傳改寫後的 HTML。
+///
+/// 用 DOM parser 只走訪 text node：既有 `<a>` 子樹整棵略過（不產生巢狀 `<a>`），
+/// 屬性值（如 `href="…"`）因非 text node 也不會被誤改。解析或序列化意外失敗時
+/// 回傳原字串（裸網址維持純文字、描述區不致渲染中斷）並記 warning。純函式、無副作用。
+String linkifyHtml(String html) {
+  if (html.isEmpty) return html;
+  try {
+    final fragment = html_parser.parseFragment(html);
+    _linkifyNode(fragment);
+    return fragment.outerHtml;
+  } catch (e, st) {
+    _log.warning(
+      'linkifyHtml failed (len=${html.length}); returning original',
+      e,
+      st,
+    );
+    return html;
+  }
+}
+
+/// 遞迴改寫 [node] 子節點：text node 內裸網址換成 `<a>`，`<a>` 子樹略過，其餘遞迴。
+void _linkifyNode(Node node) {
+  for (final child in List<Node>.from(node.nodes)) {
+    if (child is Text) {
+      final replacements = _linkifyText(child.data ?? '');
+      if (replacements == null) continue;
+      final idx = node.nodes.indexOf(child);
+      node.nodes.removeAt(idx);
+      node.nodes.insertAll(idx, replacements);
+    } else if (child is Element) {
+      if (child.localName == 'a') continue;
+      _linkifyNode(child);
+    }
+  }
+}
+
+/// 把 [text] 拆成「文字／`<a>` 連結」節點序列；若無可連結網址回 null（呼叫端略過替換）。
+List<Node>? _linkifyText(String text) {
+  if (!_urlRe.hasMatch(text)) return null;
+  final nodes = <Node>[];
+  var last = 0;
+  for (final m in _urlRe.allMatches(text)) {
+    var url = m.group(0)!;
+    var end = m.end;
+    while (url.isNotEmpty && _trailingPunct.contains(url[url.length - 1])) {
+      url = url.substring(0, url.length - 1);
+      end--;
+    }
+    if (url.isEmpty) continue;
+    if (m.start > last) nodes.add(Text(text.substring(last, m.start)));
+    nodes.add(
+      Element.tag('a')
+        ..attributes['href'] = url
+        ..append(Text(url)),
+    );
+    last = end;
+  }
+  if (nodes.isEmpty) return null;
+  if (last < text.length) nodes.add(Text(text.substring(last)));
+  return nodes;
+}
+```
+
+- [ ] **Step 5: 跑測試確認通過**
+
+執行：`fvm flutter test test/utils/html_linkify_test.dart`
+預期：PASS，全部 11 個測試綠燈。
+
+- [ ] **Step 6: 品質檢查 + commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+git add pubspec.yaml pubspec.lock lib/utils/html_linkify.dart test/utils/html_linkify_test.dart
+git commit -m "feat(item-detail): add linkifyHtml to wrap bare http(s) URLs in anchors"
+```
+
+預期：`analyze` 輸出 `No issues found!`；`test` 輸出 `All tests passed!`。
+
+---
+
+### Task 2: 抽出 `openExternalUrlString` 共用 helper
+
+把「字串 → Uri → 開啟」的解析防呆抽成共用函式，供 `AppLink` 與後續 `AppHtml` 的 `onLinkTap` 共用，消除重複樣板。
+
+**Files:**
+- Modify: `lib/widgets/app_link.dart`
+- Test: `test/widgets/app_link_test.dart`
+
+**Interfaces:**
+- Consumes: 既有 `Future<void> openExternalUrl(Uri uri)`（同檔）。
+- Produces: `Future<void> openExternalUrlString(String? url)` — 供 Task 3 的 `AppHtml.onLinkTap` 使用。
+
+- [ ] **Step 1: 寫失敗測試**
+
+建立 `test/widgets/app_link_test.dart`：
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+
+void main() {
+  group('openExternalUrlString', () {
+    test('null URL 不丟例外、靜默返回', () async {
+      // onLinkTap 可能傳入 null；此分支不應觸碰 url_launcher 平台。
+      await expectLater(openExternalUrlString(null), completes);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+執行：`fvm flutter test test/widgets/app_link_test.dart`
+預期：FAIL，`'openExternalUrlString' isn't defined`。
+
+- [ ] **Step 3: 新增 helper 並重構 `_handleTap`**
+
+在 `lib/widgets/app_link.dart` 的 `openExternalUrl` 之上新增：
+
+```dart
+/// 解析 [url] 並以系統瀏覽器開啟；[url] 為 null 或無法解析時記 warning 並靜默返回。
+///
+/// 供 [AppLink] 與 flutter_html 的 `onLinkTap`（其回傳可能為 null）共用，統一
+/// 「字串 → Uri → 開啟」的解析與防呆。
+Future<void> openExternalUrlString(String? url) async {
+  final uri = url == null ? null : Uri.tryParse(url);
+  if (uri == null) {
+    Logger('ui.link').warning('openExternalUrlString: invalid url "$url"');
+    return;
+  }
+  await openExternalUrl(uri);
+}
+```
+
+把 `_AppLinkState._handleTap` 改為複用該 helper：
+
+```dart
+  /// 解析並開啟 [widget.url]；URL 無效時記錄 warning。
+  Future<void> _handleTap() => openExternalUrlString(widget.url);
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+執行：`fvm flutter test test/widgets/app_link_test.dart`
+預期：PASS。
+
+- [ ] **Step 5: 品質檢查 + commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+git add lib/widgets/app_link.dart test/widgets/app_link_test.dart
+git commit -m "refactor(link): extract openExternalUrlString helper shared by AppLink and onLinkTap"
+```
+
+預期：`No issues found!` 與 `All tests passed!`。
+
+---
+
+### Task 3: `AppHtml` 共用元件
+
+把 `linkifyHtml` 與 `openExternalUrlString` 串成可重用的 HTML 渲染元件，統一連結色與點擊行為。
+
+**Files:**
+- Create: `lib/widgets/app_html.dart`
+- Test: `test/widgets/app_html_test.dart`
+
+**Interfaces:**
+- Consumes: `String linkifyHtml(String html)`（Task 1）、`Future<void> openExternalUrlString(String? url)`（Task 2）、`Color linkBaseColor(ThemeData theme)`（既有 `app_link.dart`）、`flutter_html` 的 `Html`／`Style`／`OnTap`。
+- Produces: `class AppHtml`（`const AppHtml({Key? key, required String data, Map<String, Style> style})`）— 供 Task 4 取代 dialog 內的 `Html`。
+
+- [ ] **Step 1: 寫失敗測試**
+
+建立 `test/widgets/app_html_test.dart`：
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_html.dart';
+
+void main() {
+  testWidgets('純文字網址被渲染成連結文字', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AppHtml(data: 'visit https://example.com now'),
+        ),
+      ),
+    );
+    // AppHtml 內部組一個 flutter_html 的 Html；連結文字應出現在 rich text 中。
+    expect(find.byType(Html), findsOneWidget);
+    expect(
+      find.textContaining('https://example.com', findRichText: true),
+      findsWidgets,
+    );
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+執行：`fvm flutter test test/widgets/app_html_test.dart`
+預期：FAIL，`'AppHtml' isn't defined` / `app_html.dart` 不存在。
+
+- [ ] **Step 3: 實作 `AppHtml`**
+
+建立 `lib/widgets/app_html.dart`：
+
+```dart
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/utils/html_linkify.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+
+/// 渲染 HTML 的共用元件：自動把純文字 `http(s)` 網址轉成可點連結（含內容既有的
+/// `<a href>`），點擊以系統瀏覽器開啟。
+///
+/// 連結採全應用統一的靜態 primary 連結色（[linkBaseColor]）+ 底線，對齊既有行內
+/// 連結風格；不做 per-link hover。呼叫端可透過 [style] 覆蓋 `body`／`p` 等標籤樣式
+/// （疊在預設 `a` 樣式之後）。
+class AppHtml extends StatelessWidget {
+  /// 建立 [AppHtml]。[data] 為 HTML 字串；[style] 為額外的 flutter_html 標籤樣式。
+  const AppHtml({super.key, required this.data, this.style = const {}});
+
+  /// 要渲染的 HTML 內容。
+  final String data;
+
+  /// 額外的標籤樣式覆寫（疊在預設 `a` 樣式之後）。
+  final Map<String, Style> style;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Html(
+      data: linkifyHtml(data),
+      onLinkTap: (url, _, __) => unawaited(openExternalUrlString(url)),
+      style: {
+        'a': Style(
+          color: linkBaseColor(theme),
+          textDecoration: TextDecoration.underline,
+        ),
+        ...style,
+      },
+    );
+  }
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+執行：`fvm flutter test test/widgets/app_html_test.dart`
+預期：PASS。
+
+- [ ] **Step 5: 品質檢查 + commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+git add lib/widgets/app_html.dart test/widgets/app_html_test.dart
+git commit -m "feat(widgets): add AppHtml wrapper with linkified URLs and unified link tap"
+```
+
+預期：`No issues found!` 與 `All tests passed!`。
+
+---
+
+### Task 4: 物品詳情 dialog 兩處 `Html` 改用 `AppHtml`
+
+把標題區 `desc` 與圖片區 `descHtml` 兩處渲染換成 `AppHtml`，讓詳情內容的純文字網址可點。
+
+**Files:**
+- Modify: `lib/widgets/dialogs/gacha_item_detail_dialog.dart`（import 區；標題區 `desc` 的 `Html`（約 615 行）；圖片區 `descHtml` 的 `Html`（約 698 行））
+
+**Interfaces:**
+- Consumes: `class AppHtml`（Task 3）。
+- Produces: 無新對外介面（行為變更）。
+
+- [ ] **Step 1: 新增 import**
+
+在 `lib/widgets/dialogs/gacha_item_detail_dialog.dart` 既有 import 區，於 `app_link.dart` import 之後加入（維持既有匯入排列）：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_html.dart';
+```
+
+- [ ] **Step 2: 標題區 `desc` 改用 `AppHtml`**
+
+把標題區（約 615-630 行）原本的：
+
+```dart
+                      child: Html(
+                        data: desc,
+                        style: {
+                          'body': Style(
+                            fontSize: FontSize(
+                              theme.textTheme.bodyMedium?.fontSize ?? 14,
+                            ),
+                            lineHeight: LineHeight.number(1.2),
+                            color: tokens.textSecondary,
+                            margin: Margins.zero,
+                            padding: HtmlPaddings.zero,
+                          ),
+                          'p': Style(margin: Margins.zero),
+                        },
+                      ),
+```
+
+改為（只把 `Html` 換成 `AppHtml`，`style` map 原樣保留）：
+
+```dart
+                      child: AppHtml(
+                        data: desc,
+                        style: {
+                          'body': Style(
+                            fontSize: FontSize(
+                              theme.textTheme.bodyMedium?.fontSize ?? 14,
+                            ),
+                            lineHeight: LineHeight.number(1.2),
+                            color: tokens.textSecondary,
+                            margin: Margins.zero,
+                            padding: HtmlPaddings.zero,
+                          ),
+                          'p': Style(margin: Margins.zero),
+                        },
+                      ),
+```
+
+- [ ] **Step 3: 圖片區 `descHtml` 改用 `AppHtml`**
+
+把圖片區（約 698-704 行）原本的：
+
+```dart
+            Html(
+              data: current.descHtml,
+              style: {
+                'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+                'p': Style(margin: Margins.symmetric(vertical: 4)),
+              },
+            ),
+```
+
+改為：
+
+```dart
+            AppHtml(
+              data: current.descHtml,
+              style: {
+                'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+                'p': Style(margin: Margins.symmetric(vertical: 4)),
+              },
+            ),
+```
+
+> 註：保留 `flutter_html` 的 import — `Style`、`Margins`、`HtmlPaddings`、`FontSize`、`LineHeight` 仍由它提供。
+
+- [ ] **Step 4: 跑既有 dialog 測試確認無回歸**
+
+執行：`fvm flutter test test/widgets/dialogs/gacha_item_detail_dialog_test.dart test/widgets/dialogs/gacha_item_detail_dialog_lazy_test.dart`
+預期：PASS。既有 `find.byType(Html)` 斷言（約 328、351 行）仍命中 `AppHtml` 內層的 `Html`，毋須改測試；若有 finder 失敗則為真實回歸，需調查。
+
+- [ ] **Step 5: 全套品質檢查 + commit**
+
+```bash
+fvm dart format lib/ test/
+fvm flutter analyze
+fvm flutter test
+git add lib/widgets/dialogs/gacha_item_detail_dialog.dart
+git commit -m "feat(item-detail): render desc and gallery descriptions via AppHtml to linkify URLs"
+```
+
+預期：`No issues found!` 與 `All tests passed!`。
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+- 偵測範圍只 http/https → Task 1 regex `https?://`，測試涵蓋 ftp/www/裸網域不中。✓
+- 裸 URL 與既有 `<a>` 都可點 → Task 1 跳過 `<a>` 子樹 + Task 3 `onLinkTap` 全域生效。✓
+- 行內連結靜態 primary 色、無 hover → Task 3 `'a': Style(color: linkBaseColor, underline)`。✓
+- 適用兩處（desc + descHtml）→ Task 4 兩個 site。✓
+- parser-based、fail-safe 回原字串 + log → Task 1 `try/catch` + `_log.warning`。✓
+- 複用 `openExternalUrl` → Task 2 抽 `openExternalUrlString` 委派之。✓
+- 尾端標點剝除（半/全形）→ Task 1 `_trailingPunct` + 兩個測試。✓
+- `html` 提升顯式依賴 → Task 1 Step 1。✓
+- 測試（linkify 單元 / AppHtml widget / dialog 無回歸）→ Task 1／3／4。✓
+
+**2. Placeholder scan**：無 TBD／TODO／「類似 Task N」；每個改碼步驟都附完整程式碼。✓
+
+**3. Type consistency**：`linkifyHtml(String) → String`、`openExternalUrlString(String?) → Future<void>`、`AppHtml({required String data, Map<String, Style> style})` 在定義（Task 1/2/3）與使用（Task 3/4）處一致。`onLinkTap` 簽名 `(String? url, Map<String,String>, Element?)` 對齊 flutter_html `OnTap`。✓

--- a/docs/superpowers/specs/2026-06-18-item-detail-linkify-urls-design.md
+++ b/docs/superpowers/specs/2026-06-18-item-detail-linkify-urls-design.md
@@ -1,0 +1,121 @@
+# 物品詳情純文字網址自動連結化 — 設計
+
+## 背景與問題
+
+物品詳情 dialog（`lib/widgets/dialogs/gacha_item_detail_dialog.dart`）有兩處用 `flutter_html` 的 `Html` 渲染 HoYoWiki 內容：
+
+1. **標題區的 `desc`** — 詞條說明（資料層註解標明「可能為純文字或含 HTML」）。
+2. **圖片區的 `current.descHtml`** — gallery 圖片說明 HTML。
+
+目前兩處 `Html` 都沒有傳 `onLinkTap`，因此：
+
+- 內容中的**純文字網址**（例如 `詳見 https://example.com`）只會以純文字呈現，無法點擊前往。
+- 即使內容本來就含 `<a href>`，因為沒有 `onLinkTap`，一樣點不動。
+
+需求：物品詳情內的純文字網址要自動變成可點擊前往；既有 `<a href>` 連結也應一併可點，避免「這個 URL 可點、那個不可點」的不一致。
+
+## 目標與範圍
+
+- **偵測範圍（保守）**：只比對 `http://` 與 `https://` 開頭的完整網址。不處理 `www.` 前綴與裸網域（`foo.com`），以杜絕把版本號（`版本 2.0`）、檔名、含點英文縮寫誤判成網址。
+- **既有 `<a href>` 一併可點**：裸 URL 與既有 `<a>` 透過同一 `onLinkTap` 開啟外部瀏覽器，體驗一致。
+- **行內連結風格對齊現有應用程式**：採靜態 primary 連結色（與 `release_notes_content.dart` 的 markdown 行內連結一致），**不做** per-link hover 重新著色。
+- **適用兩處**：標題區 `desc` 與圖片區 `descHtml` 皆涵蓋。
+
+### 不做（YAGNI）
+
+- 不支援 `www.` 前綴與裸網域。
+- 不做行內連結 hover 變色（流動文字裡的行內連結，現行 app 即為靜態 primary 色；要做 hover 需 `TagExtension.inline` + 自訂 inline 元件，較複雜且 `WidgetSpan` 在 rich text 中無法換行、長 URL 會溢出，超出需求）。
+- 不把 `AppHtml` 套用到物品詳情以外的既有 `Html` 用途（其他有需要再說）。
+
+## 既有資產與風格基準
+
+- `lib/widgets/app_link.dart`：`openExternalUrl(Uri)` 已統一以系統瀏覽器開啟連結並在失敗時 `warning`；`AppLink._handleTap` 內含 `Uri.tryParse` + 無效時 `warning` 的樣板。
+- `lib/utils/github_release_linkify.dart`：既有 linkify 工具（純字串轉換、無副作用、放 `lib/utils/`）— 作為新工具的擺放位置與 dartdoc 風格基準。注意它針對 **Markdown** 做 raw-regex 改寫；HTML 情境的差異見下節。
+- `lib/widgets/dialogs/release_notes_content.dart`：既有**行內連結風格的權威基準** — `LinkConfig(style: TextStyle(color: linkBaseColor(theme)))`，靜態 primary 色、無 hover。
+- `linkBaseColor(theme)`（`app_link.dart`）：全應用統一連結色（`colorScheme.primary`）。
+
+## 取向決策
+
+採 **HTML parser 走訪文字節點做 linkify**，而非對原始字串跑 regex。
+
+原因：內容是「純文字或含 HTML 混雜」。對 HTML raw-string 跑 regex 難以安全避開兩種情境——(1) URL 出現在既有 `href="…"` 屬性值內、(2) URL 出現在既有 `<a>…</a>` 連結文字內（linkify 會造出非法的巢狀 `<a>`）。用 parser 只走訪「非 `<a>` 子孫的 text node」可從結構上乾淨避開兩者。此分歧於 `github_release_linkify.dart`（Markdown，靠 `(?<![(<])` lookbehind 防重複包裝）是刻意的：HTML 需要結構感知，raw-regex 無法安全提供。
+
+`html` 套件目前已是 `flutter_html` 的傳遞依賴，將其**提升為顯式依賴**（pubspec 一行）後直接使用其 DOM parser。
+
+## 架構與元件
+
+### 1. `lib/utils/html_linkify.dart` — 純函式 `linkifyHtml`
+
+```
+String linkifyHtml(String html)
+```
+
+- 用 `html` 套件 `parseFragment(html)` 解析成 DOM 片段。
+- 遞迴走訪節點；遇到 `<a>` 元素則**整棵子樹略過**（其內文字不再 linkify，避免巢狀 `<a>`）。
+- 對其餘 text node：以 regex `https?://[^\s<]+` 找出裸 URL，**剝除尾端標點**後，將 URL 段替換為 `<a href="URL">URL</a>` 元素，URL 前後文字保留為 text node。
+  - 尾端標點剝除集合涵蓋半形 `. , ; : ! ? ) ] }` 與全形 `。 ， ！ ？ ； ： ） 」 』 】`，避免「…網站 https://foo.com。」把句號吃進連結。
+- 序列化回字串（`fragment.outerHtml` 之類），回傳。
+- **fail-safe**：整段包 `try/catch`；解析或序列化意外失敗時回傳**原字串**（最壞情況裸 URL 維持純文字，絕不讓描述區渲染中斷），並 `Logger('ui.linkify').warning(...)` 帶上脫敏後的長度／前綴等 context（不寫入完整內容）。
+- 純函式、無副作用，可獨立單元測試。
+
+### 2. `lib/widgets/app_html.dart` — 共用 `AppHtml`
+
+```
+AppHtml({required String data, Map<String, Style> style = const {}})
+```
+
+- 內部渲染 `Html(data: linkifyHtml(data), onLinkTap: …, style: {…})`。
+- `style` 合併：先放預設 `'a'` 樣式，再展開呼叫端傳入的 `style`（呼叫端可覆蓋，但通常只覆蓋 `body`／`p`）。
+  - 預設 `'a'`：`Style(color: linkBaseColor(theme), textDecoration: TextDecoration.underline)`（靜態 primary 色 + 底線作點擊提示；對齊既有行內連結風格）。
+- `onLinkTap: (url, _, __) => openExternalUrlString(url)`（`OnTap` 簽名為 `void Function(String? url, Map<String,String> attributes, html.Element? element)`）。
+- 手型游標由 flutter_html 對可點 `<a>` 預設提供；實作時驗證，若預設未提供再於 `'a'` 樣式補強。
+
+### 3. `lib/widgets/app_link.dart` — 抽出共用開連結 helper
+
+```
+Future<void> openExternalUrlString(String? url)
+```
+
+- `url` 為 null 或 `Uri.tryParse` 失敗 → `Logger('ui.link').warning(...)` 後靜默返回。
+- 有效 → 呼叫既有 `openExternalUrl(uri)`。
+- 重構 `AppLink._handleTap` 改為呼叫此 helper，消除重複的 `tryParse` + `warning` 樣板；`AppHtml.onLinkTap` 亦呼叫之。符合「抽出共用、別造輪子」。
+
+## 資料流與接點
+
+物品詳情 dialog 兩處 `Html(...)` 改為 `AppHtml(...)`，沿用各自原本的 `body`／`p` 樣式：
+
+- **標題區 `desc`**：保留外層 `DefaultTextStyle.merge(height: 1.0)` 與既有 `body`（fontSize、lineHeight 1.2、textSecondary 色、margin/padding 歸零）、`p`（margin 歸零）樣式，僅把 `Html` 換成 `AppHtml`。
+- **圖片區 `descHtml`**：保留既有 `body`（margin/padding 歸零）、`p`（上下 4px margin）樣式，`Html` 換成 `AppHtml`。
+
+兩處不再各自寫 `Html`，`onLinkTap` 與連結色集中於 `AppHtml`，杜絕不一致。
+
+## 錯誤處理
+
+| 情境 | 行為 |
+| --- | --- |
+| `linkifyHtml` 解析／序列化意外失敗 | 回傳原字串 + `warning`，渲染不中斷 |
+| `onLinkTap` 收到 null 或無法解析的 URL | `openExternalUrlString` `tryParse` 失敗 → `warning`，不崩 |
+| `canLaunchUrl` 回 false（無可用處理程式） | 沿用 `openExternalUrl` 既有 `warning` |
+
+## 測試
+
+### `test/utils/html_linkify_test.dart`（單元，重點）
+
+- 單一 `https://` URL（純文字）→ 包成 `<a href>`。
+- `http://` 亦中；`ftp://`、`www.foo.com`、裸網域 `foo.com` **不中**（驗證保守範圍）。
+- 尾端半形標點（`https://foo.com.`）與全形標點（`https://foo.com。`）**不吃進連結**。
+- 既有 `<a href="…">…</a>` **不被改、不雙重包覆、不產生巢狀 `<a>`**。
+- URL 出現在屬性值內（如 `<img src="https://…">`）**不被當文字 linkify**。
+- 同一段含多個 URL → 全部各自包成連結。
+- 無 URL 的純文字 → 語意不變。
+- 空字串 → 不崩、回空。
+
+### `test/widgets/app_html_test.dart`（widget）
+
+- 含裸 URL 的 `data` → render 出對應 anchor。
+- 點擊連結 → 觸發外部開啟（以 `url_launcher` 平台 mock 驗證 launch 被呼叫，沿用專案既有 mock 方式）。
+- 既有 dialog 測試（`gacha_item_detail_dialog_test.dart` 等）維持綠燈，確認無回歸。
+
+## 提交前品質檢查
+
+依 `CLAUDE.md`：`fvm dart format lib/ test/` → `fvm flutter analyze`（須 `No issues found!`）→ `fvm flutter test`（須 `All tests passed!`）。

--- a/lib/utils/html_linkify.dart
+++ b/lib/utils/html_linkify.dart
@@ -1,0 +1,75 @@
+import 'package:html/dom.dart';
+import 'package:html/parser.dart' as html_parser;
+import 'package:logging/logging.dart';
+
+/// [linkifyHtml] 的 logger。
+final Logger _log = Logger('ui.linkify');
+
+/// 比對 `http://` 或 `https://` 開頭的裸網址（延伸到空白或 `<` 為止）。
+final RegExp _urlRe = RegExp(r'https?://[^\s<]+');
+
+/// 連結尾端要剝除的標點（半形 + 全形），避免把句末標點吃進網址。
+const String _trailingPunct = '.,;:!?)]}。，！？；：）」』】';
+
+/// 把 [html] 內的純文字 `http(s)` 裸網址包成 `<a href>`，回傳改寫後的 HTML。
+///
+/// 用 DOM parser 只走訪 text node：既有 `<a>` 子樹整棵略過（不產生巢狀 `<a>`），
+/// 屬性值（如 `href="…"`）因非 text node 也不會被誤改。解析或序列化意外失敗時
+/// 回傳原字串（裸網址維持純文字、描述區不致渲染中斷）並記 warning。純函式、無副作用。
+String linkifyHtml(String html) {
+  if (html.isEmpty) return html;
+  try {
+    final fragment = html_parser.parseFragment(html);
+    _linkifyNode(fragment);
+    return fragment.outerHtml;
+  } catch (e, st) {
+    _log.warning(
+      'linkifyHtml failed (len=${html.length}); returning original',
+      e,
+      st,
+    );
+    return html;
+  }
+}
+
+/// 遞迴改寫 [node] 子節點：text node 內裸網址換成 `<a>`，`<a>` 子樹略過，其餘遞迴。
+void _linkifyNode(Node node) {
+  for (final child in List<Node>.from(node.nodes)) {
+    if (child is Text) {
+      final replacements = _linkifyText(child.data);
+      if (replacements == null) continue;
+      final idx = node.nodes.indexOf(child);
+      node.nodes.removeAt(idx);
+      node.nodes.insertAll(idx, replacements);
+    } else if (child is Element) {
+      if (child.localName == 'a') continue;
+      _linkifyNode(child);
+    }
+  }
+}
+
+/// 把 [text] 拆成「文字／`<a>` 連結」節點序列；若無可連結網址回 null（呼叫端略過替換）。
+List<Node>? _linkifyText(String text) {
+  if (!_urlRe.hasMatch(text)) return null;
+  final nodes = <Node>[];
+  var last = 0;
+  for (final m in _urlRe.allMatches(text)) {
+    var url = m.group(0)!;
+    var end = m.end;
+    while (url.isNotEmpty && _trailingPunct.contains(url[url.length - 1])) {
+      url = url.substring(0, url.length - 1);
+      end--;
+    }
+    if (url.isEmpty) continue;
+    if (m.start > last) nodes.add(Text(text.substring(last, m.start)));
+    nodes.add(
+      Element.tag('a')
+        ..attributes['href'] = url
+        ..append(Text(url)),
+    );
+    last = end;
+  }
+  if (nodes.isEmpty) return null;
+  if (last < text.length) nodes.add(Text(text.substring(last)));
+  return nodes;
+}

--- a/lib/utils/html_linkify.dart
+++ b/lib/utils/html_linkify.dart
@@ -60,7 +60,10 @@ List<Node>? _linkifyText(String text) {
       url = url.substring(0, url.length - 1);
       end--;
     }
-    if (url.isEmpty) continue;
+    if (url.isEmpty) {
+      last = m.end;
+      continue;
+    }
     if (m.start > last) nodes.add(Text(text.substring(last, m.start)));
     nodes.add(
       Element.tag('a')

--- a/lib/widgets/app_html.dart
+++ b/lib/widgets/app_html.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/utils/html_linkify.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+
+/// 渲染 HTML 的共用元件：自動把純文字 `http(s)` 網址轉成可點連結（含內容既有的
+/// `<a href>`），點擊以系統瀏覽器開啟。
+///
+/// 連結採全應用統一的靜態 primary 連結色（[linkBaseColor]）+ 底線，對齊既有行內
+/// 連結風格；不做 per-link hover。呼叫端可透過 [style] 覆蓋 `body`／`p` 等標籤樣式
+/// （疊在預設 `a` 樣式之後）。
+class AppHtml extends StatelessWidget {
+  /// 建立 [AppHtml]。[data] 為 HTML 字串；[style] 為額外的 flutter_html 標籤樣式。
+  const AppHtml({super.key, required this.data, this.style = const {}});
+
+  /// 要渲染的 HTML 內容。
+  final String data;
+
+  /// 額外的標籤樣式覆寫（疊在預設 `a` 樣式之後）。
+  final Map<String, Style> style;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Html(
+      data: linkifyHtml(data),
+      onLinkTap: (url, _, _) => unawaited(openExternalUrlString(url)),
+      style: {
+        'a': Style(
+          color: linkBaseColor(theme),
+          textDecoration: TextDecoration.underline,
+        ),
+        ...style,
+      },
+    );
+  }
+}

--- a/lib/widgets/app_link.dart
+++ b/lib/widgets/app_link.dart
@@ -37,14 +37,7 @@ class _AppLinkState extends State<AppLink> {
   bool _hovering = false;
 
   /// 解析並開啟 [widget.url]；URL 無效時記錄 warning。
-  Future<void> _handleTap() async {
-    final uri = Uri.tryParse(widget.url);
-    if (uri == null) {
-      Logger('ui.link').warning('AppLink: invalid url "${widget.url}"');
-      return;
-    }
-    await openExternalUrl(uri);
-  }
+  Future<void> _handleTap() => openExternalUrlString(widget.url);
 
   @override
   Widget build(BuildContext context) {
@@ -65,6 +58,19 @@ class _AppLinkState extends State<AppLink> {
       ),
     );
   }
+}
+
+/// 解析 [url] 並以系統瀏覽器開啟；[url] 為 null 或無法解析時記 warning 並靜默返回。
+///
+/// 供 [AppLink] 與 flutter_html 的 `onLinkTap`（其回傳可能為 null）共用，統一
+/// 「字串 → Uri → 開啟」的解析與防呆。
+Future<void> openExternalUrlString(String? url) async {
+  final uri = url == null ? null : Uri.tryParse(url);
+  if (uri == null) {
+    Logger('ui.link').warning('openExternalUrlString: invalid url "$url"');
+    return;
+  }
+  await openExternalUrl(uri);
 }
 
 /// 以系統瀏覽器開啟 [uri]；無法啟動時記錄 warning 並靜默返回。

--- a/lib/widgets/dialogs/gacha_item_detail_dialog.dart
+++ b/lib/widgets/dialogs/gacha_item_detail_dialog.dart
@@ -16,6 +16,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_cache_usage.da
 import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_html.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/app_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/dialog_toast.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gallery_chip_bar.dart';
@@ -612,7 +613,7 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
                       // 約 6px。壓成 1.0 後區塊最小高度＝文字行高，單行/多行首行對齊。
                       child: DefaultTextStyle.merge(
                         style: const TextStyle(height: 1.0),
-                        child: Html(
+                        child: AppHtml(
                           data: desc,
                           style: {
                             'body': Style(
@@ -695,7 +696,7 @@ class _GachaItemDetailDialogState extends ConsumerState<GachaItemDetailDialog> {
             // 顯式收緊段落 margin：flutter_html 預設 `<p>` 上下 1em margin，
             // 在 imgDescHtml 「<p>標題</p><p>內文</p>」結構下會有 ~25-30px
             // 空白；官方頁面只有 ~6-8px。body margin/padding 歸零避免額外間距。
-            Html(
+            AppHtml(
               data: current.descHtml,
               style: {
                 'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,7 +366,7 @@ packages:
     source: hosted
     version: "2.0.0"
   html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: html
       sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   screen_retriever: ^0.2.1
   url_launcher: ^6.3.2
   flutter_html: ^3.0.0
+  html: ^0.15.5
   font_awesome_flutter: ^11.0.0
   pub_semver: ^2.2.0
   markdown_widget: ^2.3.2+8

--- a/test/utils/html_linkify_test.dart
+++ b/test/utils/html_linkify_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/utils/html_linkify.dart';
+
+/// 計算 [out] 內 `<a ` 出現次數，用來驗證沒有產生多餘／巢狀連結。
+int _anchorCount(String out) => '<a '.allMatches(out).length;
+
+void main() {
+  group('linkifyHtml', () {
+    test('純文字 https 網址 → 包成 <a href>', () {
+      final out = linkifyHtml('visit https://example.com now');
+      expect(
+        out,
+        contains('<a href="https://example.com">https://example.com</a>'),
+      );
+      expect(_anchorCount(out), 1);
+    });
+
+    test('http 也會被連結化', () {
+      final out = linkifyHtml('go http://foo.com');
+      expect(out, contains('<a href="http://foo.com">http://foo.com</a>'));
+    });
+
+    test('ftp / www / 裸網域不被連結化', () {
+      expect(_anchorCount(linkifyHtml('x ftp://foo.com y')), 0);
+      expect(_anchorCount(linkifyHtml('visit www.foo.com')), 0);
+      expect(_anchorCount(linkifyHtml('go to foo.com now')), 0);
+    });
+
+    test('尾端半形句點不吃進連結', () {
+      final out = linkifyHtml('see https://foo.com.');
+      expect(out, contains('<a href="https://foo.com">https://foo.com</a>'));
+      expect(out, contains('</a>.'));
+    });
+
+    test('尾端全形句號不吃進連結', () {
+      final out = linkifyHtml('詳見 https://foo.com。');
+      expect(out, contains('<a href="https://foo.com">https://foo.com</a>'));
+      expect(out, contains('</a>。'));
+    });
+
+    test('既有 <a href> 不被改、不雙重包覆', () {
+      final out = linkifyHtml('<a href="https://x.com">link</a>');
+      expect(out, contains('<a href="https://x.com">link</a>'));
+      expect(_anchorCount(out), 1);
+    });
+
+    test('既有 <a> 內文是網址也不產生巢狀 <a>', () {
+      final out = linkifyHtml('<a href="x">https://foo.com</a>');
+      expect(_anchorCount(out), 1);
+    });
+
+    test('屬性值內的網址不被當文字連結化', () {
+      final out = linkifyHtml('<img src="https://img.com/a.png">');
+      expect(out, isNot(contains('<a')));
+    });
+
+    test('同段多個網址各自連結化', () {
+      final out = linkifyHtml('a https://1.com b https://2.com');
+      expect(_anchorCount(out), 2);
+    });
+
+    test('無網址純文字語意不變', () {
+      expect(linkifyHtml('hello world'), 'hello world');
+    });
+
+    test('空字串回空字串', () {
+      expect(linkifyHtml(''), '');
+    });
+  });
+}

--- a/test/utils/html_linkify_test.dart
+++ b/test/utils/html_linkify_test.dart
@@ -38,6 +38,12 @@ void main() {
       expect(out, contains('</a>。'));
     });
 
+    test('連續尾端標點全部剝除', () {
+      final out = linkifyHtml('see https://foo.com).');
+      expect(out, contains('<a href="https://foo.com">https://foo.com</a>'));
+      expect(out, contains('</a>).'));
+    });
+
     test('既有 <a href> 不被改、不雙重包覆', () {
       final out = linkifyHtml('<a href="https://x.com">link</a>');
       expect(out, contains('<a href="https://x.com">link</a>'));

--- a/test/widgets/app_html_test.dart
+++ b/test/widgets/app_html_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_html.dart';
+
+void main() {
+  testWidgets('純文字網址被渲染成連結文字', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: AppHtml(data: 'visit https://example.com now')),
+      ),
+    );
+    // AppHtml 內部組一個 flutter_html 的 Html；連結文字應出現在 rich text 中。
+    expect(find.byType(Html), findsOneWidget);
+    expect(
+      find.textContaining('https://example.com', findRichText: true),
+      findsWidgets,
+    );
+  });
+}

--- a/test/widgets/app_html_test.dart
+++ b/test/widgets/app_html_test.dart
@@ -17,4 +17,30 @@ void main() {
       findsWidgets,
     );
   });
+
+  testWidgets('onLinkTap 已接上（callback 非 null）', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: AppHtml(data: 'see https://example.com')),
+      ),
+    );
+    final html = tester.widget<Html>(find.byType(Html));
+    expect(html.onLinkTap, isNotNull);
+  });
+
+  testWidgets('呼叫端 style 覆蓋預設 a 樣式', (tester) async {
+    final overrideAnchor = Style(color: Colors.red);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppHtml(
+            data: 'see https://example.com',
+            style: {'a': overrideAnchor},
+          ),
+        ),
+      ),
+    );
+    final html = tester.widget<Html>(find.byType(Html));
+    expect(identical(html.style['a'], overrideAnchor), isTrue);
+  });
 }

--- a/test/widgets/app_link_test.dart
+++ b/test/widgets/app_link_test.dart
@@ -5,6 +5,12 @@ import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/app_link.dart';
 
 void main() {
+  group('openExternalUrlString', () {
+    test('null URL 不丟例外、靜默返回', () async {
+      // onLinkTap 可能傳入 null；此分支不應觸碰 url_launcher 平台。
+      await expectLater(openExternalUrlString(null), completes);
+    });
+  });
   testWidgets('預設樣式：primary color，無底線', (tester) async {
     final theme = buildDarkTheme();
     await tester.pumpWidget(


### PR DESCRIPTION
## 摘要

物品詳情 dialog 內若有純文字網址（非可點擊），現在會自動變成可點擊的連結並以系統瀏覽器開啟。內容裡本來就寫成 `<a href>` 的連結也一併可點，點擊行為一致。

涵蓋兩處 HoYoWiki 內容：標題區的詞條說明（`desc`）與圖片區的 gallery 說明（`descHtml`）。

## 設計重點

- **保守偵測**：只比對 `http://` 與 `https://` 開頭的完整網址；不處理 `www.` 與裸網域（`foo.com`），避免把版本號、檔名等含點字串誤判成網址。
- **parser-based linkify**：`linkifyHtml`（`lib/utils/html_linkify.dart`）用 `html` 套件的 DOM parser 只走訪 text node，既有 `<a>` 子樹整棵略過（不產生巢狀 `<a>`），屬性值（如 `href="…"`）也不會被誤改。解析意外失敗時回傳原字串、描述區不致渲染中斷。
- **行內連結風格對齊現有應用程式**：採靜態 primary 連結色（`linkBaseColor`）+ 底線，與既有 release notes 行內連結一致；不做 per-link hover。
- **共用、不造輪子**：抽出 `openExternalUrlString(String?)` 供 `AppLink` 與新的 `AppHtml` 共用；新增 `AppHtml` 包裝 `flutter_html` 的 `Html`，統一 linkify + `onLinkTap` + 連結色。

## 變更檔案

- 新增 `lib/utils/html_linkify.dart`（純函式 `linkifyHtml`）
- 新增 `lib/widgets/app_html.dart`（`AppHtml` 共用元件）
- `lib/widgets/app_link.dart`：抽出 `openExternalUrlString` helper，`AppLink._handleTap` 改為委派
- `lib/widgets/dialogs/gacha_item_detail_dialog.dart`：兩處 `Html` → `AppHtml`
- `pubspec.yaml`：`html` 由傳遞依賴提升為顯式依賴

## 測試

- `linkifyHtml` 單元測試（12 個）：http/https 命中、ftp/www/裸網域不中、半／全形尾端標點不吃進連結、既有 `<a>` 不雙包、屬性值不碰、多網址、連續尾端標點。
- `AppHtml` widget 測試（3 個）：render、`onLinkTap` 已接上、呼叫端 `style` 覆蓋預設 `'a'`。
- `openExternalUrlString` null-guard 測試。
- 既有物品詳情 dialog 測試全綠（無回歸）。
- 全套 988 tests passed，`flutter analyze` 無 issue。

## 設計與計畫文件

- `docs/superpowers/specs/2026-06-18-item-detail-linkify-urls-design.md`
- `docs/superpowers/plans/2026-06-18-item-detail-linkify-urls.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)