### PR TITLE
feat(timeline): luck-based coloring across timeline, records, and share image

### DIFF
--- a/docs/superpowers/plans/2026-06-19-timeline-luck-color.md
+++ b/docs/superpowers/plans/2026-06-19-timeline-luck-color.md
@@ -1,0 +1,1159 @@
+# Timeline Luck Color Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 時間軸（及所有「抽數」語意呈現處）依「抽數 / 該池保底」比例呈綠（歐）／金（普通）／紅（非）三階色，並把卡池調色盤移出歐非色帶、補橫向年/月分隔。
+
+**Architecture:** 新增純函式 `luckTierFor`／`luckColorFor`（`luck_palette.dart`）與在地化標籤＋圖例 widget（`luck_legend.dart`）；`gacha_types.dart` 新增集中查詢 helper `gachaTypeFor`／`pityThresholdFor`。兩個時間軸 widget 與記錄列表把抽數相關顏色換成歐非色；卡池調色盤整體移到 cyan→magenta 弧段。
+
+**Tech Stack:** Flutter／Dart、FVM 釘版、Riverpod、flutter gen-l10n（ARB i18n）。
+
+## Global Constraints
+
+- 回答與設計文件用繁體中文 (台灣)；CJK 全形標點，但**省略號一律用 ASCII `...`**。
+- commit message／PR 標題用英文、conventional commits。
+- 所有 Flutter／Dart 指令優先用 `fvm`（找不到才退回 `flutter`／`dart`）。
+- 嚴禁重複造輪子：顏色重用既有 `GachaTokens.stateSuccess`／`stateWarning`／`stateDanger`，**不新增 token**；查詢集中到 `gachaTypeFor`／`pityThresholdFor`。
+- 所有宣告（含 private）寫一行 `///` dartdoc（Flutter override 例外）。
+- 純 UI 顏色呈現，**不埋 log**。
+- 不改 `TimelineEntry` 資料模型；不新增設定選項。
+- 分級門檻（具名常數，verbatim）：`ratio <= 0.5` 歐、`0.5 < ratio <= 0.8` 普通、`ratio > 0.8` 非；`ratio = pulls / pityThreshold`。
+- 未知卡池 fallback 保底為 `5★90 / 4★10`（原神慣例，**非**姐妹的 80）。
+- 提交前依序 `fvm dart format lib/ test/`、`fvm flutter analyze`（No issues found!）、`fvm flutter test`（All tests passed!）全綠；不要 `--no-verify`；不要主動 push。
+- 已在分支 `feat/timeline-luck-color`，spec 已 commit。
+
+## File Structure
+
+| 檔案 | 責任 |
+|---|---|
+| `lib/data/gacha_types.dart`（改） | 新增 `gachaTypeFor` / `pityThresholdFor` 查詢 helper |
+| `lib/widgets/luck_palette.dart`（新） | `LuckTier` enum、`luckTierFor`、`luckColorFor` 純函式 |
+| `lib/widgets/luck_legend.dart`（新） | `luckTierLabel`、`LuckLegend` widget |
+| `lib/l10n/app_*.arb`（改 ×9） | 3 個歐非分級 key |
+| `lib/widgets/cards/timeline_horizontal.dart`（改） | 節點/名稱/抽數歐非色、tooltip、移除 colors、年/月帶 |
+| `lib/widgets/cards/timeline_vertical.dart`（改） | 節點/名稱/抽數歐非色、meta Text.rich、tooltip、`showLuckLegend` |
+| `lib/widgets/data/sortable_table.dart`（改） | 「保底內」欄歐非色 |
+| `lib/widgets/banner_colors.dart`（改） | 卡池調色盤移到 cyan→magenta |
+| `lib/pages/overview_page.dart`（改） | `TimelineVertical(showLuckLegend: true)` |
+| `lib/pages/banner_page.dart`（改） | `ChartCard(legend: LuckLegend())`、移除 `colors` |
+| `lib/widgets/share/share_card.dart`（改） | `TimelineVertical(showLuckLegend: true)` |
+
+---
+
+### Task 1: `gacha_types.dart` 集中查詢 helper
+
+**Files:**
+- Modify: `lib/data/gacha_types.dart`（檔尾、`convertibleGachaTypes` 之後新增 top-level 函式）
+- Test: `test/data/gacha_types_test.dart`（既有檔，`void main()` 內新增 group）
+
+**Interfaces:**
+- Produces:
+  - `GachaType gachaTypeFor(String gachaType)` — 查 `gachaTypes`，查無回傳帶 `5★90/4★10`、`category: GachaCategory.gacha` 的 fallback。
+  - `int pityThresholdFor(String gachaType, int rank)` — 回傳該池該 rank 保底門檻；rank 無對應時回傳主保底門檻。
+
+- [ ] **Step 1: 寫失敗測試**（在 `test/data/gacha_types_test.dart` 的 `void main() {` 內，既有 group 之後新增）
+
+```dart
+  group('gachaTypeFor', () {
+    test('已知 gachaType 回傳對應 GachaType', () {
+      expect(gachaTypeFor('301').nameKey, 'gachaTypeCharacter');
+      expect(gachaTypeFor('1000').nameKey, 'gachaTypeOdesStandard');
+    });
+
+    test('未知 gachaType 回傳 fallback（5★90 / 4★10 / gacha）', () {
+      final t = gachaTypeFor('999');
+      expect(t.gachaType, '999');
+      expect(t.primaryPity.threshold, 90);
+      expect(t.secondaryPity!.threshold, 10);
+      expect(t.category, GachaCategory.gacha);
+    });
+  });
+
+  group('pityThresholdFor', () {
+    test('角色池 5★ → 90', () => expect(pityThresholdFor('301', 5), 90));
+    test('武器池 5★ → 80', () => expect(pityThresholdFor('302', 5), 80));
+    test('新手池 5★ → 20', () => expect(pityThresholdFor('100', 5), 20));
+    test('頌願活動 5★ → 70', () => expect(pityThresholdFor('2000', 5), 70));
+    test('頌願常駐 4★ → 70', () => expect(pityThresholdFor('1000', 4), 70));
+    test('一般祈願 4★ → 10', () => expect(pityThresholdFor('301', 4), 10));
+    test('未知池 5★ → fallback 90', () => expect(pityThresholdFor('999', 5), 90));
+    test('rank 無對應回傳主保底門檻', () {
+      expect(pityThresholdFor('301', 3), 90); // 角色池主保底 5★90
+      expect(pityThresholdFor('1000', 5), 70); // 頌願常駐主保底 4★70
+    });
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/data/gacha_types_test.dart`
+Expected: FAIL（`gachaTypeFor` / `pityThresholdFor` 未定義）
+
+- [ ] **Step 3: 實作**（`lib/data/gacha_types.dart` 結尾，`convertibleGachaTypes` 之後新增）
+
+```dart
+
+/// 依 [gachaType] 字串查 [GachaType]；查無時回傳帶預設保底（5★90／4★10、
+/// 一般祈願分類）的 fallback。沿用 timeline 既有的未知卡池保底假設。
+GachaType gachaTypeFor(String gachaType) => gachaTypes.firstWhere(
+  (t) => t.gachaType == gachaType,
+  orElse: () => GachaType(
+    gachaType: gachaType,
+    nameKey: gachaType,
+    category: GachaCategory.gacha,
+    pities: const [
+      PityRule(rank: 5, threshold: 90),
+      PityRule(rank: 4, threshold: 10),
+    ],
+  ),
+);
+
+/// 查 [gachaType] 池中 [rank] 的保底門檻；該池無對應 [rank] 規則時，回傳主保底
+/// 門檻當保守值。
+int pityThresholdFor(String gachaType, int rank) {
+  final type = gachaTypeFor(gachaType);
+  for (final p in type.pities) {
+    if (p.rank == rank) return p.threshold;
+  }
+  return type.primaryPity.threshold;
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/data/gacha_types_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/data/gacha_types.dart test/data/gacha_types_test.dart
+git commit -m "feat(gacha-types): add gachaTypeFor/pityThresholdFor lookup helpers"
+```
+
+---
+
+### Task 2: `luck_palette.dart` 歐非分級純函式
+
+**Files:**
+- Create: `lib/widgets/luck_palette.dart`
+- Test: `test/widgets/luck_palette_test.dart`
+
+**Interfaces:**
+- Consumes: `GachaTokens`（`lib/theme/tokens.dart`，`.dark`/`.light` const 與 `stateSuccess`/`stateWarning`/`stateDanger`）。
+- Produces:
+  - `enum LuckTier { lucky, average, unlucky }`
+  - `LuckTier luckTierFor(int pulls, int pityThreshold)`
+  - `Color luckColorFor(LuckTier tier, GachaTokens t)`
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/luck_palette_test.dart`）
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+
+void main() {
+  group('luckTierFor — 90 池', () {
+    test('45 抽（ratio 0.5）= 歐', () => expect(luckTierFor(45, 90), LuckTier.lucky));
+    test('46 抽 = 普通', () => expect(luckTierFor(46, 90), LuckTier.average));
+    test('72 抽（ratio 0.8）= 普通', () => expect(luckTierFor(72, 90), LuckTier.average));
+    test('73 抽 = 非', () => expect(luckTierFor(73, 90), LuckTier.unlucky));
+    test('90 抽 = 非', () => expect(luckTierFor(90, 90), LuckTier.unlucky));
+    test('91 抽（ratio > 1）= 非', () => expect(luckTierFor(91, 90), LuckTier.unlucky));
+  });
+
+  group('luckTierFor — 80 池', () {
+    test('40 抽 = 歐', () => expect(luckTierFor(40, 80), LuckTier.lucky));
+    test('41 抽 = 普通', () => expect(luckTierFor(41, 80), LuckTier.average));
+    test('64 抽 = 普通', () => expect(luckTierFor(64, 80), LuckTier.average));
+    test('65 抽 = 非', () => expect(luckTierFor(65, 80), LuckTier.unlucky));
+  });
+
+  group('luckTierFor — 20 池', () {
+    test('10 抽 = 歐', () => expect(luckTierFor(10, 20), LuckTier.lucky));
+    test('11 抽 = 普通', () => expect(luckTierFor(11, 20), LuckTier.average));
+    test('16 抽 = 普通', () => expect(luckTierFor(16, 20), LuckTier.average));
+    test('17 抽 = 非', () => expect(luckTierFor(17, 20), LuckTier.unlucky));
+  });
+
+  group('luckTierFor — 70 池', () {
+    test('35 抽 = 歐', () => expect(luckTierFor(35, 70), LuckTier.lucky));
+    test('36 抽 = 普通', () => expect(luckTierFor(36, 70), LuckTier.average));
+    test('56 抽 = 普通', () => expect(luckTierFor(56, 70), LuckTier.average));
+    test('57 抽 = 非', () => expect(luckTierFor(57, 70), LuckTier.unlucky));
+  });
+
+  test('pityThreshold <= 0 防呆 = 非', () {
+    expect(luckTierFor(1, 0), LuckTier.unlucky);
+  });
+
+  group('luckColorFor 對應既有語意色', () {
+    const t = GachaTokens.dark;
+    test('歐 → stateSuccess', () => expect(luckColorFor(LuckTier.lucky, t), t.stateSuccess));
+    test('普通 → stateWarning', () => expect(luckColorFor(LuckTier.average, t), t.stateWarning));
+    test('非 → stateDanger', () => expect(luckColorFor(LuckTier.unlucky, t), t.stateDanger));
+  });
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/luck_palette_test.dart`
+Expected: FAIL（`luck_palette.dart` 不存在）
+
+- [ ] **Step 3: 實作**（`lib/widgets/luck_palette.dart`）
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+
+/// 歐非分級：依「抽到該筆所花抽數 / 該池保底門檻」的比例分三階。
+enum LuckTier {
+  /// 歐：半個保底內出貨。
+  lucky,
+
+  /// 普通。
+  average,
+
+  /// 非：進入軟保底區（接近硬保底）。
+  unlucky,
+}
+
+/// 歐（綠）上界比例：抽數在保底的一半以內視為歐。
+const double _luckyMaxRatio = 0.5;
+
+/// 普通（金）上界比例：超過此比例即進入軟保底區，視為非。
+const double _averageMaxRatio = 0.8;
+
+/// 依 [pulls] 相對 [pityThreshold] 的比例回傳分級。
+/// `ratio <= 0.5` 歐；`<= 0.8` 普通；其餘（含 ratio > 1）非。
+/// [pityThreshold] <= 0 時防呆視為非（避免除以零；正常資料不會發生）。
+LuckTier luckTierFor(int pulls, int pityThreshold) {
+  if (pityThreshold <= 0) return LuckTier.unlucky;
+  final ratio = pulls / pityThreshold;
+  if (ratio <= _luckyMaxRatio) return LuckTier.lucky;
+  if (ratio <= _averageMaxRatio) return LuckTier.average;
+  return LuckTier.unlucky;
+}
+
+/// 將分級映射到既有語意色（綠 / 金 / 紅），不新增 token。
+Color luckColorFor(LuckTier tier, GachaTokens t) => switch (tier) {
+  LuckTier.lucky => t.stateSuccess,
+  LuckTier.average => t.stateWarning,
+  LuckTier.unlucky => t.stateDanger,
+};
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/widgets/luck_palette_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/luck_palette.dart test/widgets/luck_palette_test.dart
+git commit -m "feat(luck): add luck tier palette (luckTierFor/luckColorFor)"
+```
+
+---
+
+### Task 3: i18n — 歐非分級 ARB key（9 個實翻語系）
+
+**Files:**
+- Modify: `lib/l10n/app_zh.arb`（zh-Hant 模板）、`app_zh_Hans.arb`、`app_en.arb`、`app_es.arb`、`app_fr.arb`、`app_ja.arb`、`app_pt_BR.arb`、`app_th.arb`、`app_vi.arb`
+- 不碰 22 個空殼（4-key）ARB。
+
+**Interfaces:**
+- Produces（`fvm flutter gen-l10n` 後）：`AppLocalizations` 上的 getter `luckTierLucky`、`luckTierAverage`、`luckTierUnlucky`（皆 `String`，無 placeholder）。
+
+- [ ] **Step 1: 在每個實翻 ARB 的最後一個 key 後（檔尾 `}` 前）插入 3 個 key**
+
+三個 key 為純字串、無 placeholder，依本專案慣例**不加 `@description`**（模板亦同）。各語系值：
+
+| ARB | luckTierLucky | luckTierAverage | luckTierUnlucky |
+|---|---|---|---|
+| `app_zh.arb` | 歐 | 普通 | 非 |
+| `app_zh_Hans.arb` | 欧 | 普通 | 非 |
+| `app_en.arb` | Lucky | Average | Unlucky |
+| `app_ja.arb` | 強運 | 普通 | 不運 |
+| `app_es.arb` | Con suerte | Normal | Sin suerte |
+| `app_fr.arb` | Chanceux | Normal | Malchanceux |
+| `app_pt_BR.arb` | Sortudo | Normal | Azarado |
+| `app_th.arb` | โชคดี | ปกติ | โชคร้าย |
+| `app_vi.arb` | May mắn | Bình thường | Kém may |
+
+> zh-Hant / zh-Hans / en / ja 逐字對齊姐妹 PR #37；es/fr/pt-BR/th/vi 按語意翻，**插入前對照 `docs/術語表.md`**，若術語表有「歐/非」官方對應就改用官方譯名。
+
+每檔在現有最後一個 key 後加逗號，再加（以 `app_en.arb` 為例）：
+
+```json
+  "luckTierLucky": "Lucky",
+  "luckTierAverage": "Average",
+  "luckTierUnlucky": "Unlucky"
+```
+
+（注意 JSON 尾逗號：插在中間就帶逗號、插在最後一個 key 則該 key 不帶尾逗號。）
+
+- [ ] **Step 2: 重新產生 l10n**
+
+Run: `fvm flutter gen-l10n`
+Expected: 無錯誤；`lib/l10n/generated/app_localizations.dart` 出現 3 個 getter。
+
+- [ ] **Step 3: 驗證 getter 存在（暫時性檢查，不留測試）**
+
+Run: `fvm flutter analyze lib/l10n/generated/app_localizations.dart`
+Expected: No issues found!（getter 已生成）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "feat(l10n): add luck tier labels (lucky/average/unlucky) to translated ARBs"
+```
+
+---
+
+### Task 4: `luck_legend.dart` — 標籤 helper + 圖例 widget
+
+**Files:**
+- Create: `lib/widgets/luck_legend.dart`
+- Test: `test/widgets/luck_legend_test.dart`
+
+**Interfaces:**
+- Consumes: `LuckTier`、`luckColorFor`（Task 2）；`luckTierLucky/Average/Unlucky`（Task 3）；`GachaTokens`、`AppSpacing`（`theme/tokens.dart`）；`theme.gacha` 擴充 getter。
+- Produces:
+  - `String luckTierLabel(LuckTier tier, AppLocalizations l)`
+  - `class LuckLegend extends StatelessWidget`（const 建構）
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/luck_legend_test.dart`）
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+
+void main() {
+  testWidgets('LuckLegend 顯示三個分級標籤', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAppTheme(Brightness.dark),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: const Scaffold(body: LuckLegend()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    expect(find.text(l.luckTierLucky), findsOneWidget);
+    expect(find.text(l.luckTierAverage), findsOneWidget);
+    expect(find.text(l.luckTierUnlucky), findsOneWidget);
+  });
+}
+```
+
+> 若 `buildAppTheme` 簽名不同，依 `lib/theme/app_theme.dart` 既有 export 調整（既有 widget 測試如 `timeline_vertical_test.dart` 已有建立含 `theme.gacha` 的 MaterialApp 範例，照抄其 pump helper 即可）。
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/luck_legend_test.dart`
+Expected: FAIL（`luck_legend.dart` 不存在）
+
+- [ ] **Step 3: 實作**（`lib/widgets/luck_legend.dart`）
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+
+/// 將歐非分級對應到目前語言的標籤（供 tooltip 與 [LuckLegend] 共用）。
+String luckTierLabel(LuckTier tier, AppLocalizations l) => switch (tier) {
+  LuckTier.lucky => l.luckTierLucky,
+  LuckTier.average => l.luckTierAverage,
+  LuckTier.unlucky => l.luckTierUnlucky,
+};
+
+/// 時間軸歐非色圖例：歐／普通／非 三個色點＋標籤，低視窗寬度可換行。
+/// 刻意不標抽數——跨池保底門檻不同，標數字會誤導。
+class LuckLegend extends StatelessWidget {
+  /// 建立 [LuckLegend]。
+  const LuckLegend({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final l = AppLocalizations.of(context)!;
+    return Wrap(
+      spacing: AppSpacing.l,
+      runSpacing: AppSpacing.xs,
+      children: [
+        for (final tier in LuckTier.values)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  color: luckColorFor(tier, tokens),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Text(
+                luckTierLabel(tier, l),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: tokens.textSecondary,
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `fvm flutter test test/widgets/luck_legend_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/luck_legend.dart test/widgets/luck_legend_test.dart
+git commit -m "feat(luck): add LuckLegend widget and luckTierLabel helper"
+```
+
+---
+
+### Task 5: 垂直時間軸套歐非色 + meta + tooltip + 圖例
+
+**Files:**
+- Modify: `lib/widgets/cards/timeline_vertical.dart`
+- Modify: `lib/pages/overview_page.dart:430`、`lib/widgets/share/share_card.dart:434`
+- Test: `test/widgets/cards/timeline_vertical_test.dart`
+
+**Interfaces:**
+- Consumes: `pityThresholdFor`（T1）、`luckTierFor`／`luckColorFor`（T2）、`luckTierLabel`／`LuckLegend`（T4）。
+- Produces: `TimelineVertical` 新增可選具名參數 `bool showLuckLegend = false`。
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/cards/timeline_vertical_test.dart` 新增；沿用該檔既有 pump helper 與 `TimelineEntry` 建構）
+
+```dart
+  testWidgets('節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+    final entry = TimelineEntry(
+      name: '刻晴',
+      gachaType: '301', // 90 池
+      time: DateTime(2026, 6, 1),
+      pullsSincePrev: 40, // 40/90 ≈ 0.44 → 歐
+    );
+    await pumpTimelineVertical(tester, entries: [entry], targetRank: 5);
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    final expected = '刻晴 · ${l.luckTierLucky} · ${l.timelineSinceLast(40)}';
+    expect(find.byTooltip(expected), findsWidgets);
+  });
+
+  testWidgets('showLuckLegend 時顯示圖例', (tester) async {
+    await pumpTimelineVertical(
+      tester,
+      entries: const [],
+      targetRank: 5,
+      nowPulls: 10,
+      showLuckLegend: true,
+    );
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    expect(find.text(l.luckTierLucky), findsOneWidget);
+  });
+```
+
+> 若既有檔無 `pumpTimelineVertical` helper，依該檔現有 testWidgets 的 MaterialApp 建構抽一個，並讓它接受 `showLuckLegend`。
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/cards/timeline_vertical_test.dart`
+Expected: FAIL（`showLuckLegend` 參數不存在 / tooltip 文案不符）
+
+- [ ] **Step 3a: 加 import 與 `showLuckLegend` 參數**
+
+`timeline_vertical.dart` 頂部 import 區加：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+```
+
+`TimelineVertical` 建構子（`required this.isAcrossBanners` 之後）加參數，並新增 field：
+
+```dart
+    this.showLuckLegend = false,
+```
+
+```dart
+  /// 為 true 時在卡片底部釘上 [LuckLegend]（即使 entries 溢出被裁仍可見）。
+  final bool showLuckLegend;
+```
+
+- [ ] **Step 3b: `container()` 加底部圖例**
+
+把 `container()` 內 `final Widget content = fillHeight ? ... : body;` 與 `return Container(...)` 改為：在 `showLuckLegend` 時於邊框內底部排 `LuckLegend`：
+
+```dart
+      final Widget content;
+      if (showLuckLegend) {
+        const legend = Padding(
+          padding: EdgeInsets.only(top: AppSpacing.s),
+          child: LuckLegend(),
+        );
+        content = fillHeight
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    child: ClipRect(
+                      child: OverflowBox(
+                        minHeight: 0,
+                        maxHeight: double.infinity,
+                        alignment: Alignment.topCenter,
+                        child: body,
+                      ),
+                    ),
+                  ),
+                  legend,
+                ],
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [body, legend],
+              );
+      } else {
+        content = fillHeight
+            ? ClipRect(
+                child: OverflowBox(
+                  minHeight: 0,
+                  maxHeight: double.infinity,
+                  alignment: Alignment.topCenter,
+                  child: body,
+                ),
+              )
+            : body;
+      }
+```
+
+> WHY：`AppSpacing.s` 為 const，`Padding` 與 `LuckLegend` 皆 const → 可宣告 `const legend`。`fillHeight` 路徑用 `Expanded` 占滿剩餘高並自行 `ClipRect` 裁切，圖例釘底部恆可見。
+
+- [ ] **Step 3c: 節點/名稱套歐非色 + tooltip**
+
+`_EntryRow` 新增 `targetRank` field 與建構參數：
+
+```dart
+    required this.targetRank,
+```
+
+```dart
+  /// 主要顯示稀有度，用於查保底門檻換算歐非色。
+  final int targetRank;
+```
+
+在 `TimelineVertical.build` 的 `for (var i = 0; ...)` 內 `_EntryRow(...)` 補 `targetRank: targetRank,`。
+
+`_EntryRow.build` 開頭，把 `final accent = colors.colorFor(entry.gachaType);` 改為計算歐非：
+
+```dart
+    final rank = entry.sourceRecord?.rankType ?? targetRank;
+    final pity = pityThresholdFor(entry.gachaType, rank);
+    final tier = luckTierFor(entry.pullsSincePrev, pity);
+    final luck = luckColorFor(tier, tokens);
+```
+
+- `_nameRow` 內 `color: colors.colorFor(entry.gachaType)` → `color: luck`。注意 `_nameRow` 目前是 getter；改為**方法** `Widget _nameRow(Color nameColor)`，或在 `build` 內就地建構名稱 Row 並用 `luck`。最小改法：把 getter 改為 `Widget _nameRowWith(Color color)` 並在兩處呼叫端（`build` 內 Tooltip child）傳 `luck`。
+- 節點 `_Node(color: accent, ...)` → `_Node(color: luck, ...)`。
+- 三處 `Tooltip(message: entry.name, ...)` 中，**節點那一個**（`SizedBox(width: _haloSize)` 外層）的 message 改為：
+
+```dart
+            message:
+                '${entry.name} · ${luckTierLabel(tier, l)} · '
+                '${l.timelineSinceLast(entry.pullsSincePrev)}',
+```
+
+（名稱列與 meta 列的 Tooltip 維持只顯示 `entry.name`。）
+
+- [ ] **Step 3d: meta 行卡池名稱用卡池色、N 抽用歐非色**
+
+把 meta 的 `Text('${...} · ${_bannerName(...)} · ${l.timelineSinceLast(...)}', ...)` 改為 `Text.rich`：
+
+```dart
+                  Text.rich(
+                    TextSpan(
+                      style: TextStyle(
+                        color: tokens.textMuted,
+                        fontSize: 12,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                      children: [
+                        TextSpan(text: '${_formatShortDate(entry.time)} · '),
+                        TextSpan(
+                          text: _bannerName(entry.gachaType, l),
+                          style: TextStyle(
+                            color: colors.colorFor(entry.gachaType),
+                          ),
+                        ),
+                        const TextSpan(text: ' · '),
+                        TextSpan(
+                          text: l.timelineSinceLast(entry.pullsSincePrev),
+                          style: TextStyle(color: luck),
+                        ),
+                      ],
+                    ),
+                  ),
+```
+
+（外層仍包在原 `Tooltip(message: entry.name, ...)` 內。）
+
+- [ ] **Step 3e: `_bannerName` 改用 `gachaTypeFor`（DRY）**
+
+把 `_bannerName` 內整段 `gachaTypes.firstWhere(... orElse: GachaType(...))` 改為：
+
+```dart
+  /// 依 [gachaType] 查在地化卡池名稱；查無時回傳帶預設保底的 fallback 名稱。
+  String _bannerName(String gachaType, AppLocalizations l) =>
+      gachaTypeFor(gachaType).resolveName(l);
+```
+
+import 區確認已有 `gacha_types.dart`（既有）。
+
+- [ ] **Step 3f: 呼叫端傳 `showLuckLegend: true`**
+
+`lib/pages/overview_page.dart` 的 `TimelineVertical(... isAcrossBanners: true,)` 後加 `showLuckLegend: true,`。
+`lib/widgets/share/share_card.dart` 的 `TimelineVertical(... fillHeight: true,)` 後加 `showLuckLegend: true,`。
+
+- [ ] **Step 4: 跑測試**
+
+Run: `fvm flutter test test/widgets/cards/timeline_vertical_test.dart`
+Expected: PASS（既有斷言若驗證節點＝卡池色，需同步改為歐非色預期）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/cards/timeline_vertical.dart lib/pages/overview_page.dart lib/widgets/share/share_card.dart test/widgets/cards/timeline_vertical_test.dart
+git commit -m "feat(timeline): luck-color vertical timeline nodes, names, pulls, tooltip, legend"
+```
+
+---
+
+### Task 6: 橫向時間軸套歐非色 + tooltip + 圖例 + 移除 colors
+
+**Files:**
+- Modify: `lib/widgets/cards/timeline_horizontal.dart`
+- Modify: `lib/pages/banner_page.dart:282-300`
+- Test: `test/widgets/cards/timeline_horizontal_test.dart`
+
+**Interfaces:**
+- Consumes: `pityThresholdFor`（T1）、`luckTierFor`／`luckColorFor`（T2）、`luckTierLabel`／`LuckLegend`（T4）。
+- Produces: `TimelineHorizontal` 移除 `colors` 參數；節點/名稱/抽數呈歐非色。
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/cards/timeline_horizontal_test.dart` 新增）
+
+```dart
+  testWidgets('橫向節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+    final entry = TimelineEntry(
+      name: '魈',
+      gachaType: '301',
+      time: DateTime(2026, 6, 1),
+      pullsSincePrev: 85, // 85/90 ≈ 0.94 → 非
+    );
+    await pumpTimelineHorizontal(tester, entries: [entry], targetRank: 5);
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    final expected = '魈 · ${l.luckTierUnlucky} · ${l.timelineSinceLast(85)}';
+    expect(find.byTooltip(expected), findsOneWidget);
+  });
+```
+
+> `pumpTimelineHorizontal` 依該檔既有 testWidgets 抽出，並**移除**對 `colors:` 的傳入。
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/cards/timeline_horizontal_test.dart`
+Expected: FAIL
+
+- [ ] **Step 3a: import + 移除 `colors` 參數**
+
+頂部加：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+```
+
+`TimelineHorizontal` 移除 `required this.colors,` 與 `final BannerColors colors;`（dartdoc 一併移除）。
+build 內 `_EntryColumn(entry: entry, colors: widget.colors, tokens: tokens)` 移除 `colors:`，並把 `for (final entry in widget.entries)` 改為帶 index（給 Task 7 月份用，先改 `for (var i = 0; i < widget.entries.length; i++)`，傳 `entry: widget.entries[i]`）。
+
+> `bannerDistributionEntries` top-level 函式保留不動（其 `BannerColors` 參數獨立於 widget）。
+
+- [ ] **Step 3b: `_EntryColumn` 套歐非色 + tooltip**
+
+`_EntryColumn` 移除 `colors` field／參數；新增 `targetRank`：
+
+```dart
+    required this.targetRank,
+```
+
+```dart
+  /// 該卡池萃取的稀有度（5 或 4），用於查保底門檻。
+  final int targetRank;
+```
+
+`build` 開頭把 `final accent = colors.colorFor(entry.gachaType);` 改為：
+
+```dart
+    final rank = entry.sourceRecord?.rankType ?? targetRank;
+    final pity = pityThresholdFor(entry.gachaType, rank);
+    final tier = luckTierFor(entry.pullsSincePrev, pity);
+    final luck = luckColorFor(tier, tokens);
+```
+
+把兩處名稱 `Text(... style: TextStyle(color: accent ...))` 的 `accent` 改 `luck`；`_Node(color: accent, ...)` 改 `_Node(color: luck, ...)`。
+
+`Tooltip(message: entry.name, ...)` 的 message 改為：
+
+```dart
+      message:
+          '${entry.name} · ${luckTierLabel(tier, l)} · '
+          '${l.timelineSinceLast(entry.pullsSincePrev)}',
+```
+
+meta 的 `Text('${_formatShortDate(entry.time)} · ${l.timelineSinceLast(entry.pullsSincePrev)}', ...)` 改為 `Text.rich`，把抽數段套歐非色：
+
+```dart
+            Text.rich(
+              TextSpan(
+                style: TextStyle(
+                  color: tokens.textMuted,
+                  fontSize: 10,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+                children: [
+                  TextSpan(text: '${_formatShortDate(entry.time)} · '),
+                  TextSpan(
+                    text: l.timelineSinceLast(entry.pullsSincePrev),
+                    style: TextStyle(color: luck),
+                  ),
+                ],
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+            ),
+```
+
+build 內 `_EntryColumn(entry: widget.entries[i], tokens: tokens)` 補 `targetRank: widget.targetRank,`。
+
+- [ ] **Step 3c: banner_page 接線**
+
+`lib/pages/banner_page.dart` 包時間軸的 `ChartCard`（`icon: Icons.timeline`）加 `legend: const LuckLegend(),`；`TimelineHorizontal(...)` 移除 `colors: BannerColors.of(...)` 那行。確認該檔 import 有 `luck_legend.dart`；若移除 `colors` 後 `BannerColors` 不再被該檔其他處使用，移除其 import（analyze 會提示）。
+
+- [ ] **Step 4: 跑測試**
+
+Run: `fvm flutter test test/widgets/cards/timeline_horizontal_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/cards/timeline_horizontal.dart lib/pages/banner_page.dart test/widgets/cards/timeline_horizontal_test.dart
+git commit -m "feat(timeline): luck-color horizontal timeline, drop banner colors, add legend"
+```
+
+---
+
+### Task 7: 記錄列表「保底內」欄套歐非色
+
+**Files:**
+- Modify: `lib/widgets/data/sortable_table.dart`
+- Test: `test/widgets/data/sortable_table_test.dart`
+
+**Interfaces:**
+- Consumes: `pityThresholdFor`（T1）、`luckTierFor`／`luckColorFor`（T2）。`_Row` 新增 `final int mainRank;`。
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/data/sortable_table_test.dart` 新增；沿用既有 `RecordRow` 建構與 pump helper）
+
+```dart
+  testWidgets('保底內欄依抽數呈歐非色', (tester) async {
+    // 角色池(301) 5★：85 抽 → 非(紅 = stateDanger)
+    await pumpSortableTable(
+      tester,
+      rows: [makeRow(gachaType: '301', rankType: 5, mainPityIndex: 85)],
+      mainRank: 5,
+    );
+    final tokens = GachaTokens.dark;
+    final text = tester.widget<Text>(find.text('85'));
+    expect(text.style?.color, tokens.stateDanger);
+  });
+```
+
+> `makeRow` / `pumpSortableTable` 依既有測試 helper 命名調整；`mainPityIndex` 對應該欄值。
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/data/sortable_table_test.dart`
+Expected: FAIL（「85」目前為 muted 色）
+
+- [ ] **Step 3a: import + `_Row` 新增 `mainRank`**
+
+頂部加：
+
+```dart
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+```
+
+`_Row` 建構子（`required this.l,` 之後）加 `required this.mainRank,`，並新增 field：
+
+```dart
+  /// 該卡池主稀有度 rank，用於換算「保底內」欄歐非色。
+  final int mainRank;
+```
+
+`_Row(...)` 建構處（`l: l,` 之後）加 `mainRank: widget.mainRank,`。
+
+- [ ] **Step 3b: 「保底內」欄套歐非色**
+
+`_Row.build` 內，在 `final record = row.record;` 之後加：
+
+```dart
+    final pityLuck = luckColorFor(
+      luckTierFor(row.mainPityIndex, pityThresholdFor(record.gachaType, mainRank)),
+      tokens,
+    );
+```
+
+把 `mainPityIndex` 那格（`'${row.mainPityIndex}'`）的 `style: mutedNum` 改為：
+
+```dart
+              style: TextStyle(
+                color: pityLuck,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+```
+
+（`totalIndex` 那格維持 `mutedNum` 不動。）
+
+- [ ] **Step 4: 跑測試**
+
+Run: `fvm flutter test test/widgets/data/sortable_table_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/data/sortable_table.dart test/widgets/data/sortable_table_test.dart
+git commit -m "feat(records): luck-color the pity-progress column in record list"
+```
+
+---
+
+### Task 8: 卡池調色盤移出歐非色帶
+
+**Files:**
+- Modify: `lib/widgets/banner_colors.dart`
+- Test: `test/widgets/banner_colors_test.dart`（新建）
+
+**Interfaces:**
+- Consumes: `GachaTokens.dark`／`.light` 的 `stateSuccess`／`stateWarning`／`stateDanger`。
+- Produces: 8 個卡池色全部落在 cyan→magenta 弧段，皆 ≠ 三歐非色。
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/banner_colors_test.dart`）
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
+
+void main() {
+  for (final (label, brightness, tokens) in [
+    ('dark', Brightness.dark, GachaTokens.dark),
+    ('light', Brightness.light, GachaTokens.light),
+  ]) {
+    test('$label：任一卡池色不得等於歐非三色', () {
+      final colors = BannerColors.of(brightness);
+      final luck = {tokens.stateSuccess, tokens.stateWarning, tokens.stateDanger};
+      for (final t in gachaTypes) {
+        expect(
+          luck.contains(colors.colorFor(t.gachaType)),
+          isFalse,
+          reason: '${t.gachaType} 撞歐非色',
+        );
+      }
+      expect(luck.contains(colors.fallback), isFalse);
+    });
+  }
+}
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/banner_colors_test.dart`
+Expected: FAIL（現況 character=stateSuccess、weapon=stateDanger 撞色）
+
+- [ ] **Step 3: 改 `_dark` / `_light` 色值**（cyan→magenta 弧段；exact hex 可微調，唯一硬約束＝本測試通過）
+
+`_dark`：
+
+```dart
+  static const _dark = BannerColors(
+    character: Color(0xFF35BFD0), // 青藍
+    weapon: Color(0xFF4FA3E8), // 天藍
+    chronicled: Color(0xFF6E8BE6), // 矢車菊藍
+    standard: Color(0xFF8A7CE0), // 靛藍
+    beginner: Color(0xFFA86FD9), // 紫羅蘭
+    odesEvent: Color(0xFFC56FD0), // 蘭紫
+    odesStandard: Color(0xFFD96BA8), // 桃紅
+    fallback: Color(0xFF8A92A6), // 中性
+  );
+```
+
+`_light`：
+
+```dart
+  static const _light = BannerColors(
+    character: Color(0xFF1B92A8),
+    weapon: Color(0xFF2E6FC0),
+    chronicled: Color(0xFF4F5FC0),
+    standard: Color(0xFF6A4FC0),
+    beginner: Color(0xFF8A3FB0),
+    odesEvent: Color(0xFFA63FA8),
+    odesStandard: Color(0xFFB23A7E),
+    fallback: Color(0xFF6A7080),
+  );
+```
+
+更新類別 dartdoc：把「避開稀有度 token」改述為「避開歐非語意色（綠/金/紅）」並說明 WHY（節點已改歐非色、卡池色僅用於 meta 卡池名稱與分佈圖）。
+
+- [ ] **Step 4: 跑測試**
+
+Run: `fvm flutter test test/widgets/banner_colors_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/banner_colors.dart test/widgets/banner_colors_test.dart
+git commit -m "feat(banner-colors): shift palette to cyan-magenta arc clear of luck colors"
+```
+
+---
+
+### Task 9: 橫向時間軸年/月分隔
+
+**Files:**
+- Modify: `lib/widgets/cards/timeline_horizontal.dart`
+- Test: `test/widgets/cards/timeline_horizontal_test.dart`
+
+**Interfaces:**
+- Consumes: `l.timelineMonthLabel`（既有）。`_EntryColumn` 新增 `isMonthStart`、`showMonthDivider`。
+
+- [ ] **Step 1: 寫失敗測試**（`test/widgets/cards/timeline_horizontal_test.dart` 新增）
+
+```dart
+  testWidgets('跨月顯示年/月標籤', (tester) async {
+    final entries = [
+      TimelineEntry(name: 'A', gachaType: '301', time: DateTime(2026, 6, 2), pullsSincePrev: 10),
+      TimelineEntry(name: 'B', gachaType: '301', time: DateTime(2026, 5, 20), pullsSincePrev: 10),
+    ];
+    await pumpTimelineHorizontal(tester, entries: entries, targetRank: 5);
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    expect(find.text(l.timelineMonthLabel('2026', '06')), findsOneWidget);
+    expect(find.text(l.timelineMonthLabel('2026', '05')), findsOneWidget);
+  });
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `fvm flutter test test/widgets/cards/timeline_horizontal_test.dart`
+Expected: FAIL（無年/月標籤）
+
+- [ ] **Step 3a: 新增 `_monthBandHeight` 常數**
+
+`timeline_horizontal.dart` 常數區（`_haloSize` 附近）加：
+
+```dart
+/// 月份標籤帶高度。每欄頂部保留此高（組首填年/月、其餘留白），底部以等高
+/// spacer 對稱補回，使節點 y 不因標籤帶位移、仍對齊背景軸線。
+const double _monthBandHeight = 26;
+```
+
+- [ ] **Step 3b: build 計算 monthStart 並下傳**
+
+在 `build` 的 `return Stack(` 之前計算：
+
+```dart
+    // 每欄是否為其月份分組首欄（左→右 = 新→舊，某月最新一筆即該組起點）。
+    final monthStart = <bool>[];
+    int? prevYearMonth;
+    for (final entry in widget.entries) {
+      final ym = entry.time.year * 12 + entry.time.month;
+      monthStart.add(prevYearMonth != ym);
+      prevYearMonth = ym;
+    }
+```
+
+把 Task 6 的 `for (var i = 0; ...)` 內 `_EntryColumn(...)` 補：
+
+```dart
+                        isMonthStart: monthStart[i],
+                        showMonthDivider: monthStart[i] && i > 0,
+```
+
+- [ ] **Step 3c: `_EntryColumn` 加標籤帶 + 對稱 spacer + 分隔線**
+
+`_EntryColumn` 新增 field／參數：
+
+```dart
+    required this.isMonthStart,
+    required this.showMonthDivider,
+```
+
+```dart
+  /// 是否為其月份分組首欄；true 時頂部標籤帶顯示年/月。
+  final bool isMonthStart;
+
+  /// 是否在左側畫月份分隔線（月份交界、且非最左欄時為 true）。
+  final bool showMonthDivider;
+```
+
+`build` 內，計算 label：
+
+```dart
+    final monthLabel = isMonthStart
+        ? l.timelineMonthLabel(
+            entry.time.year.toString(),
+            entry.time.month.toString().padLeft(2, '0'),
+          )
+        : null;
+```
+
+把回傳的 `Tooltip(... child: SizedBox(width: _colWidth, child: Column(...)))` 包進帶分隔線的 `Container`，並在 `Column` children **最前**插入標籤帶、**最後**插入對稱 spacer：
+
+```dart
+      child: Container(
+        decoration: showMonthDivider
+            ? BoxDecoration(
+                border: Border(left: BorderSide(color: tokens.borderEmphasis)),
+              )
+            : null,
+        child: SizedBox(
+          width: _colWidth,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // 月份標籤帶（組首填年/月，其餘留白佔位）。
+              SizedBox(
+                height: _monthBandHeight,
+                child: monthLabel == null
+                    ? null
+                    : Align(
+                        alignment: Alignment.topCenter,
+                        child: Text(
+                          monthLabel,
+                          maxLines: 1,
+                          style: TextStyle(
+                            color: tokens.textSecondary,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.4,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        ),
+                      ),
+              ),
+              // ...（原有 icon+name / _Node / meta 不變）...
+              // 對稱補回標籤帶高度，使節點維持原垂直中心、對齊軸線。
+              const SizedBox(height: _monthBandHeight),
+            ],
+          ),
+        ),
+      ),
+```
+
+> WHY：頂部 `_monthBandHeight` 與底部 `_monthBandHeight` 等高 → 欄的垂直中心不變，節點仍落在背景軸線上。`_NowColumn` 不加帶、不受影響（其節點中心與 entry 欄一致）。
+
+- [ ] **Step 4: 跑測試**
+
+Run: `fvm flutter test test/widgets/cards/timeline_horizontal_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/cards/timeline_horizontal.dart test/widgets/cards/timeline_horizontal_test.dart
+git commit -m "feat(timeline): add year/month bands and dividers to horizontal timeline"
+```
+
+---
+
+### Task 10: 全面驗收
+
+**Files:** 無（驗收與修補）
+
+- [ ] **Step 1: 格式化**
+
+Run: `fvm dart format lib/ test/`
+Expected: 僅格式調整，無破壞。
+
+- [ ] **Step 2: 靜態分析**
+
+Run: `fvm flutter analyze`
+Expected: `No issues found!`（若有未使用 import，如 banner_page 的 `BannerColors`，移除）
+
+- [ ] **Step 3: 全套測試**
+
+Run: `fvm flutter test`
+Expected: `All tests passed!`
+
+- [ ] **Step 4: 手動目視（可選，build runner）**
+
+Run: `fvm flutter run -d windows`
+確認：單卡池頁時間軸綠/金/紅 + 年月帶 + 圖例；總覽頁 meta 卡池名稱卡池色、N 抽歐非色；記錄列表「保底內」歐非色；分享圖圖例釘底。
+
+- [ ] **Step 5: Commit（若有 analyze/format 修補）**
+
+```bash
+git add -A
+git commit -m "chore(timeline): formatting and analyze fixups for luck color feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 分級門檻／luckTierFor／luckColorFor → Task 2 ✓
+- gachaTypeFor／pityThresholdFor → Task 1 ✓
+- luck_legend / luckTierLabel → Task 4 ✓
+- 垂直時間軸節點/名稱/meta/tooltip/圖例 → Task 5 ✓
+- 橫向時間軸節點/名稱/meta/tooltip/移除 colors/圖例 → Task 6 ✓
+- 記錄列表「保底內」欄 → Task 7 ✓
+- 卡池調色盤挪移 + 不撞色測試 → Task 8 ✓
+- 橫向年/月分隔 → Task 9 ✓
+- i18n 9 實翻 ARB、4 對齊姐妹 / 5 語意翻 → Task 3 ✓
+- 呼叫端 overview/banner/share 接線 → Task 5（vertical）/ Task 6（horizontal）✓
+- 「現在」節點金色共用：已知接受、無需 task ✓
+- 全綠驗收 → Task 10 ✓
+
+**Placeholder scan：** 無 TBD/TODO；es/fr/pt-BR/th/vi 譯文為具體字串並註明對照術語表。
+
+**Type consistency：** `luckTierFor(int,int)→LuckTier`、`luckColorFor(LuckTier,GachaTokens)→Color`、`luckTierLabel(LuckTier,AppLocalizations)→String`、`pityThresholdFor(String,int)→int`、`gachaTypeFor(String)→GachaType` 全程一致；`entry.sourceRecord?.rankType ?? targetRank` 取稀有度一致；`_Row.mainRank` 與 `SortableTable.mainRank` 對齊。

--- a/docs/superpowers/specs/2026-06-19-timeline-luck-color-design.md
+++ b/docs/superpowers/specs/2026-06-19-timeline-luck-color-design.md
@@ -1,0 +1,261 @@
+# 時間軸歐非配色設計（對齊姐妹專案 PR #37）
+
+## 背景與目標
+
+時間軸目前以**卡池顏色**上色，整條同色、看不出每次出貨「歐還是非」。本設計改為依
+**抽到該筆所花的抽數相對該池保底門檻的比例**，呈現綠（歐）／金（普通）／紅（非）
+三階，並把這套歐非色一致延伸到所有「抽數」語意的呈現處，同時調整卡池調色盤避免與
+歐非色混淆。
+
+對齊姐妹專案 [wuthering-waves-convene-gacha-analyzer PR #37](https://github.com/GoneTone/wuthering-waves-convene-gacha-analyzer/pull/37)
+的設計與做法，並依本專案差異調整（保底門檻、頌願卡池、ARB 語系範圍）。
+
+## 分級門檻
+
+| 比例（`pulls / pity`） | 分級 | 顏色 token |
+|---|---|---|
+| `ratio <= 0.5` | 歐（lucky） | `stateSuccess`（綠） |
+| `0.5 < ratio <= 0.8` | 普通（average） | `stateWarning`（金/琥珀） |
+| `ratio > 0.8`（含 `> 1`） | 非（unlucky） | `stateDanger`（紅） |
+
+- 門檻 `0.5`／`0.8` 以具名常數定義，附 WHY 註解（綠＝半保底內、紅＝進入軟保底區）。
+- `pity <= 0` 防呆視為「非」（避免除以零；正常資料不會發生）。
+- 顏色一律**重用既有語意色**、**不新增 token**；中階是金/琥珀（非純黃），刻意接受。
+
+門檻依各卡池保底**自動換算**，本專案各池保底已定義於 `gachaTypes`：
+
+| 卡池 | gacha_type | 主稀有度 | 保底門檻 |
+|---|---|---|---|
+| 角色活動祈願 | 301 | 5★ | 90 |
+| 武器活動祈願 | 302 | 5★ | 80 |
+| 集錄祈願 | 500 | 5★ | 90 |
+| 常駐祈願 | 200 | 5★ | 90 |
+| 新手祈願 | 100 | 5★ | 20 |
+| 頌願活動 | 2000 | 5★ | 70 |
+| 頌願常駐 | 1000 | 4★ | 70 |
+
+頌願（odes）走同一 `BannerPage`／`TimelineVertical`，自動涵蓋。`頌願常駐` 主稀有度為
+4★，故門檻查詢一律用 `pityThresholdFor(gachaType, rank)` 帶 rank，rank 由 entry 的實際
+稀有度決定（缺值退回 targetRank）。
+
+## 架構與元件
+
+### 新增：`lib/widgets/luck_palette.dart`
+
+純函式核心，不 import l10n：
+
+```dart
+enum LuckTier { lucky, average, unlucky }
+
+/// 依「抽數 / 保底門檻」比例回傳分級。ratio <= 0.5 歐；<= 0.8 普通；其餘（含 > 1）非。
+/// pityThreshold <= 0 防呆視為非。
+LuckTier luckTierFor(int pulls, int pityThreshold);
+
+/// 將分級映射到既有語意色（綠 / 金 / 紅），不新增 token。
+Color luckColorFor(LuckTier tier, GachaTokens t);
+```
+
+`luckColorFor`：lucky → `stateSuccess`、average → `stateWarning`、unlucky → `stateDanger`。
+
+### 新增：`lib/widgets/luck_legend.dart`
+
+```dart
+/// 分級 → 在地化標籤（供 tooltip 與 LuckLegend 共用）。
+String luckTierLabel(LuckTier tier, AppLocalizations l);
+
+/// 歐非色圖例：歐／普通／非 三個色點＋在地化標籤，Wrap 可換行。
+class LuckLegend extends StatelessWidget { ... }
+```
+
+- 色點樣式對齊既有 `DistributionLegend`（10×10、圓角 2），但**不重用**——後者強制帶
+  count／百分比兩欄，不適合純色說明。
+- 刻意**不標抽數**——跨池保底門檻不同，標數字會誤導。
+
+### 修改：`lib/data/gacha_types.dart`
+
+新增集中查詢 helper，消除散落各處的 `firstWhere`：
+
+```dart
+/// 依 gachaType 字串查 GachaType；查無時回傳帶預設保底（5★90／4★10）的 fallback。
+GachaType gachaTypeFor(String gachaType);
+
+/// 查指定卡池、指定 rank 的保底門檻；該池無對應 rank 規則時回傳主保底門檻。
+int pityThresholdFor(String gachaType, int rank);
+```
+
+- `gachaTypeFor` 的 fallback 沿用 `timeline_vertical.dart` 現有 `_bannerName` 內那組
+  （未知 type → `PityRule(5,90)`＋`PityRule(4,10)`，`category: GachaCategory.gacha`）。
+  **與姐妹專案不同**：姐妹 fallback 主保底 80，本專案沿用既有 90（原神角色池慣例）。
+- 順手把 `timeline_vertical.dart` 的 `_bannerName` 改用 `gachaTypeFor`，移除重複的
+  firstWhere-with-fallback。
+
+### 修改：`lib/widgets/cards/timeline_vertical.dart`（總覽頁／分享圖）
+
+- `_EntryRow` 新增 `targetRank` 參數（由 `TimelineVertical.targetRank` 下傳）。
+- 顏色計算：
+  ```dart
+  final rank = entry.sourceRecord?.rankType ?? targetRank;
+  final pity = pityThresholdFor(entry.gachaType, rank);
+  final tier = luckTierFor(entry.pullsSincePrev, pity);
+  final luck = luckColorFor(tier, tokens);
+  ```
+  `luck` 用於**節點**與**物品名稱文字**（`_nameRow`）。
+- meta 行（原 `日期 · 卡池名稱 · N抽`）改用 `Text.rich`：
+  - 卡池名稱字串用 `colors.colorFor(entry.gachaType)` 上色（保留「哪個池子」辨識）；
+  - 「N 抽」那段套**歐非色**；
+  - 日期維持 `textMuted`。
+- 節點 `Tooltip` 訊息改為 `{名稱} · {luckTierLabel} · {timelineSinceLast(pulls)}`。
+- 新增可選參數 `bool showLuckLegend = false`；為 `true` 時把圖例**釘在卡片底部**：
+  - `fillHeight` 時 `container()` 內容區改 `Column[Expanded(裁切內容), LuckLegend]`，
+    確保 entries 溢出被裁時圖例仍可見；
+  - 非 `fillHeight` 時 `Column[內容, LuckLegend]` 自然排在內容下方。
+
+### 修改：`lib/widgets/cards/timeline_horizontal.dart`（單卡池頁）
+
+- `_EntryColumn` 新增 `targetRank` 參數（由 `TimelineHorizontal.targetRank` 下傳）。
+- 顏色計算同上，`luck` 取代原 `accent`，用於**節點**與**物品名稱文字**。
+- meta 行 `MM/dd · N抽` 的「N 抽」改用 `Text.rich` 套歐非色，日期維持 muted。
+- 節點 `Tooltip` 訊息補上 `分級 · N 抽`（同垂直版格式）。
+- 移除已無用的 `colors` 參數（節點/名稱改歐非色後卡池色未用於本元件）。
+  - `bannerDistributionEntries` helper 仍保留（供 `DistributionLegend` 分佈圖用），
+    其 `BannerColors` 參數不受影響。
+- 橫向圖例改走既有 `ChartCard.legend` slot：`banner_page` 在包住時間軸的 `ChartCard`
+  傳 `legend: const LuckLegend()`（該 ChartCard 目前無 legend，乾淨新增）。
+
+### 修改：`lib/widgets/data/sortable_table.dart`（記錄列表）
+
+- 「保底內」欄（`row.mainPityIndex`，距上次主稀有度的抽數）改用歐非色：
+  ```dart
+  luckColorFor(
+    luckTierFor(row.mainPityIndex, pityThresholdFor(record.gachaType, widget.mainRank)),
+    tokens,
+  )
+  ```
+  `_Row` 為此新增 `mainRank` 欄位（由 `SortableTable.mainRank` 下傳）。
+- 「總抽數」欄（`row.totalIndex`，累積序號、非運氣指標）維持 `textMuted`。
+
+### 修改：呼叫端
+
+- `lib/pages/overview_page.dart`：`TimelineVertical(... showLuckLegend: true)`。
+- `lib/pages/banner_page.dart`：包橫向時間軸的 `ChartCard` 傳 `legend: const LuckLegend()`；
+  `TimelineHorizontal` 不再傳 `colors`。
+- `lib/widgets/share/share_card.dart`：`TimelineVertical(... fillHeight: true,
+  showLuckLegend: true)`——圖例釘在卡片底部，即使 entries 溢出被裁仍可見。
+
+## 卡池調色盤挪移（避免撞色）
+
+**動機**：本專案 `BannerColors` 與語意色**直接撞 hex**：
+- `character` dark `0xFF46B07A` ＝ 歐綠 `stateSuccess`；
+- `weapon` dark `0xFFE6736B` ＝ 非紅 `stateDanger`；
+- `chronicled` 橘 ≈ 琥珀 `stateWarning`。
+
+歐非色與卡池名稱在 meta 行並存會混淆，故把 8 個卡池色（character / weapon / chronicled
+/ standard / beginner / odesEvent / odesStandard / fallback）整體重排到 **cyan → magenta**
+弧段，全部避開綠/琥珀/紅；dark 與 light 各一組（色相一致、light 加深）。**未新增任何
+token**。
+
+提案色相（exact hex 實作時可微調，唯一硬約束為下方測試）：
+
+| 卡池 | dark | light |
+|---|---|---|
+| character（青藍） | `0xFF35BFD0` | `0xFF1B92A8` |
+| weapon（天藍） | `0xFF4FA3E8` | `0xFF2E6FC0` |
+| chronicled（矢車菊藍） | `0xFF6E8BE6` | `0xFF4F5FC0` |
+| standard（靛藍） | `0xFF8A7CE0` | `0xFF6A4FC0` |
+| beginner（紫羅蘭） | `0xFFA86FD9` | `0xFF8A3FB0` |
+| odesEvent（蘭紫） | `0xFFC56FD0` | `0xFFA63FA8` |
+| odesStandard（桃紅） | `0xFFD96BA8` | `0xFFB23A7E` |
+| fallback（中性，不動） | `0xFF8A92A6` | `0xFF6A7080` |
+
+**約束固化**：`test/widgets/banner_colors_test.dart` 新增斷言「任一卡池色不得等於該主題
+的 `stateSuccess`／`stateWarning`／`stateDanger`」（dark + light 各一）。
+
+**取捨**：原 `BannerColors` 註解要求「卡池色避開稀有度 token（5★金/4★紫/3★藍/2★灰）」；
+節點改歐非色後卡池色不再上節點、只用於 meta 卡池名稱小字與分佈圖，此約束放寬，改以
+**避開歐非色**為主軸；與稀有度 token 的少量色相接近可接受（不同元件、不同語境）。
+
+## 「現在」節點金色共用（已知並接受）
+
+本專案 `stateWarning` ＝ `accentPrimary` ＝ `fiveStar` ＝ `0xFFD6A268`，故「普通」階金色
+與時間軸「現在」節點同色。可接受——「現在」是**中空節點＋文字標籤**，視覺可區分；與
+姐妹「中階金/琥珀刻意接受」一致。不另做處理。
+
+## tooltip 文案
+
+節點 tooltip 由「只有物品名稱」改為組裝既有片段：
+
+```
+{物品名稱} · {分級名稱} · {timelineSinceLast(pulls)}
+```
+
+例：`刻晴 · 歐 · 40 抽`。分級名稱取自下方 l10n key，抽數重用既有 `timelineSinceLast`，
+不另外新增 tooltip 專用 key。
+
+## 橫向時間軸年/月分隔（對齊垂直版）
+
+本專案橫向時間軸目前**無**年/月分隔（垂直版有）。本次補上，與垂直版一致：
+
+- 每個月份分組（左→右＝新→舊，該月最新一筆為組首）在組首欄**上方標年/月**（重用
+  `timelineMonthLabel`），月份**交界畫垂直分隔線**（畫在組首欄左側 `Border`；最左欄＝
+  最新月份起點不畫）。
+- **節點對齊關鍵**：每欄頂部保留固定高 `_monthBandHeight` 的標籤帶（組首填標籤、其餘
+  留白且標籤靠上對齊），**底部以等高 spacer 對稱補回**。置中欄加等高上下 padding 不改變
+  其垂直中心，故節點 y 不位移、仍對齊背景軸線；「現在」欄不加帶、不受影響。
+
+## i18n
+
+新增 3 個 key：`luckTierLucky`（歐）／`luckTierAverage`（普通）／`luckTierUnlucky`（非），
+**同時用於 `LuckLegend` 標籤與節點 tooltip 分級名稱**。
+
+範圍：新增到**所有實翻 ARB（9 個）**，跳過 22 個空殼 ARB（4-key，留給 Crowdin pipeline）。
+
+實翻 ARB：`app_zh.arb`（zh-Hant 模板）、`app_zh_Hans.arb`、`app_en.arb`、`app_es.arb`、
+`app_fr.arb`、`app_ja.arb`、`app_pt_BR.arb`、`app_th.arb`、`app_vi.arb`。
+
+**翻譯與姐妹專案一致**（zh-Hant / zh-Hans / en / ja 逐字對齊姐妹 PR #37）；
+`es / fr / pt-BR / th / vi` 姐妹專案無對應，按語意新翻（實作時對照 `docs/術語表.md`）：
+
+| key | zh-Hant | zh-Hans | en | ja | es | fr | pt-BR | th | vi |
+|---|---|---|---|---|---|---|---|---|---|
+| `luckTierLucky` | 歐 | 欧 | Lucky | 強運 | Con suerte | Chanceux | Sortudo | โชคดี | May mắn |
+| `luckTierAverage` | 普通 | 普通 | Average | 普通 | Normal | Normal | Normal | ปกติ | Bình thường |
+| `luckTierUnlucky` | 非 | 非 | Unlucky | 不運 | Sin suerte | Malchanceux | Azarado | โชคร้าย | Kém may |
+
+（es/fr/pt-BR/th/vi 為提案，實作時對照術語表定稿。）
+
+- generated l10n 為 gitignore，改完 ARB 後跑 `fvm flutter gen-l10n`。
+- 省略號等標點依專案慣例；分級名稱皆無 placeholder。
+
+## 測試
+
+- `test/widgets/luck_palette_test.dart`：`luckTierFor` 各池邊界
+  - 90 池：45→歐、46→普通、72→普通、73→非、90→非、91→非。
+  - 80 池：40→歐、41→普通、64→普通、65→非。
+  - 20 池：10→歐、11→普通、16→普通、17→非。
+  - 70 池：35→歐、36→普通、56→普通、57→非。
+  - 防呆：`pityThreshold = 0` → 非。
+  - `luckColorFor` 對應 `stateSuccess`／`stateWarning`／`stateDanger`。
+- `test/data/gacha_types_test.dart`：`gachaTypeFor`（已知 301→角色、未知→fallback 5★90/4★10）、
+  `pityThresholdFor`（301 5★→90、302 5★→80、100 5★→20、1000 4★→70、任一 4★→10、未知→90、
+  rank 無對應→主保底）。
+- `test/widgets/luck_legend_test.dart`：3 標籤皆顯示、色點對應歐非色。
+- 既有時間軸 widget 測試：斷言節點/名稱顏色＝歐非色、tooltip 文案、meta「N 抽」歐非色、
+  月份分組（含橫向新增）。
+- `test/widgets/banner_colors_test.dart`：任一卡池色 ≠ 該主題 stateSuccess/Warning/Danger。
+- `test/widgets/data/sortable_table_test.dart`：「保底內」欄歐非色、「總抽數」維持 muted。
+- `test/widgets/share/share_card_test.dart`：分享圖呈歐非色、entries 溢出時圖例底部仍在卡片內。
+
+## 驗收條件
+
+- `fvm dart format lib/ test/`、`fvm flutter analyze`（No issues found!）、
+  `fvm flutter test`（All tests passed!）全綠。
+- 單卡池頁時間軸節點/名稱顏色隨抽數呈綠/金/紅，下方有圖例；橫向有年/月分隔。
+- 總覽頁時間軸節點/名稱呈歐非色，meta 卡池名稱以卡池色顯示、「N 抽」呈歐非色，下方有圖例。
+- 記錄列表「保底內」欄呈歐非色，「總抽數」維持 muted。
+- 節點 tooltip 顯示「名稱 · 分級 · N 抽」。
+- 分享圖呈歐非色，且時間軸卡片底部有圖例（即使 entries 溢出被裁仍可見）。
+- 卡池調色盤全避開歐非色帶，測試固化不撞色。
+
+## 日誌
+
+本功能為純 UI／顏色呈現，無 I/O、外部 API 或錯誤分支，依專案慣例不額外埋 log。

--- a/lib/data/gacha_types.dart
+++ b/lib/data/gacha_types.dart
@@ -136,3 +136,28 @@ final Set<String> convertibleGachaTypes = {
   for (final t in gachaTypes)
     if (t.category == GachaCategory.gacha) t.gachaType,
 };
+
+/// 依 [gachaType] 字串查 [GachaType]；查無時回傳帶預設保底（5★90／4★10、
+/// 一般祈願分類）的 fallback。沿用 timeline 既有的未知卡池保底假設。
+GachaType gachaTypeFor(String gachaType) => gachaTypes.firstWhere(
+  (t) => t.gachaType == gachaType,
+  orElse: () => GachaType(
+    gachaType: gachaType,
+    nameKey: gachaType,
+    category: GachaCategory.gacha,
+    pities: const [
+      PityRule(rank: 5, threshold: 90),
+      PityRule(rank: 4, threshold: 10),
+    ],
+  ),
+);
+
+/// 查 [gachaType] 池中 [rank] 的保底門檻；該池無對應 [rank] 規則時，回傳主保底
+/// 門檻當保守值。
+int pityThresholdFor(String gachaType, int rank) {
+  final type = gachaTypeFor(gachaType);
+  for (final p in type.pities) {
+    if (p.rank == rank) return p.threshold;
+  }
+  return type.primaryPity.threshold;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "Lucky",
+  "luckTierAverage": "Average",
+  "luckTierUnlucky": "Unlucky"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "Con suerte",
+  "luckTierAverage": "Normal",
+  "luckTierUnlucky": "Sin suerte"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "Chanceux",
+  "luckTierAverage": "Normal",
+  "luckTierUnlucky": "Malchanceux"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "強運",
+  "luckTierAverage": "普通",
+  "luckTierUnlucky": "不運"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "Sortudo",
+  "luckTierAverage": "Normal",
+  "luckTierUnlucky": "Azarado"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "โชคดี",
+  "luckTierAverage": "ปกติ",
+  "luckTierUnlucky": "โชคร้าย"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -960,5 +960,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "May mắn",
+  "luckTierAverage": "Bình thường",
+  "luckTierUnlucky": "Kém may"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -749,5 +749,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "歐",
+  "luckTierAverage": "普通",
+  "luckTierUnlucky": "非"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -956,5 +956,9 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "luckTierLucky": "欧",
+  "luckTierAverage": "普通",
+  "luckTierUnlucky": "非"
 }

--- a/lib/pages/banner_page.dart
+++ b/lib/pages/banner_page.dart
@@ -16,7 +16,6 @@ import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/record_filter.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/utils/relative_time.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/chart_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/five_star_overview.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/pity_card.dart';
@@ -32,6 +31,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/page_header.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/rank_palette.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/rarity_pie.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/share_action_button.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/share_card.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/share/share_image_helper.dart';
@@ -285,12 +285,12 @@ class BannerPage extends ConsumerWidget {
                         _countAtRank(stats, primary.rank),
                       ),
                       icon: Icons.timeline,
+                      legend: const LuckLegend(),
                       chart: TimelineHorizontal(
                         entries: buildTimelineEntries(
                           records,
                           targetRank: primary.rank,
                         ),
-                        colors: BannerColors.of(Theme.of(context).brightness),
                         targetRank: primary.rank,
                         nowPulls: pullsSinceLastRanked(
                           records,

--- a/lib/pages/overview_page.dart
+++ b/lib/pages/overview_page.dart
@@ -433,6 +433,7 @@ class _OverviewSection extends StatelessWidget {
           targetRank: timelineRank,
           nowPulls: timelineNowPulls,
           isAcrossBanners: true,
+          showLuckLegend: true,
         ),
       ],
     );

--- a/lib/widgets/banner_colors.dart
+++ b/lib/widgets/banner_colors.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 
 /// 卡池配色表，給 Timeline 系列 widget 共用。
 ///
-/// 配色刻意跟稀有度 token（5★ 金、4★ 紫、3★ 藍、2★ 灰）保持距離，避免使用者
-/// 看到時間軸節點的顏色誤判為稀有度。每個 banner 一個獨特色相，dark / light
-/// 各一組對應飽和度。
+/// 配色刻意避開歐非語意色（綠 stateSuccess / 金 stateWarning / 紅 stateDanger），因為
+/// 時間軸節點已改由歐非色標示運氣等級。卡池色僅用於 meta 列的卡池名稱與分佈圖。
+/// 每個 banner 一個獨特色相，dark / light 各一組對應飽和度。
 @immutable
 class BannerColors {
   /// 建立 [BannerColors]。
@@ -25,25 +25,25 @@ class BannerColors {
 
   /// Dark mode palette。
   static const _dark = BannerColors(
-    character: Color(0xFF46B07A), // 森林綠
-    weapon: Color(0xFFE6736B), // 珊瑚紅
-    chronicled: Color(0xFFFF9F40), // 鮮橘
-    standard: Color(0xFF26A69A), // 青綠
-    beginner: Color(0xFF7A8AAD), // 灰藍
-    odesEvent: Color(0xFFEC4899), // 桃紅
-    odesStandard: Color(0xFFB59574), // 棕褐
+    character: Color(0xFF35BFD0), // 青藍
+    weapon: Color(0xFF4FA3E8), // 天藍
+    chronicled: Color(0xFF6E8BE6), // 矢車菊藍
+    standard: Color(0xFF8A7CE0), // 靛藍
+    beginner: Color(0xFFA86FD9), // 紫羅蘭
+    odesEvent: Color(0xFFC56FD0), // 蘭紫
+    odesStandard: Color(0xFFD96BA8), // 桃紅
     fallback: Color(0xFF8A92A6), // 中性
   );
 
   /// Light mode palette。
   static const _light = BannerColors(
-    character: Color(0xFF2E7D32),
-    weapon: Color(0xFFC62828),
-    chronicled: Color(0xFFE07B22),
-    standard: Color(0xFF00897B),
-    beginner: Color(0xFF5A6680),
-    odesEvent: Color(0xFFC2185B),
-    odesStandard: Color(0xFF7A5F40),
+    character: Color(0xFF1B92A8),
+    weapon: Color(0xFF2E6FC0),
+    chronicled: Color(0xFF4F5FC0),
+    standard: Color(0xFF6A4FC0),
+    beginner: Color(0xFF8A3FB0),
+    odesEvent: Color(0xFFA63FA8),
+    odesStandard: Color(0xFFB23A7E),
     fallback: Color(0xFF6A7080),
   );
 

--- a/lib/widgets/cards/timeline_horizontal.dart
+++ b/lib/widgets/cards/timeline_horizontal.dart
@@ -9,6 +9,8 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/scroll/scroll_affordance.dart';
 
 /// 每個時間軸欄的固定寬度。
@@ -59,7 +61,6 @@ class TimelineHorizontal extends StatefulWidget {
   const TimelineHorizontal({
     super.key,
     required this.entries,
-    required this.colors,
     required this.targetRank,
     this.nowPulls,
   });
@@ -67,10 +68,7 @@ class TimelineHorizontal extends StatefulWidget {
   /// 要顯示的時間軸條目（由新到舊排序）。
   final List<TimelineEntry> entries;
 
-  /// 各卡池節點的顏色映射。
-  final BannerColors colors;
-
-  /// 該卡池萃取的稀有度（5 或 4）。用於「暫無 N★ 紀錄」文案。
+  /// 該卡池萃取的稀有度（5 或 4）。用於「暫無 N★ 紀錄」文案及歐非色計算。
   final int targetRank;
 
   /// 傳入時在時間軸最左端加入「現在」欄，值為距上次目標稀有度的抽數。
@@ -189,10 +187,10 @@ class _TimelineHorizontalState extends State<TimelineHorizontal> {
                   children: [
                     if (widget.nowPulls != null)
                       _NowColumn(nowPulls: widget.nowPulls!, tokens: tokens),
-                    for (final entry in widget.entries)
+                    for (var i = 0; i < widget.entries.length; i++)
                       _EntryColumn(
-                        entry: entry,
-                        colors: widget.colors,
+                        entry: widget.entries[i],
+                        targetRank: widget.targetRank,
                         tokens: tokens,
                       ),
                   ],
@@ -260,15 +258,15 @@ class _TimelineHorizontalState extends State<TimelineHorizontal> {
 class _EntryColumn extends StatelessWidget {
   const _EntryColumn({
     required this.entry,
-    required this.colors,
+    required this.targetRank,
     required this.tokens,
   });
 
   /// 該欄對應的時間軸條目。
   final TimelineEntry entry;
 
-  /// 各卡池節點的顏色映射。
-  final BannerColors colors;
+  /// 該卡池萃取的稀有度（5 或 4），用於查保底門檻。
+  final int targetRank;
 
   /// 主題 token。
   final GachaTokens tokens;
@@ -281,10 +279,15 @@ class _EntryColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final accent = colors.colorFor(entry.gachaType);
+    final rank = entry.sourceRecord?.rankType ?? targetRank;
+    final pity = pityThresholdFor(entry.gachaType, rank);
+    final tier = luckTierFor(entry.pullsSincePrev, pity);
+    final luck = luckColorFor(tier, tokens);
     final l = AppLocalizations.of(context)!;
     return Tooltip(
-      message: entry.name,
+      message:
+          '${entry.name} · ${luckTierLabel(tier, l)} · '
+          '${l.timelineSinceLast(entry.pullsSincePrev)}',
       preferBelow: false,
       waitDuration: const Duration(milliseconds: 100),
       child: SizedBox(
@@ -308,7 +311,7 @@ class _EntryColumn extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       textAlign: TextAlign.center,
                       style: TextStyle(
-                        color: accent,
+                        color: luck,
                         fontWeight: FontWeight.bold,
                         fontSize: 12,
                       ),
@@ -323,24 +326,32 @@ class _EntryColumn extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  color: accent,
+                  color: luck,
                   fontWeight: FontWeight.bold,
                   fontSize: 12,
                 ),
               ),
             const SizedBox(height: AppSpacing.xs),
-            _Node(color: accent, tokens: tokens),
+            _Node(color: luck, tokens: tokens),
             const SizedBox(height: AppSpacing.xs),
-            Text(
-              '${_formatShortDate(entry.time)} · ${l.timelineSinceLast(entry.pullsSincePrev)}',
+            Text.rich(
+              TextSpan(
+                style: TextStyle(
+                  color: tokens.textMuted,
+                  fontSize: 10,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+                children: [
+                  TextSpan(text: '${_formatShortDate(entry.time)} · '),
+                  TextSpan(
+                    text: l.timelineSinceLast(entry.pullsSincePrev),
+                    style: TextStyle(color: luck),
+                  ),
+                ],
+              ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
-              style: TextStyle(
-                color: tokens.textMuted,
-                fontSize: 10,
-                fontFeatures: const [FontFeature.tabularFigures()],
-              ),
             ),
           ],
         ),

--- a/lib/widgets/cards/timeline_horizontal.dart
+++ b/lib/widgets/cards/timeline_horizontal.dart
@@ -22,6 +22,10 @@ const double _nodeSize = 14;
 /// 節點外圍 halo（觸控熱區）直徑。
 const double _haloSize = 22;
 
+/// 月份標籤帶高度。每欄頂部保留此高（組首填年/月、其餘留白），底部以等高
+/// spacer 對稱補回，使節點 y 不因標籤帶位移、仍對齊背景軸線。
+const double _monthBandHeight = 26;
+
 /// 邊緣漸隱遮罩的寬度。
 const double _edgeFadeWidth = 32;
 
@@ -151,6 +155,15 @@ class _TimelineHorizontalState extends State<TimelineHorizontal> {
       );
     }
 
+    // 每欄是否為其月份分組首欄（左→右 = 新→舊，某月最新一筆即該組起點）。
+    final monthStart = <bool>[];
+    int? prevYearMonth;
+    for (final entry in widget.entries) {
+      final ym = entry.time.year * 12 + entry.time.month;
+      monthStart.add(prevYearMonth != ym);
+      prevYearMonth = ym;
+    }
+
     return Stack(
       children: [
         // 背景軸線
@@ -192,6 +205,8 @@ class _TimelineHorizontalState extends State<TimelineHorizontal> {
                         entry: widget.entries[i],
                         targetRank: widget.targetRank,
                         tokens: tokens,
+                        isMonthStart: monthStart[i],
+                        showMonthDivider: monthStart[i] && i > 0,
                       ),
                   ],
                 ),
@@ -260,6 +275,8 @@ class _EntryColumn extends StatelessWidget {
     required this.entry,
     required this.targetRank,
     required this.tokens,
+    required this.isMonthStart,
+    required this.showMonthDivider,
   });
 
   /// 該欄對應的時間軸條目。
@@ -270,6 +287,12 @@ class _EntryColumn extends StatelessWidget {
 
   /// 主題 token。
   final GachaTokens tokens;
+
+  /// 是否為其月份分組首欄；true 時頂部標籤帶顯示年/月。
+  final bool isMonthStart;
+
+  /// 是否在左側畫月份分隔線（月份交界、且非最左欄時為 true）。
+  final bool showMonthDivider;
 
   /// 將 [DateTime] 格式化為 `MM/dd` 字串。
   static String _formatShortDate(DateTime t) {
@@ -284,76 +307,111 @@ class _EntryColumn extends StatelessWidget {
     final tier = luckTierFor(entry.pullsSincePrev, pity);
     final luck = luckColorFor(tier, tokens);
     final l = AppLocalizations.of(context)!;
+    final monthLabel = isMonthStart
+        ? l.timelineMonthLabel(
+            entry.time.year.toString(),
+            entry.time.month.toString().padLeft(2, '0'),
+          )
+        : null;
     return Tooltip(
       message:
           '${entry.name} · ${luckTierLabel(tier, l)} · '
           '${l.timelineSinceLast(entry.pullsSincePrev)}',
       preferBelow: false,
       waitDuration: const Duration(milliseconds: 100),
-      child: SizedBox(
-        width: _colWidth,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            if (entry.sourceRecord != null)
-              GachaItemTapTarget(
-                record: entry.sourceRecord!,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    GachaItemIcon(record: entry.sourceRecord!, size: 32),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      entry.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: luck,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 12,
+      child: Container(
+        decoration: showMonthDivider
+            ? BoxDecoration(
+                border: Border(left: BorderSide(color: tokens.borderEmphasis)),
+              )
+            : null,
+        child: SizedBox(
+          width: _colWidth,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // 月份標籤帶（組首填年/月，其餘留白佔位）。
+              SizedBox(
+                height: _monthBandHeight,
+                child: monthLabel == null
+                    ? null
+                    : Align(
+                        alignment: Alignment.topCenter,
+                        child: Text(
+                          monthLabel,
+                          maxLines: 1,
+                          style: TextStyle(
+                            color: tokens.textSecondary,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.4,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        ),
                       ),
+              ),
+              if (entry.sourceRecord != null)
+                GachaItemTapTarget(
+                  record: entry.sourceRecord!,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      GachaItemIcon(record: entry.sourceRecord!, size: 32),
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        entry.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: luck,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              else
+                Text(
+                  entry.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: luck,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 12,
+                  ),
+                ),
+              const SizedBox(height: AppSpacing.xs),
+              _Node(color: luck, tokens: tokens),
+              const SizedBox(height: AppSpacing.xs),
+              Text.rich(
+                TextSpan(
+                  style: TextStyle(
+                    color: tokens.textMuted,
+                    fontSize: 10,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                  children: [
+                    TextSpan(text: '${_formatShortDate(entry.time)} · '),
+                    TextSpan(
+                      text: l.timelineSinceLast(entry.pullsSincePrev),
+                      style: TextStyle(color: luck),
                     ),
                   ],
                 ),
-              )
-            else
-              Text(
-                entry.name,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: luck,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 12,
-                ),
               ),
-            const SizedBox(height: AppSpacing.xs),
-            _Node(color: luck, tokens: tokens),
-            const SizedBox(height: AppSpacing.xs),
-            Text.rich(
-              TextSpan(
-                style: TextStyle(
-                  color: tokens.textMuted,
-                  fontSize: 10,
-                  fontFeatures: const [FontFeature.tabularFigures()],
-                ),
-                children: [
-                  TextSpan(text: '${_formatShortDate(entry.time)} · '),
-                  TextSpan(
-                    text: l.timelineSinceLast(entry.pullsSincePrev),
-                    style: TextStyle(color: luck),
-                  ),
-                ],
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-            ),
-          ],
+              // 對稱補回標籤帶高度，使節點維持原垂直中心、對齊軸線。
+              const SizedBox(height: _monthBandHeight),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/cards/timeline_horizontal.dart
+++ b/lib/widgets/cards/timeline_horizontal.dart
@@ -9,7 +9,6 @@ import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/distribution_legend.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/scroll/scroll_affordance.dart';
 
@@ -314,9 +313,7 @@ class _EntryColumn extends StatelessWidget {
           )
         : null;
     return Tooltip(
-      message:
-          '${entry.name} · ${luckTierLabel(tier, l)} · '
-          '${l.timelineSinceLast(entry.pullsSincePrev)}',
+      message: entry.name,
       preferBelow: false,
       waitDuration: const Duration(milliseconds: 100),
       child: Container(

--- a/lib/widgets/cards/timeline_vertical.dart
+++ b/lib/widgets/cards/timeline_vertical.dart
@@ -434,11 +434,9 @@ class _EntryRow extends StatelessWidget {
                   )
                 : const SizedBox.shrink(),
           ),
-          // 節點圓 (tooltip 顯示名稱 · 分級 · N 抽)
+          // 節點圓 (tooltip 僅顯示物品名稱)
           Tooltip(
-            message:
-                '${entry.name} · ${luckTierLabel(tier, l)} · '
-                '${l.timelineSinceLast(entry.pullsSincePrev)}',
+            message: entry.name,
             preferBelow: false,
             waitDuration: const Duration(milliseconds: 100),
             child: SizedBox(

--- a/lib/widgets/cards/timeline_vertical.dart
+++ b/lib/widgets/cards/timeline_vertical.dart
@@ -7,6 +7,8 @@ import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
 
 /// 左側月份標籤欄的固定寬度。
 const double _monthColumnWidth = 80;
@@ -36,6 +38,7 @@ class TimelineVertical extends StatefulWidget {
     this.fillHeight = false,
     this.nowPulls,
     this.isAcrossBanners = false,
+    this.showLuckLegend = false,
   });
 
   /// 要顯示的時間軸條目（由新到舊排序）。
@@ -75,6 +78,9 @@ class TimelineVertical extends StatefulWidget {
 
   /// true 表示跨卡池場景，影響「現在」row 的 i18n 文案。
   final bool isAcrossBanners;
+
+  /// 為 true 時在卡片底部釘上 [LuckLegend]（即使 entries 溢出被裁仍可見）。
+  final bool showLuckLegend;
 
   @override
   State<TimelineVertical> createState() => _TimelineVerticalState();
@@ -173,16 +179,48 @@ class _TimelineVerticalState extends State<TimelineVertical> {
       // OverflowBox 區域 = 有界高，body 自然高較矮 → 下方為卡內留白。
       // fillHeight=false（App 既有用法）：child 維持原 body，渲染樹與加入
       // 此參數前逐字等價、零回歸。
-      final Widget content = fillHeight
-          ? ClipRect(
-              child: OverflowBox(
-                minHeight: 0,
-                maxHeight: double.infinity,
-                alignment: Alignment.topCenter,
-                child: body,
-              ),
-            )
-          : body;
+      // showLuckLegend=true：在邊框內底部釘上 LuckLegend，fillHeight 路徑
+      // 用 Expanded 占滿剩餘高並用 ClipRect 裁切，讓圖例恆可見。
+      final Widget content;
+      if (widget.showLuckLegend) {
+        const legend = Padding(
+          padding: EdgeInsets.only(top: AppSpacing.s),
+          child: LuckLegend(),
+        );
+        content = fillHeight
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    child: ClipRect(
+                      child: OverflowBox(
+                        minHeight: 0,
+                        maxHeight: double.infinity,
+                        alignment: Alignment.topCenter,
+                        child: body,
+                      ),
+                    ),
+                  ),
+                  legend,
+                ],
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [body, legend],
+              );
+      } else {
+        content = fillHeight
+            ? ClipRect(
+                child: OverflowBox(
+                  minHeight: 0,
+                  maxHeight: double.infinity,
+                  alignment: Alignment.topCenter,
+                  child: body,
+                ),
+              )
+            : body;
+      }
       return Container(
         constraints: fillHeight
             ? const BoxConstraints(minHeight: double.infinity)
@@ -271,6 +309,7 @@ class _TimelineVerticalState extends State<TimelineVertical> {
                       showMonthTag: monthFlag[i],
                       colors: colors,
                       tokens: tokens,
+                      targetRank: targetRank,
                     ),
                 ],
               ),
@@ -303,6 +342,7 @@ class _EntryRow extends StatelessWidget {
     required this.showMonthTag,
     required this.colors,
     required this.tokens,
+    required this.targetRank,
   });
 
   /// 該 row 對應的時間軸條目。
@@ -317,8 +357,11 @@ class _EntryRow extends StatelessWidget {
   /// 主題 token。
   final GachaTokens tokens;
 
-  /// 名稱行：可選 icon + 粗體名稱文字的 [Row]。
-  Widget get _nameRow => Row(
+  /// 主要顯示稀有度，用於查保底門檻換算歐非色。
+  final int targetRank;
+
+  /// 名稱行：可選 icon + 粗體名稱文字的 [Row]，名稱色由 [nameColor] 決定。
+  Widget _nameRowWith(Color nameColor) => Row(
     mainAxisSize: MainAxisSize.min,
     crossAxisAlignment: CrossAxisAlignment.center,
     children: [
@@ -330,7 +373,7 @@ class _EntryRow extends StatelessWidget {
         child: Text(
           entry.name,
           style: TextStyle(
-            color: colors.colorFor(entry.gachaType),
+            color: nameColor,
             fontWeight: FontWeight.bold,
             fontSize: 14,
           ),
@@ -347,28 +390,20 @@ class _EntryRow extends StatelessWidget {
     return '${two(t.month)}/${two(t.day)}';
   }
 
-  /// 依 [gachaType] 查詢對應的在地化卡池名稱；查無時回傳 [gachaType] 本身。
-  String _bannerName(String gachaType, AppLocalizations l) => gachaTypes
-      .firstWhere(
-        (t) => t.gachaType == gachaType,
-        orElse: () => GachaType(
-          gachaType: gachaType,
-          nameKey: gachaType,
-          category: GachaCategory.gacha,
-          pities: const [
-            PityRule(rank: 5, threshold: 90),
-            PityRule(rank: 4, threshold: 10),
-          ],
-        ),
-      )
-      .resolveName(l);
+  /// 依 [gachaType] 查在地化卡池名稱；查無時回傳帶預設保底的 fallback 名稱。
+  String _bannerName(String gachaType, AppLocalizations l) =>
+      gachaTypeFor(gachaType).resolveName(l);
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context)!;
-    final accent = colors.colorFor(entry.gachaType);
+    final rank = entry.sourceRecord?.rankType ?? targetRank;
+    final pity = pityThresholdFor(entry.gachaType, rank);
+    final tier = luckTierFor(entry.pullsSincePrev, pity);
+    final luck = luckColorFor(tier, tokens);
     final year = entry.time.year.toString();
     final month = entry.time.month.toString().padLeft(2, '0');
+    final nameRow = _nameRowWith(luck);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -399,15 +434,17 @@ class _EntryRow extends StatelessWidget {
                   )
                 : const SizedBox.shrink(),
           ),
-          // 節點圓 (tooltip 目標 = halo 大小，會顯示在節點正上方)
+          // 節點圓 (tooltip 顯示名稱 · 分級 · N 抽)
           Tooltip(
-            message: entry.name,
+            message:
+                '${entry.name} · ${luckTierLabel(tier, l)} · '
+                '${l.timelineSinceLast(entry.pullsSincePrev)}',
             preferBelow: false,
             waitDuration: const Duration(milliseconds: 100),
             child: SizedBox(
               width: _haloSize,
               child: Center(
-                child: _Node(color: accent, tokens: tokens),
+                child: _Node(color: luck, tokens: tokens),
               ),
             ),
           ),
@@ -428,21 +465,36 @@ class _EntryRow extends StatelessWidget {
                     child: entry.sourceRecord != null
                         ? GachaItemTapTarget(
                             record: entry.sourceRecord!,
-                            child: _nameRow,
+                            child: nameRow,
                           )
-                        : _nameRow,
+                        : nameRow,
                   ),
                   const SizedBox(height: 2),
                   Tooltip(
                     message: entry.name,
                     preferBelow: false,
                     waitDuration: const Duration(milliseconds: 100),
-                    child: Text(
-                      '${_formatShortDate(entry.time)} · ${_bannerName(entry.gachaType, l)} · ${l.timelineSinceLast(entry.pullsSincePrev)}',
-                      style: TextStyle(
-                        color: tokens.textMuted,
-                        fontSize: 12,
-                        fontFeatures: const [FontFeature.tabularFigures()],
+                    child: Text.rich(
+                      TextSpan(
+                        style: TextStyle(
+                          color: tokens.textMuted,
+                          fontSize: 12,
+                          fontFeatures: const [FontFeature.tabularFigures()],
+                        ),
+                        children: [
+                          TextSpan(text: '${_formatShortDate(entry.time)} · '),
+                          TextSpan(
+                            text: _bannerName(entry.gachaType, l),
+                            style: TextStyle(
+                              color: colors.colorFor(entry.gachaType),
+                            ),
+                          ),
+                          const TextSpan(text: ' · '),
+                          TextSpan(
+                            text: l.timelineSinceLast(entry.pullsSincePrev),
+                            style: TextStyle(color: luck),
+                          ),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/widgets/data/sortable_table.dart
+++ b/lib/widgets/data/sortable_table.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
 
 import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_filter.dart';
@@ -9,6 +10,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/utils/relative_time.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/data/pager.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/dialogs/gacha_item_detail_dialog.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
 
 /// 可排序的祈願記錄表格，含分頁功能。
 class SortableTable extends StatefulWidget {
@@ -109,6 +111,7 @@ class _SortableTableState extends State<SortableTable> {
                   theme: theme,
                   tokens: tokens,
                   l: l,
+                  mainRank: widget.mainRank,
                 ),
             ],
           ),
@@ -335,6 +338,7 @@ class _Row extends StatelessWidget {
     required this.theme,
     required this.tokens,
     required this.l,
+    required this.mainRank,
   });
 
   /// 祈願記錄資料。
@@ -352,9 +356,19 @@ class _Row extends StatelessWidget {
   /// 國際化字串。
   final AppLocalizations l;
 
+  /// 該卡池主稀有度 rank，用於換算「保底內」欄歐非色。
+  final int mainRank;
+
   @override
   Widget build(BuildContext context) {
     final record = row.record;
+    final pityLuck = luckColorFor(
+      luckTierFor(
+        row.mainPityIndex,
+        pityThresholdFor(record.gachaType, mainRank),
+      ),
+      tokens,
+    );
     final accent = switch (record.rankType) {
       5 => tokens.fiveStar,
       4 => tokens.fourStar,
@@ -431,7 +445,10 @@ class _Row extends StatelessWidget {
             child: Text(
               '${row.mainPityIndex}',
               textAlign: TextAlign.end,
-              style: mutedNum,
+              style: TextStyle(
+                color: pityLuck,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
             ),
           ),
         ],

--- a/lib/widgets/luck_legend.dart
+++ b/lib/widgets/luck_legend.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+
+/// 將歐非分級對應到目前語言的標籤（供 tooltip 與 [LuckLegend] 共用）。
+String luckTierLabel(LuckTier tier, AppLocalizations l) => switch (tier) {
+  LuckTier.lucky => l.luckTierLucky,
+  LuckTier.average => l.luckTierAverage,
+  LuckTier.unlucky => l.luckTierUnlucky,
+};
+
+/// 時間軸歐非色圖例：歐／普通／非 三個色點＋標籤，低視窗寬度可換行。
+/// 刻意不標抽數——跨池保底門檻不同，標數字會誤導。
+class LuckLegend extends StatelessWidget {
+  /// 建立 [LuckLegend]。
+  const LuckLegend({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tokens = theme.gacha;
+    final l = AppLocalizations.of(context)!;
+    return Wrap(
+      spacing: AppSpacing.l,
+      runSpacing: AppSpacing.xs,
+      children: [
+        for (final tier in LuckTier.values)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  color: luckColorFor(tier, tokens),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Text(
+                luckTierLabel(tier, l),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: tokens.textSecondary,
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/luck_palette.dart
+++ b/lib/widgets/luck_palette.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+
+/// 歐非分級：依「抽到該筆所花抽數 / 該池保底門檻」的比例分三階。
+enum LuckTier {
+  /// 歐：半個保底內出貨。
+  lucky,
+
+  /// 普通。
+  average,
+
+  /// 非：進入軟保底區（接近硬保底）。
+  unlucky,
+}
+
+/// 歐（綠）上界比例：抽數在保底的一半以內視為歐。
+const double _luckyMaxRatio = 0.5;
+
+/// 普通（金）上界比例：超過此比例即進入軟保底區，視為非。
+const double _averageMaxRatio = 0.8;
+
+/// 依 [pulls] 相對 [pityThreshold] 的比例回傳分級。
+/// `ratio <= 0.5` 歐；`<= 0.8` 普通；其餘（含 ratio > 1）非。
+/// [pityThreshold] <= 0 時防呆視為非（避免除以零；正常資料不會發生）。
+LuckTier luckTierFor(int pulls, int pityThreshold) {
+  if (pityThreshold <= 0) return LuckTier.unlucky;
+  final ratio = pulls / pityThreshold;
+  if (ratio <= _luckyMaxRatio) return LuckTier.lucky;
+  if (ratio <= _averageMaxRatio) return LuckTier.average;
+  return LuckTier.unlucky;
+}
+
+/// 將分級映射到既有語意色（綠 / 金 / 紅），不新增 token。
+Color luckColorFor(LuckTier tier, GachaTokens t) => switch (tier) {
+  LuckTier.lucky => t.stateSuccess,
+  LuckTier.average => t.stateWarning,
+  LuckTier.unlucky => t.stateDanger,
+};

--- a/lib/widgets/share/share_card.dart
+++ b/lib/widgets/share/share_card.dart
@@ -442,6 +442,7 @@ class _SectionView extends StatelessWidget {
       nowPulls: section.timelineNowPulls,
       isAcrossBanners: section.isAcrossBanners,
       fillHeight: true,
+      showLuckLegend: true,
     );
   }
 

--- a/test/data/gacha_types_test.dart
+++ b/test/data/gacha_types_test.dart
@@ -91,4 +91,33 @@ void main() {
       );
     });
   });
+
+  group('gachaTypeFor', () {
+    test('已知 gachaType 回傳對應 GachaType', () {
+      expect(gachaTypeFor('301').nameKey, 'gachaTypeCharacter');
+      expect(gachaTypeFor('1000').nameKey, 'gachaTypeOdesStandard');
+    });
+
+    test('未知 gachaType 回傳 fallback（5★90 / 4★10 / gacha）', () {
+      final t = gachaTypeFor('999');
+      expect(t.gachaType, '999');
+      expect(t.primaryPity.threshold, 90);
+      expect(t.secondaryPity!.threshold, 10);
+      expect(t.category, GachaCategory.gacha);
+    });
+  });
+
+  group('pityThresholdFor', () {
+    test('角色池 5★ → 90', () => expect(pityThresholdFor('301', 5), 90));
+    test('武器池 5★ → 80', () => expect(pityThresholdFor('302', 5), 80));
+    test('新手池 5★ → 20', () => expect(pityThresholdFor('100', 5), 20));
+    test('頌願活動 5★ → 70', () => expect(pityThresholdFor('2000', 5), 70));
+    test('頌願常駐 4★ → 70', () => expect(pityThresholdFor('1000', 4), 70));
+    test('一般祈願 4★ → 10', () => expect(pityThresholdFor('301', 4), 10));
+    test('未知池 5★ → fallback 90', () => expect(pityThresholdFor('999', 5), 90));
+    test('rank 無對應回傳主保底門檻', () {
+      expect(pityThresholdFor('301', 3), 90); // 角色池主保底 5★90
+      expect(pityThresholdFor('1000', 5), 70); // 頌願常駐主保底 4★70
+    });
+  });
 }

--- a/test/widgets/banner_colors_test.dart
+++ b/test/widgets/banner_colors_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/data/gacha_types.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
+
+void main() {
+  for (final (label, brightness, tokens) in [
+    ('dark', Brightness.dark, GachaTokens.dark),
+    ('light', Brightness.light, GachaTokens.light),
+  ]) {
+    test('$label：任一卡池色不得等於歐非三色', () {
+      final colors = BannerColors.of(brightness);
+      final luck = {
+        tokens.stateSuccess,
+        tokens.stateWarning,
+        tokens.stateDanger,
+      };
+      for (final t in gachaTypes) {
+        expect(
+          luck.contains(colors.colorFor(t.gachaType)),
+          isFalse,
+          reason: '${t.gachaType} 撞歐非色',
+        );
+      }
+      expect(luck.contains(colors.fallback), isFalse);
+    });
+  }
+}

--- a/test/widgets/cards/timeline_horizontal_test.dart
+++ b/test/widgets/cards/timeline_horizontal_test.dart
@@ -340,6 +340,29 @@ void main() {
     expect(find.byTooltip(expected), findsOneWidget);
   });
 
+  testWidgets('跨月顯示年/月標籤', (tester) async {
+    final entries = [
+      TimelineEntry(
+        name: 'A',
+        gachaType: '301',
+        time: DateTime(2026, 6, 2),
+        pullsSincePrev: 10,
+      ),
+      TimelineEntry(
+        name: 'B',
+        gachaType: '301',
+        time: DateTime(2026, 5, 20),
+        pullsSincePrev: 10,
+      ),
+    ];
+    await pumpTimelineHorizontal(tester, entries: entries, targetRank: 5);
+    final l = AppLocalizations.of(
+      tester.element(find.byType(TimelineHorizontal)),
+    )!;
+    expect(find.text(l.timelineMonthLabel('2026', '06')), findsOneWidget);
+    expect(find.text(l.timelineMonthLabel('2026', '05')), findsOneWidget);
+  });
+
   testWidgets('每欄名稱上方顯示 GachaItemIcon', (tester) async {
     late Directory tempDir;
     await tester.runAsync(() async {

--- a/test/widgets/cards/timeline_horizontal_test.dart
+++ b/test/widgets/cards/timeline_horizontal_test.dart
@@ -10,7 +10,6 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart'
 import 'package:genshin_impact_wish_gacha_analyzer/services/timeline_entries.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
-import 'package:genshin_impact_wish_gacha_analyzer/widgets/banner_colors.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/cards/timeline_horizontal.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
 
@@ -22,7 +21,14 @@ TimelineEntry _e(String name, String gachaType, int pulls, DateTime time) =>
       pullsSincePrev: pulls,
     );
 
-Widget _wrap(Widget Function(BuildContext ctx, BannerColors colors) build) =>
+/// 將 [TimelineHorizontal] 包在標準測試 scaffold 內並 pump。
+Future<void> pumpTimelineHorizontal(
+  WidgetTester tester, {
+  required List<TimelineEntry> entries,
+  required int targetRank,
+  int? nowPulls,
+}) async {
+  await tester.pumpWidget(
     MaterialApp(
       theme: buildDarkTheme(),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -31,27 +37,29 @@ Widget _wrap(Widget Function(BuildContext ctx, BannerColors colors) build) =>
         body: SizedBox(
           width: 1000,
           height: 160,
-          child: Builder(
-            builder: (ctx) {
-              final colors = BannerColors.of(Theme.of(ctx).brightness);
-              return build(ctx, colors);
-            },
+          child: TimelineHorizontal(
+            entries: entries,
+            targetRank: targetRank,
+            nowPulls: nowPulls,
           ),
         ),
       ),
-    );
+    ),
+  );
+}
+
+Widget _wrap(Widget Function(BuildContext ctx) build) => MaterialApp(
+  theme: buildDarkTheme(),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(
+    body: SizedBox(width: 1000, height: 160, child: Builder(builder: build)),
+  ),
+);
 
 void main() {
   testWidgets('empty + no nowPulls → shows timelineNoRecords', (tester) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: const [],
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
-    );
+    await pumpTimelineHorizontal(tester, entries: const [], targetRank: 5);
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineHorizontal)),
     )!;
@@ -62,17 +70,13 @@ void main() {
   });
 
   testWidgets('renders one column per entry', (tester) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: [
-            _e('夜蘭', '301', 87, DateTime(2025, 4, 1)),
-            _e('流浪者', '301', 74, DateTime(2025, 3, 1)),
-          ],
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: [
+        _e('夜蘭', '301', 87, DateTime(2025, 4, 1)),
+        _e('流浪者', '301', 74, DateTime(2025, 3, 1)),
+      ],
+      targetRank: 5,
     );
     expect(find.text('夜蘭'), findsOneWidget);
     expect(find.text('流浪者'), findsOneWidget);
@@ -81,15 +85,11 @@ void main() {
   testWidgets('nowPulls != null → adds Now column at the leftmost', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: [_e('夜蘭', '301', 87, DateTime(2025, 4, 1))],
-          colors: colors,
-          nowPulls: 28,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: [_e('夜蘭', '301', 87, DateTime(2025, 4, 1))],
+      nowPulls: 28,
+      targetRank: 5,
     );
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineHorizontal)),
@@ -101,15 +101,11 @@ void main() {
   testWidgets('empty + nowPulls != null → renders only the Now column', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: const [],
-          colors: colors,
-          nowPulls: 5,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: const [],
+      nowPulls: 5,
+      targetRank: 5,
     );
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineHorizontal)),
@@ -124,15 +120,11 @@ void main() {
   testWidgets('Now column appears leftmost (before entry columns)', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: [_e('夜蘭', '301', 87, DateTime(2025, 4, 1))],
-          colors: colors,
-          nowPulls: 28,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: [_e('夜蘭', '301', 87, DateTime(2025, 4, 1))],
+      nowPulls: 28,
+      targetRank: 5,
     );
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineHorizontal)),
@@ -153,12 +145,7 @@ void main() {
           DateTime(2025, 1, 1).add(Duration(days: i)),
         ),
     ];
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) =>
-            TimelineHorizontal(entries: entries, colors: colors, targetRank: 5),
-      ),
-    );
+    await pumpTimelineHorizontal(tester, entries: entries, targetRank: 5);
     final scrollableState = tester.state<ScrollableState>(
       find.descendant(
         of: find.byType(TimelineHorizontal),
@@ -191,14 +178,10 @@ void main() {
   testWidgets('overflow + offset=0 → right arrow visible, left hidden', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: manyEntries(20),
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: manyEntries(20),
+      targetRank: 5,
     );
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.chevron_right), findsOneWidget);
@@ -206,14 +189,10 @@ void main() {
   });
 
   testWidgets('overflow + offset=middle → both arrows visible', (tester) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: manyEntries(20),
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: manyEntries(20),
+      targetRank: 5,
     );
     await tester.pumpAndSettle();
     final scrollable = tester.state<ScrollableState>(
@@ -231,14 +210,10 @@ void main() {
   testWidgets('overflow + offset=max → left arrow visible, right hidden', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: manyEntries(20),
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: manyEntries(20),
+      targetRank: 5,
     );
     await tester.pumpAndSettle();
     final scrollable = tester.state<ScrollableState>(
@@ -256,17 +231,13 @@ void main() {
   testWidgets('no overflow (2 entries) → no arrows on either side', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: [
-            _e('夜蘭', '301', 87, DateTime(2025, 4, 1)),
-            _e('流浪者', '301', 74, DateTime(2025, 3, 1)),
-          ],
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: [
+        _e('夜蘭', '301', 87, DateTime(2025, 4, 1)),
+        _e('流浪者', '301', 74, DateTime(2025, 3, 1)),
+      ],
+      targetRank: 5,
     );
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.chevron_left), findsNothing);
@@ -276,14 +247,10 @@ void main() {
   testWidgets('tap right arrow → scrolls by one column (90 px)', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _wrap(
-        (ctx, colors) => TimelineHorizontal(
-          entries: manyEntries(20),
-          colors: colors,
-          targetRank: 5,
-        ),
-      ),
+    await pumpTimelineHorizontal(
+      tester,
+      entries: manyEntries(20),
+      targetRank: 5,
     );
     await tester.pumpAndSettle();
     final scrollable = tester.state<ScrollableState>(
@@ -301,14 +268,10 @@ void main() {
   testWidgets(
     'tap right arrow repeatedly → clamps at maxScrollExtent and hides right arrow',
     (tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          (ctx, colors) => TimelineHorizontal(
-            entries: manyEntries(20),
-            colors: colors,
-            targetRank: 5,
-          ),
-        ),
+      await pumpTimelineHorizontal(
+        tester,
+        entries: manyEntries(20),
+        targetRank: 5,
       );
       await tester.pumpAndSettle();
       final scrollable = tester.state<ScrollableState>(
@@ -334,10 +297,8 @@ void main() {
   testWidgets(
     'entries shrink from overflow to non-overflow → arrows disappear',
     (tester) async {
-      Widget makeWidget(List<TimelineEntry> entries) => _wrap(
-        (ctx, colors) =>
-            TimelineHorizontal(entries: entries, colors: colors, targetRank: 5),
-      );
+      Widget makeWidget(List<TimelineEntry> entries) =>
+          _wrap((ctx) => TimelineHorizontal(entries: entries, targetRank: 5));
       await tester.pumpWidget(makeWidget(manyEntries(20)));
       await tester.pumpAndSettle();
       expect(find.byIcon(Icons.chevron_right), findsOneWidget);
@@ -357,20 +318,27 @@ void main() {
   testWidgets(
     'empty + no nowPulls → no scroll affordance even if widget renders',
     (tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          (ctx, colors) => TimelineHorizontal(
-            entries: const [],
-            colors: colors,
-            targetRank: 5,
-          ),
-        ),
-      );
+      await pumpTimelineHorizontal(tester, entries: const [], targetRank: 5);
       await tester.pumpAndSettle();
       expect(find.byIcon(Icons.chevron_left), findsNothing);
       expect(find.byIcon(Icons.chevron_right), findsNothing);
     },
   );
+
+  testWidgets('橫向節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+    final entry = TimelineEntry(
+      name: '魈',
+      gachaType: '301',
+      time: DateTime(2026, 6, 1),
+      pullsSincePrev: 85, // 85/90 ≈ 0.94 → 非
+    );
+    await pumpTimelineHorizontal(tester, entries: [entry], targetRank: 5);
+    final l = AppLocalizations.of(
+      tester.element(find.byType(TimelineHorizontal)),
+    )!;
+    final expected = '魈 · ${l.luckTierUnlucky} · ${l.timelineSinceLast(85)}';
+    expect(find.byTooltip(expected), findsOneWidget);
+  });
 
   testWidgets('每欄名稱上方顯示 GachaItemIcon', (tester) async {
     late Directory tempDir;
@@ -430,16 +398,7 @@ void main() {
             body: SizedBox(
               width: 1000,
               height: 160,
-              child: Builder(
-                builder: (ctx) {
-                  final colors = BannerColors.of(Theme.of(ctx).brightness);
-                  return TimelineHorizontal(
-                    entries: entries,
-                    colors: colors,
-                    targetRank: 5,
-                  );
-                },
-              ),
+              child: TimelineHorizontal(entries: entries, targetRank: 5),
             ),
           ),
         ),

--- a/test/widgets/cards/timeline_horizontal_test.dart
+++ b/test/widgets/cards/timeline_horizontal_test.dart
@@ -325,7 +325,7 @@ void main() {
     },
   );
 
-  testWidgets('橫向節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+  testWidgets('橫向節點 tooltip 僅顯示物品名稱（不含分級／抽數）', (tester) async {
     final entry = TimelineEntry(
       name: '魈',
       gachaType: '301',
@@ -336,8 +336,11 @@ void main() {
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineHorizontal)),
     )!;
-    final expected = '魈 · ${l.luckTierUnlucky} · ${l.timelineSinceLast(85)}';
-    expect(find.byTooltip(expected), findsOneWidget);
+    expect(find.byTooltip('魈'), findsOneWidget);
+    expect(
+      find.byTooltip('魈 · ${l.luckTierUnlucky} · ${l.timelineSinceLast(85)}'),
+      findsNothing,
+    );
   });
 
   testWidgets('跨月顯示年/月標籤', (tester) async {

--- a/test/widgets/cards/timeline_vertical_test.dart
+++ b/test/widgets/cards/timeline_vertical_test.dart
@@ -768,7 +768,7 @@ void main() {
     },
   );
 
-  testWidgets('節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+  testWidgets('節點 tooltip 僅顯示物品名稱（不含分級／抽數）', (tester) async {
     final entry = TimelineEntry(
       name: '刻晴',
       gachaType: '301', // 90 池
@@ -779,8 +779,11 @@ void main() {
     final l = AppLocalizations.of(
       tester.element(find.byType(TimelineVertical)),
     )!;
-    final expected = '刻晴 · ${l.luckTierLucky} · ${l.timelineSinceLast(40)}';
-    expect(find.byTooltip(expected), findsWidgets);
+    expect(find.byTooltip('刻晴'), findsWidgets);
+    expect(
+      find.byTooltip('刻晴 · ${l.luckTierLucky} · ${l.timelineSinceLast(40)}'),
+      findsNothing,
+    );
   });
 
   testWidgets('showLuckLegend 時顯示圖例', (tester) async {

--- a/test/widgets/cards/timeline_vertical_test.dart
+++ b/test/widgets/cards/timeline_vertical_test.dart
@@ -36,6 +36,28 @@ Widget _wrap(Widget Function(BuildContext, BannerColors) build) => MaterialApp(
   ),
 );
 
+/// pump helper：封裝 [TimelineVertical] 所有常用參數，方便新測試用單行建立。
+Future<void> pumpTimelineVertical(
+  WidgetTester tester, {
+  required List<TimelineEntry> entries,
+  required int targetRank,
+  int? nowPulls,
+  bool showLuckLegend = false,
+}) async {
+  await tester.pumpWidget(
+    _wrap(
+      (ctx, colors) => TimelineVertical(
+        entries: entries,
+        colors: colors,
+        targetRank: targetRank,
+        nowPulls: nowPulls,
+        showLuckLegend: showLuckLegend,
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
 void main() {
   testWidgets('empty + no nowPulls → shows timelineNoRecords', (tester) async {
     await tester.pumpWidget(
@@ -745,4 +767,33 @@ void main() {
       expect(find.text('夜蘭'), findsNWidgets(2));
     },
   );
+
+  testWidgets('節點 tooltip 顯示 名稱 · 分級 · N 抽', (tester) async {
+    final entry = TimelineEntry(
+      name: '刻晴',
+      gachaType: '301', // 90 池
+      time: DateTime(2026, 6, 1),
+      pullsSincePrev: 40, // 40/90 ≈ 0.44 → 歐
+    );
+    await pumpTimelineVertical(tester, entries: [entry], targetRank: 5);
+    final l = AppLocalizations.of(
+      tester.element(find.byType(TimelineVertical)),
+    )!;
+    final expected = '刻晴 · ${l.luckTierLucky} · ${l.timelineSinceLast(40)}';
+    expect(find.byTooltip(expected), findsWidgets);
+  });
+
+  testWidgets('showLuckLegend 時顯示圖例', (tester) async {
+    await pumpTimelineVertical(
+      tester,
+      entries: const [],
+      targetRank: 5,
+      nowPulls: 10,
+      showLuckLegend: true,
+    );
+    final l = AppLocalizations.of(
+      tester.element(find.byType(TimelineVertical)),
+    )!;
+    expect(find.text(l.luckTierLucky), findsOneWidget);
+  });
 }

--- a/test/widgets/data/sortable_table_test.dart
+++ b/test/widgets/data/sortable_table_test.dart
@@ -76,7 +76,7 @@ RecordRow makeRow({
   itemTypeKey: 'kind:character',
 );
 
-/// pump [SortableTable] with given [rows] and [mainRank] inside the test harness.
+/// 將 [SortableTable] 搭配給定的 [rows] 和 [mainRank] pump 進測試環境。
 Future<void> pumpSortableTable(
   WidgetTester tester, {
   required List<RecordRow> rows,

--- a/test/widgets/data/sortable_table_test.dart
+++ b/test/widgets/data/sortable_table_test.dart
@@ -10,6 +10,7 @@ import 'package:genshin_impact_wish_gacha_analyzer/services/gacha_row.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/services/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/state/hoyowiki_index.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/data/sortable_table.dart';
 import 'package:genshin_impact_wish_gacha_analyzer/widgets/gacha_item_icon.dart';
 
@@ -52,6 +53,48 @@ ProviderContainer _makeContainer(Directory tempDir) => ProviderContainer(
     hoyowikiCacheDirProvider.overrideWithValue(tempDir),
   ],
 );
+
+/// 建立指定欄位的 [RecordRow]（直接構造，略過 [buildRecordRows] 累計邏輯）。
+RecordRow makeRow({
+  required String gachaType,
+  required int rankType,
+  required int mainPityIndex,
+  int totalIndex = 1,
+}) => RecordRow(
+  record: GachaRecord(
+    id: '1',
+    uid: '1',
+    gachaType: gachaType,
+    name: 'TestItem',
+    itemType: '角色',
+    rankType: rankType,
+    time: DateTime(2025, 1, 1),
+    lang: 'zh-tw',
+  ),
+  totalIndex: totalIndex,
+  mainPityIndex: mainPityIndex,
+  itemTypeKey: 'kind:character',
+);
+
+/// pump [SortableTable] with given [rows] and [mainRank] inside the test harness.
+Future<void> pumpSortableTable(
+  WidgetTester tester, {
+  required List<RecordRow> rows,
+  required int mainRank,
+  required ProviderContainer container,
+}) async {
+  await tester.pumpWidget(
+    _wrap(
+      SortableTable(
+        rows: rows,
+        sort: null,
+        mainRank: mainRank,
+        onSortColumnTapped: (_) {},
+      ),
+      container: container,
+    ),
+  );
+}
 
 void main() {
   late Directory tempDir;
@@ -243,5 +286,18 @@ void main() {
 
     // 三筆 record → 三個 GachaItemIcon
     expect(find.byType(GachaItemIcon), findsNWidgets(3));
+  });
+
+  testWidgets('保底內欄依抽數呈歐非色', (tester) async {
+    // 角色池（301）5★：85 抽 → 85/90 ≈ 0.944 > 0.8 → 非（stateDanger）
+    await pumpSortableTable(
+      tester,
+      rows: [makeRow(gachaType: '301', rankType: 5, mainPityIndex: 85)],
+      mainRank: 5,
+      container: container,
+    );
+    final tokens = buildDarkTheme().gacha;
+    final text = tester.widget<Text>(find.text('85'));
+    expect(text.style?.color, tokens.stateDanger);
   });
 }

--- a/test/widgets/luck_legend_test.dart
+++ b/test/widgets/luck_legend_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:genshin_impact_wish_gacha_analyzer/l10n/generated/app_localizations.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/app_theme.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_legend.dart';
+
+void main() {
+  testWidgets('LuckLegend 顯示三個分級標籤', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildDarkTheme(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: const Scaffold(body: LuckLegend()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final l = await AppLocalizations.delegate.load(const Locale('zh'));
+    expect(find.text(l.luckTierLucky), findsOneWidget);
+    expect(find.text(l.luckTierAverage), findsOneWidget);
+    expect(find.text(l.luckTierUnlucky), findsOneWidget);
+  });
+}

--- a/test/widgets/luck_palette_test.dart
+++ b/test/widgets/luck_palette_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/theme/tokens.dart';
+import 'package:genshin_impact_wish_gacha_analyzer/widgets/luck_palette.dart';
+
+void main() {
+  group('luckTierFor — 90 池', () {
+    test(
+      '45 抽（ratio 0.5）= 歐',
+      () => expect(luckTierFor(45, 90), LuckTier.lucky),
+    );
+    test('46 抽 = 普通', () => expect(luckTierFor(46, 90), LuckTier.average));
+    test(
+      '72 抽（ratio 0.8）= 普通',
+      () => expect(luckTierFor(72, 90), LuckTier.average),
+    );
+    test('73 抽 = 非', () => expect(luckTierFor(73, 90), LuckTier.unlucky));
+    test('90 抽 = 非', () => expect(luckTierFor(90, 90), LuckTier.unlucky));
+    test(
+      '91 抽（ratio > 1）= 非',
+      () => expect(luckTierFor(91, 90), LuckTier.unlucky),
+    );
+  });
+
+  group('luckTierFor — 80 池', () {
+    test('40 抽 = 歐', () => expect(luckTierFor(40, 80), LuckTier.lucky));
+    test('41 抽 = 普通', () => expect(luckTierFor(41, 80), LuckTier.average));
+    test('64 抽 = 普通', () => expect(luckTierFor(64, 80), LuckTier.average));
+    test('65 抽 = 非', () => expect(luckTierFor(65, 80), LuckTier.unlucky));
+  });
+
+  group('luckTierFor — 20 池', () {
+    test('10 抽 = 歐', () => expect(luckTierFor(10, 20), LuckTier.lucky));
+    test('11 抽 = 普通', () => expect(luckTierFor(11, 20), LuckTier.average));
+    test('16 抽 = 普通', () => expect(luckTierFor(16, 20), LuckTier.average));
+    test('17 抽 = 非', () => expect(luckTierFor(17, 20), LuckTier.unlucky));
+  });
+
+  group('luckTierFor — 70 池', () {
+    test('35 抽 = 歐', () => expect(luckTierFor(35, 70), LuckTier.lucky));
+    test('36 抽 = 普通', () => expect(luckTierFor(36, 70), LuckTier.average));
+    test('56 抽 = 普通', () => expect(luckTierFor(56, 70), LuckTier.average));
+    test('57 抽 = 非', () => expect(luckTierFor(57, 70), LuckTier.unlucky));
+  });
+
+  test('pityThreshold <= 0 防呆 = 非', () {
+    expect(luckTierFor(1, 0), LuckTier.unlucky);
+  });
+
+  group('luckColorFor 對應既有語意色', () {
+    const t = GachaTokens.dark;
+    test(
+      '歐 → stateSuccess',
+      () => expect(luckColorFor(LuckTier.lucky, t), t.stateSuccess),
+    );
+    test(
+      '普通 → stateWarning',
+      () => expect(luckColorFor(LuckTier.average, t), t.stateWarning),
+    );
+    test(
+      '非 → stateDanger',
+      () => expect(luckColorFor(LuckTier.unlucky, t), t.stateDanger),
+    );
+  });
+}


### PR DESCRIPTION
## 概述

時間軸原本以**卡池顏色**整條同色上色，看不出每次出貨「歐還是非」。本 PR 改成依
**抽到該筆所花的抽數相對該池保底門檻的比例**呈現綠（歐）／金（普通）／紅（非）三階，
並把這套歐非色一致延伸到所有「抽數」語意的呈現處，同時調整卡池調色盤避免與歐非色混淆。
對齊姐妹專案 [wuthering-waves-convene-gacha-analyzer#37](https://github.com/GoneTone/wuthering-waves-convene-gacha-analyzer/pull/37)。

分級門檻（重用既有語意色，未新增 token）：

| 比例（`抽數 / 保底`） | 分級 | 顏色 |
|---|---|---|
| `≤ 0.5` | 歐 | `stateSuccess`（綠） |
| `0.5 ~ 0.8` | 普通 | `stateWarning`（金／琥珀） |
| `> 0.8`（含 > 1） | 非 | `stateDanger`（紅） |

門檻依各卡池保底自動換算（角色 90、武器 80、集錄 90、常駐 90、新手 20、頌願活動 5★ 70、頌願常駐 4★ 70 皆正確）。

## 主要變更

- **歐非色核心**：新增 `luck_palette.dart`（`luckTierFor`／`luckColorFor`）、`luck_legend.dart`（圖例＋在地化標籤），`gacha_types.dart` 新增 `gachaTypeFor`／`pityThresholdFor` 集中查詢 helper。
- **時間軸**：直向與橫向的節點、物品名稱、meta 的「N 抽」全部套歐非色；總覽頁 meta 的卡池名稱改用卡池色，保留「哪個池子」的辨識。
- **記錄列表**：「保底內」欄（距上次主稀有度的抽數）套歐非色；「總抽數」維持 muted。
- **卡池調色盤**：8 個卡池色整體移到 cyan → magenta 弧段，全部避開綠／金／紅（原本卡池角色＝歐非綠、武器＝歐非紅 完全同色）；新增測試固化「卡池色不得等於歐非三色」。
- **橫向時間軸年/月分隔**：每個月份分組首欄上方標年/月、月份交界畫分隔線，與直向版一致；以對稱標籤帶確保節點仍對齊軸線。
- **節點 tooltip**：滑鼠懸停在物品上**只顯示物品名稱**（依需求保持簡潔）。
- **i18n**：9 個實翻 ARB 新增 `luckTierLucky`／`luckTierAverage`／`luckTierUnlucky`（zh-Hant／zh-Hans／en／ja 逐字對齊姐妹專案，其餘按語意翻），空殼 ARB 留給 Crowdin。

## 設計決策（取捨）

- 顏色一律**重用既有語意色**、不新增 token；中階是金／琥珀（非純黃），刻意接受。
- 稀有度優先取 `entry.sourceRecord?.rankType`，缺值才退回 `targetRank`──**不改 `TimelineEntry` 資料模型**。
- 未知卡池 fallback 保底沿用本專案既有的 `5★ 90 / 4★ 10`（原神慣例）。
- 三處歐非色組合（`luckColorFor(luckTierFor(...), tokens)`）刻意保持 inline──輸入形狀不同（時間軸 entry vs 記錄 row），純函式已是正確接縫，再包一層反而是過度抽象。

## 測試

- `fvm flutter analyze` → No issues found!
- `fvm flutter test` → All tests passed!（1028 個）
- 涵蓋：`luckTierFor` 各池邊界、`pityThresholdFor`／`gachaTypeFor` 查詢、各 widget 的歐非色／tooltip／圖例／月份分組斷言、卡池色不撞歐非色、記錄列表「保底內」歐非色、分享圖圖例溢出仍可見。

## 文件

- `docs/superpowers/specs/2026-06-19-timeline-luck-color-design.md`
- `docs/superpowers/plans/2026-06-19-timeline-luck-color.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
